### PR TITLE
Fixed a warning that was coming up for vector<unsigned char> fill

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -498,8 +498,10 @@ static void TestWatchOnlyPubKey(LegacyScriptPubKeyMan* spk_man, const CPubKey& a
 // Cryptographically invalidate a PubKey whilst keeping length and first byte
 static void PollutePubKey(CPubKey& pubkey)
 {
-    std::vector<unsigned char> pubkey_raw(pubkey.begin(), pubkey.end());
-    std::fill(pubkey_raw.begin() + 1, pubkey_raw.end(), 0);
+    assert(pubkey.size() >= 1);
+    std::vector<unsigned char> pubkey_raw;
+    pubkey_raw.push_back(pubkey[0]);
+    pubkey_raw.insert(pubkey_raw.end(), pubkey.size() - 1, 0);
     pubkey = CPubKey(pubkey_raw);
     assert(!pubkey.IsFullyValid());
     assert(pubkey.IsValid());


### PR DESCRIPTION
This fixes a warning during build:
```
In file included from /usr/include/c++/14.1.1/string:51,
                 from ./crypto/sha256.h:10,
                 from ./hash.h:12,
                 from ./blsct/arith/mcl/mcl_scalar.h:15,
                 from ./blsct/arith/mcl/mcl_g1point.h:12,
                 from ./blsct/arith/mcl/mcl.h:12,
                 from ./blsct/double_public_key.h:8,
                 from ./addresstype.h:9,
                 from ./wallet/wallet.h:9,
                 from wallet/test/wallet_tests.cpp:5:
In function ‘constexpr typename __gnu_cxx::__enable_if<std::__is_scalar<_Tp>::__value, void>::__type std::__fill_a1(_ForwardIterator, _ForwardIterator, const _Tp&) [with _ForwardIterator = unsigned char*; _Tp = int]’,
    inlined from ‘constexpr void std::__fill_a1(__gnu_cxx::__normal_iterator<_Iterator, _Container>, __gnu_cxx::__normal_iterator<_Iterator, _Container>, const _Tp&) [with _Ite = unsigned char*; _Cont = vector<unsigned char>; _Tp = int]’ at /usr/include/c++/14.1.1/bits/stl_algobase.h:981:21,
    inlined from ‘constexpr void std::__fill_a(_FIte, _FIte, const _Tp&) [with _FIte = __gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> >; _Tp = int]’ at /usr/include/c++/14.1.1/bits/stl_algobase.h:998:21,
    inlined from ‘constexpr void std::fill(_ForwardIterator, _ForwardIterator, const _Tp&) [with _ForwardIterator = __gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> >; _Tp = int]’ at /usr/include/c++/14.1.1/bits/stl_algobase.h:1029:20,
    inlined from ‘void wallet::wallet_tests::PollutePubKey(CPubKey&)’ at wallet/test/wallet_tests.cpp:502:14:
/usr/include/c++/14.1.1/bits/stl_algobase.h:952:18: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’ specified bound 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  952 |         *__first = __tmp;
      |         ~~~~~~~~~^~~~~~~

```