### PR TITLE
Fix libblsct dlopen issue in Python

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -165,6 +165,7 @@ BLSCT_H = \
   blsct/building_block/lazy_points.h \
   blsct/building_block/pedersen_commitment.h \
   blsct/building_block/weighted_inner_prod_arg.h \
+  blsct/chain.h \
   blsct/common.h \
   blsct/double_public_key.h \
   blsct/eip_2333/bls12_381_keygen.h \
@@ -226,6 +227,7 @@ BLSCT_CPP = \
   blsct/building_block/lazy_point.cpp \
   blsct/building_block/lazy_points.cpp \
   blsct/building_block/weighted_inner_prod_arg.cpp \
+  blsct/chain.cpp \
   blsct/common.cpp \
   blsct/double_public_key.cpp \
   blsct/eip_2333/bls12_381_keygen.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1478,6 +1478,7 @@ libblsct_a_SOURCES = \
   support/cleanse.cpp \
   support/lockedpool.cpp \
   uint256.cpp \
+	util/moneystr.cpp \
   util/rbf.cpp \
   util/strencodings.cpp \
   util/time.cpp \
@@ -1517,7 +1518,7 @@ libunivalue_blsct_a_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR
 libunivalue_blsct_a_CXXFLAGS = $(AM_CXXFLAGS) -fPIC
 
 libblsct_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) -fPIC
