### PR TITLE
bug: are_ctx_in_equal function is checking wrong value

### DIFF
--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -969,7 +969,7 @@ const void* get_ctx_in_at(const void* vp_ctx_ins, const size_t i)
 bool are_ctx_in_equal(const void* vp_a, const void* vp_b)
 {
     auto* a = static_cast<const CTxIn*>(vp_a);
-    auto* b = static_cast<const CTxIn*>(vp_a);
+    auto* b = static_cast<const CTxIn*>(vp_b);
     return *a == *b;
 }
 

--- a/src/test/blsct/external_api/external_api_tests.cpp
+++ b/src/test/blsct/external_api/external_api_tests.cpp
@@ -601,6 +601,25 @@ BOOST_AUTO_TEST_CASE(test_unsigned_transaction_sign)
     free(signed_tx_rv);
 }
 
+BOOST_AUTO_TEST_CASE(test_are_ctx_in_equal)
+{
+    init();
+
+    // create two CTxIns with different out_points
+    uint256 hash_a, hash_b;
+    hash_a.SetHex("1111111111111111111111111111111111111111111111111111111111111111");
+    hash_b.SetHex("2222222222222222222222222222222222222222222222222222222222222222");
+
+    CTxIn tx_in_a{COutPoint{hash_a}};
+    CTxIn tx_in_b{COutPoint{hash_b}};
+
+    // same object should be equal
+    BOOST_CHECK(are_ctx_in_equal(&tx_in_a, &tx_in_a));
+
+    // different out_points should not be equal
+    BOOST_CHECK(!are_ctx_in_equal(&tx_in_a, &tx_in_b));
+}
+
 BOOST_AUTO_TEST_CASE(test_aggregate_transactions)
 {
     init();


### PR DESCRIPTION
This one is for sure a bug, it's not checking the correct value in are_ctx_in_equal() func