-libblsct_a_CPPFLAGS = $(AM_CPPFLAGS) $(BLS_INCLUDES) $(BOOST_CPPFLAGS) -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
+libblsct_a_CPPFLAGS = $(AM_CPPFLAGS) $(BLS_INCLUDES) $(BOOST_CPPFLAGS) -DLIBBLSCT -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
 
 if ENABLE_SSE41
 libblsct_a_CXXFLAGS += $(SSE41_CXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1478,7 +1478,7 @@ libblsct_a_SOURCES = \
   support/cleanse.cpp \
   support/lockedpool.cpp \
   uint256.cpp \
-	util/moneystr.cpp \
+  util/moneystr.cpp \
   util/rbf.cpp \
   util/strencodings.cpp \
   util/time.cpp \

--- a/src/bls/src/proj/bls384_256.vcxproj
+++ b/src/bls/src/proj/bls384_256.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.3" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -81,6 +81,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(SolutionDir)mcl\lib\mcl.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/blsct/chain.cpp
+++ b/src/blsct/chain.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 The Navio developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blsct/chain.h>
+#include <blsct/key_io.h>
+#include <mutex>
+
+static std::string g_chain;
+static std::mutex g_set_chain_mutex;
+
+const std::string& get_chain() {
+    return g_chain;
+}
+
+bool set_chain(enum Chain chain)
+{
+    std::lock_guard<std::mutex> lock(g_set_chain_mutex);
+    if (!g_chain.empty()) {
+        return false;
+    }
+
+    switch (chain) {
+        case MainNet:
+            g_chain = blsct::bech32_hrp::Main;
+            break;
+
+        case TestNet:
+            g_chain = blsct::bech32_hrp::TestNet;
+            break;
+
+        case SigNet:
+            g_chain = blsct::bech32_hrp::SigNet;
+            break;
+
+        case RegTest:
+            g_chain = blsct::bech32_hrp::RegTest;
+            break;
+    }
+    return true;
+}
+

--- a/src/blsct/chain.h
+++ b/src/blsct/chain.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Navio developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NAVIO_BLSCT_CHAIN_H
+#define NAVIO_BLSCT_CHAIN_H
+
+#include <string>
+
+const std::string& get_chain();
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum Chain {
+    MainNet,
+    TestNet,
+    SigNet,
+    RegTest
+};
+
+bool set_chain(enum Chain chain);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif  // NAVIO_BLSCT_CHAIN_H
+

--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -12,7 +12,6 @@
 #include <blsct/wallet/address.h>
 #include <blsct/wallet/helpers.h>
 #include <blsct/wallet/txfactory_base.h>
-#include <common/args.h>
 #include <common/url.h>
 #include <crypto/common.h>
 #include <memory.h>
@@ -35,7 +34,11 @@ static bulletproofs::RangeProofLogic<Mcl>* g_rpl;
 static bool g_is_little_endian;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
-UrlDecodeFn* const URL_DECODE = urlDecode;
+UrlDecodeFn* const URL_DECODE = nullptr;
+
+const std::string& get_chain() {
+    return g_chain;
+}
 
 extern "C" {
 

--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -27,20 +27,12 @@
 #include <optional>
 #include <string>
 
-static std::string g_chain;
 static std::mutex g_init_mutex;
-static std::mutex g_set_chain_mutex;
 static bulletproofs::RangeProofLogic<Mcl>* g_rpl;
 static bool g_is_little_endian;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;
-
-const std::string& get_chain() {
-    return g_chain;
-}
-
-extern "C" {
 
 static bool is_little_endian() {
     uint16_t n = 1;
@@ -54,36 +46,11 @@ void init()
 
     Mcl::Init for_side_effect_only;
 
-    g_chain = blsct::bech32_hrp::Main;
+    if (!set_chain(Chain::MainNet)) {
+        throw std::runtime_error("Chain has already been set");
+    }
     g_is_little_endian = is_little_endian();
     g_rpl = new(std::nothrow) bulletproofs::RangeProofLogic<Mcl>();
-}
-
-bool set_chain(enum Chain chain)
-{
-    std::lock_guard<std::mutex> lock(g_set_chain_mutex);
-    if (!g_chain.empty()) {
-        return false;
-    }
-
-    switch (chain) {
-        case MainNet:
-            g_chain = blsct::bech32_hrp::Main;
-            break;
-
-        case TestNet:
-            g_chain = blsct::bech32_hrp::TestNet;
-            break;
-
-        case SigNet:
-            g_chain = blsct::bech32_hrp::SigNet;
-            break;
-
-        case RegTest:
-            g_chain = blsct::bech32_hrp::RegTest;
-            break;
-    }
-    return true;
 }
 
 BlsctRetVal* succ(
@@ -229,7 +196,8 @@ BlsctRetVal* decode_address(
             return err(BLSCT_BAD_DPK_SIZE);
         }
         std::string enc_addr(blsct_enc_addr);
-        auto maybe_dpk = blsct::DecodeDoublePublicKey(g_chain, enc_addr);
+        auto chain = get_chain();
+        auto maybe_dpk = blsct::DecodeDoublePublicKey(chain, enc_addr);
         if (maybe_dpk) {
             auto dpk = maybe_dpk.value();
             if (dpk.IsValid()) {
@@ -262,7 +230,8 @@ BlsctRetVal* encode_address(
 
         auto bech32_encoding = encoding == Bech32 ?
             bech32_mod::Encoding::BECH32 : bech32_mod::Encoding::BECH32M;
-        auto enc_dpk_str = EncodeDoublePublicKey(g_chain, bech32_encoding, dpk);
+        auto chain = get_chain();
+        auto enc_dpk_str = EncodeDoublePublicKey(chain, bech32_encoding, dpk);
         size_t BUF_SIZE = enc_dpk_str.size() + 1;
         MALLOC_BYTES(char, enc_addr, BUF_SIZE);
         RETURN_ERR_IF_MEM_ALLOC_FAILED(enc_addr);
@@ -1285,6 +1254,4 @@ BlsctDoublePubKey* gen_dpk_with_keys_and_sub_addr_id(
 
     return blsct_dpk;
 }
-
-} // extern "C"
 

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -115,6 +115,9 @@ if (name == nullptr) err(BLSCT_MEM_ALLOC_FAILED);
 
 #define UNVOID(T, name) const T* name = reinterpret_cast<const T*>(void_##name)
 
+// global variable access
+const std::string& get_chain();
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -393,6 +396,11 @@ const BlsctScalar* get_tx_out_range_proof_s_prime(const CTxOut* tx_out);
 const BlsctScalar* get_tx_out_range_proof_delta_prime(const CTxOut* tx_out);
 const BlsctScalar* get_tx_out_range_proof_alpha_hat(const CTxOut* tx_out);
 const BlsctScalar* get_tx_out_range_proof_tau_x(const CTxOut* tx_out);
+
+const BlsctSignature* sign_message(
+    const BlsctScalar* blsct_priv_key,
+    const char* blsct_msg
+);
 
 bool verify_msg_sig(
     const BlsctPubKey* blsct_pub_key,

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -10,6 +10,7 @@
 #include <blsct/public_key.h>
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/arith/elements.h>
+#include <blsct/chain.h>
 #include <blsct/range_proof/setup.h>
 #include <primitives/transaction.h>
 #include <tinyformat.h>
@@ -114,19 +115,9 @@ if (name == nullptr) err(BLSCT_MEM_ALLOC_FAILED);
 
 #define UNVOID(T, name) const T* name = reinterpret_cast<const T*>(void_##name)
 
-// global variable access
-const std::string& get_chain();
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-enum Chain {
-    MainNet,
-    TestNet,
-    SigNet,
-    RegTest
-};
 
 enum TxOutputType {
     Normal,
@@ -236,7 +227,6 @@ void free_amounts_ret_val(BlsctAmountsRetVal* rv); // free attrs as well
 
 // library initialization
 void init();
-bool set_chain(enum Chain chain);
 
 // point
 BlsctRetVal* gen_random_point();

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -8,7 +8,6 @@
 #include <blsct/double_public_key.h>
 #include <blsct/private_key.h>
 #include <blsct/public_key.h>
-#include <blsct/wallet/address.h>
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/arith/elements.h>
 #include <blsct/range_proof/setup.h>

--- a/src/blsct/wallet/address.cpp
+++ b/src/blsct/wallet/address.cpp
@@ -5,7 +5,7 @@
 #include <blsct/wallet/address.h>
 
 #ifdef LIBBLSCT
-#include <blsct/external_api/blsct.h>
+#include <blsct/chain.h>
 #include <blsct/key_io.h>
 #endif
 

--- a/src/blsct/wallet/address.cpp
+++ b/src/blsct/wallet/address.cpp
@@ -4,13 +4,31 @@
 
 #include <blsct/wallet/address.h>
 
+#ifdef LIBBLSCT
+#include <blsct/external_api/blsct.h>
+#include <blsct/key_io.h>
+#endif
+
 namespace blsct {
 SubAddress::SubAddress(const std::string& sAddress)
 {
+#ifdef LIBBLSCT
+    auto chain = get_chain();
+    auto maybe_dpk = DecodeDoublePublicKey(chain, sAddress);
+    if (maybe_dpk) {
+        auto dpk = maybe_dpk.value();
+        if (dpk.IsValid()) {
+            pk = dpk;
+        } else {
+            throw std::runtime_error(std::string(__func__) + ": invalid double public key: " + sAddress);
+        }
+    }
+#else
     auto dest = DecodeDestination(sAddress);
     if (std::holds_alternative<blsct::DoublePublicKey>(dest)) {
         pk = std::get<blsct::DoublePublicKey>(dest);
     }
+#endif
 }
 
 SubAddress::SubAddress(const PrivateKey& viewKey, const PublicKey& spendKey, const SubAddressIdentifier& subAddressId)
@@ -41,7 +59,17 @@ SubAddress::SubAddress(const PrivateKey& viewKey, const PublicKey& spendKey, con
 
 std::string SubAddress::GetString() const
 {
+#ifdef LIBBLSCT
+    auto chain = get_chain();
+    auto enc_dpk = EncodeDoublePublicKey(
+        chain,
+        bech32_mod::Encoding::BECH32M,
+        pk
+    );
+    return enc_dpk;
+#else
     return EncodeDestination(pk);
+#endif
 }
 
 CTxDestination SubAddress::GetDestination() const

--- a/src/blsct/wallet/txfactory.h
+++ b/src/blsct/wallet/txfactory.h
@@ -31,6 +31,8 @@ public:
     bool AddInput(const CCoinsViewCache& cache, const COutPoint& outpoint, const bool& stakedCommitment = false, const bool& rbf = false);
     std::optional<CMutableTransaction> BuildTx();
     static std::optional<CMutableTransaction> CreateTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, CreateTransactionData transactionData);
+    static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const wallet::CoinFilterParams& coins_params, std::vector<InputCandidates>& inputCandidates) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
+    static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const TokenId& token_id, const CreateTransactionType& type, std::vector<InputCandidates>& inputCandidates) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
 };
 } // namespace blsct
 

--- a/src/blsct/wallet/txfactory_base.cpp
+++ b/src/blsct/wallet/txfactory_base.cpp
@@ -271,45 +271,4 @@ std::optional<CMutableTransaction> TxFactoryBase::CreateTransaction(const std::v
     return tx.BuildTx(transactionData.changeDestination, transactionData.minStake, transactionData.type);
 }
 
-void TxFactoryBase::AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const wallet::CoinFilterParams& coins_params, std::vector<InputCandidates>& inputCandidates)
-{
-    AssertLockHeld(wallet->cs_wallet);
-    for (const wallet::COutput& output : AvailableCoins(*wallet, nullptr, std::nullopt, coins_params).All()) {
-        auto tx = wallet->GetWalletTx(output.outpoint.hash);
-
-        if (tx == nullptr)
-            continue;
-
-        auto out = tx->tx->vout[output.outpoint.n];
-
-        auto recoveredInfo = tx->GetBLSCTRecoveryData(output.outpoint.n);
-        auto value = out.HasBLSCTRangeProof() ? recoveredInfo.amount : out.nValue;
-
-        inputCandidates.push_back({value, recoveredInfo.gamma, blsct_km->GetSpendingKeyForOutput(out), out.tokenId, COutPoint(output.outpoint.hash, output.outpoint.n), out.IsStakedCommitment()});
-    }
-}
-
-void TxFactoryBase::AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const TokenId& token_id, const CreateTransactionType& type, std::vector<InputCandidates>& inputCandidates)
-{
-    AssertLockHeld(wallet->cs_wallet);
-
-    wallet::CoinFilterParams coins_params;
-    coins_params.min_amount = 0;
-    coins_params.only_blsct = true;
-    coins_params.token_id = token_id;
-
-    AddAvailableCoins(wallet, blsct_km, coins_params, inputCandidates);
-
-    if (type == CreateTransactionType::STAKED_COMMITMENT || type == CreateTransactionType::STAKED_COMMITMENT_UNSTAKE) {
-        coins_params.include_staked_commitment = true;
-        AddAvailableCoins(wallet, blsct_km, coins_params, inputCandidates);
-    }
-
-    if ((type == CreateTransactionType::NORMAL && !token_id.IsNull()) || type == CreateTransactionType::TX_MINT_TOKEN) {
-        coins_params.token_id.SetNull();
-        AddAvailableCoins(wallet, blsct_km, coins_params, inputCandidates);
-    }
-}
-
-
 } // namespace blsct

--- a/src/blsct/wallet/txfactory_base.h
+++ b/src/blsct/wallet/txfactory_base.h
@@ -100,8 +100,6 @@ public:
     bool AddInput(const CAmount& amount, const MclScalar& gamma, const blsct::PrivateKey& spendingKey, const TokenId& token_id, const COutPoint& outpoint, const bool& stakedCommitment = false, const bool& rbf = false);
     std::optional<CMutableTransaction> BuildTx(const blsct::DoublePublicKey& changeDestination, const CAmount& minStake = 0, const CreateTransactionType& type = NORMAL, const bool& fSubtractedFee = false);
     static std::optional<CMutableTransaction> CreateTransaction(const std::vector<InputCandidates>& inputCandidates, const CreateTransactionData& transactionData);
-    static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const wallet::CoinFilterParams& coins_params, std::vector<InputCandidates>& inputCandidates) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
-    static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const TokenId& token_id, const CreateTransactionType& type, std::vector<InputCandidates>& inputCandidates) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
 };
 
 } // namespace blsct

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -21,7 +21,7 @@ class WalletCrossChain(BitcoinTestFramework):
         self.add_nodes(self.num_nodes)
 
         # Switch node 1 to testnet before starting it.
-        self.nodes[1].chain = 'testnet3'
+        self.nodes[1].chain = 'testnet4'
         self.nodes[1].extra_args = ['-maxconnections=0', '-prune=550'] # disable testnet sync
         self.nodes[1].replace_in_config([('regtest=', 'testnet='), ('[regtest]', '[test]')])
         self.start_nodes()


### PR DESCRIPTION
In order to avoid loading `CChainParams` that causes `Symbol not found` issues in `Python`:
- Migrate `AddAvailableCoins` in `TxFactoryBase` to `TxFactory`
- Limit the source of `SubAddress` to be `DoublePublicKey` only
