### PR TITLE
refactor(blsct): replace void* C API with typed structs and caller buffers

### DIFF
--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -1,6 +1,10 @@
+// NOTE: Scalar locals in this file are not zeroed after use. MclScalar has no
+// destructor and is upstream code we cannot modify. A blsct::Scalar wrapper
+// with memory_cleanse on destruction is tracked in:
+// https://github.com/nav-io/navio-core/issues/206
 #include <blsct/bech32_mod.h>
-#include <blsct/common.h>
 #include <blsct/chain.h>
+#include <blsct/common.h>
 #include <blsct/double_public_key.h>
 #include <blsct/eip_2333/bls12_381_keygen.h>
 #include <blsct/external_api/blsct.h>
@@ -27,96 +31,136 @@
 #include <util/rbf.h>
 #include <util/transaction_identifier.h>
 
-#include <charconv>
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <map>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 
-static std::mutex g_init_mutex;
-static bulletproofs_plus::RangeProofLogic<Mcl>* g_rpl;
-static bool g_is_little_endian;
-
-static bool is_little_endian()
+static inline void FillHexBuf(const uint8_t* data, size_t size, char* out)
 {
-    uint16_t n = 1;
-    uint8_t* p = (uint8_t*)&n;
-    return *p == 1;
+    auto hex = HexStr(Span<const uint8_t>(data, size));
+    std::memcpy(out, hex.c_str(), hex.size() + 1);
 }
 
-void init() {
-    std::lock_guard<std::mutex> lock(g_init_mutex);
+static inline size_t WriteHexBuf(const uint8_t* data, size_t size, char* buf, size_t buf_size)
+{
+    auto hex = HexStr(Span<const uint8_t>(data, size));
+    if (buf != nullptr && buf_size > hex.size()) {
+        std::memcpy(buf, hex.c_str(), hex.size() + 1);
+    }
+    return hex.size();
+}
+
+static inline size_t WriteStrBuf(const std::string& s, char* buf, size_t buf_size)
+{
+    if (buf != nullptr && buf_size > s.size()) {
+        std::memcpy(buf, s.c_str(), s.size() + 1);
+    }
+    return s.size();
+}
+
+template <typename T>
+static size_t SerializeObjToHexBuf(const T& obj, char* buf, size_t buf_size)
+{
+    DataStream st{};
+    st << obj;
+    return WriteHexBuf(reinterpret_cast<const uint8_t*>(st.data()), st.size(), buf, buf_size);
+}
+
+template <typename T>
+static size_t SerializeObjToByteBuf(const T& obj, uint8_t* buf, size_t buf_size)
+{
+    DataStream st{};
+    st << obj;
+    if (buf != nullptr && buf_size >= st.size())
+        std::memcpy(buf, st.data(), st.size());
+    return st.size();
+}
+
+static size_t SerializeCtxToHexBuf(const CMutableTransaction& ctx, char* buf, size_t buf_size)
+{
+    DataStream st{};
+    TransactionSerParams params{.allow_witness = true};
+    ParamsStream ps{params, st};
+    ctx.Serialize(ps);
+    return WriteStrBuf(HexStr(MakeByteSpan(st)), buf, buf_size);
+}
+
+static std::shared_mutex g_rpl_mutex;
+static bulletproofs_plus::RangeProofLogic<Mcl>* g_rpl;
+
+void init()
+{
+    std::unique_lock<std::shared_mutex> lock(g_rpl_mutex);
     Mcl::Init for_side_effect_only;
 
     set_chain(blsct::bech32_hrp::Mainnet);
-    g_is_little_endian = is_little_endian();
     g_rpl = new (std::nothrow) bulletproofs_plus::RangeProofLogic<Mcl>();
 }
 
-enum BlsctChain get_blsct_chain() {
+void uninit()
+{
+    std::unique_lock<std::shared_mutex> lock(g_rpl_mutex);
+    delete g_rpl;
+    g_rpl = nullptr;
+}
+
+enum BlsctChain get_blsct_chain()
+{
     auto& chain = get_chain();
 
-    if (chain == blsct::bech32_hrp::Mainnet) { return Mainnet; }
-    else if (chain == blsct::bech32_hrp::Testnet) { return Testnet; }
-    else if (chain == blsct::bech32_hrp::Signet) { return Signet; }
-    else if (chain == blsct::bech32_hrp::Regtest) { return Regtest; }
-    else { /* should not be visited */ return Mainnet; }
+    if (chain == blsct::bech32_hrp::Mainnet) {
+        return Mainnet;
+    } else if (chain == blsct::bech32_hrp::Testnet) {
+        return Testnet;
+    } else if (chain == blsct::bech32_hrp::Signet) {
+        return Signet;
+    } else if (chain == blsct::bech32_hrp::Regtest) {
+        return Regtest;
+    } else { /* should not be visited */
+        return Mainnet;
+    }
 }
 
-void set_blsct_chain(enum BlsctChain chain) {
-    if (chain == Mainnet) set_chain(blsct::bech32_hrp::Mainnet);
-    else if (chain == Testnet) set_chain(blsct::bech32_hrp::Testnet);
-    else if (chain == Signet) set_chain(blsct::bech32_hrp::Signet);
-    else if (chain == Regtest) set_chain(blsct::bech32_hrp::Regtest);
+void set_blsct_chain(enum BlsctChain chain)
+{
+    if (chain == Mainnet)
+        set_chain(blsct::bech32_hrp::Mainnet);
+    else if (chain == Testnet)
+        set_chain(blsct::bech32_hrp::Testnet);
+    else if (chain == Signet)
+        set_chain(blsct::bech32_hrp::Signet);
+    else if (chain == Regtest)
+        set_chain(blsct::bech32_hrp::Regtest);
 }
 
-BlsctRetVal* succ(
-    void* value,
-    size_t value_size
-) {
-    MALLOC_BYTES(BlsctRetVal, p, sizeof(BlsctRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(p);
-
-    p->result = BLSCT_SUCCESS;
-    p->value = value;
-    p->value_size = value_size;
-    return p;
+// R r{} zero-initializes all fields including value, so callers need not
+// check value when result != BLSCT_SUCCESS — it will be zeroed, not garbage.
+template <typename R>
+static inline R typed_err(BLSCT_RESULT result)
+{
+    R r{};
+    r.result = result;
+    return r;
 }
 
-BlsctRetVal* err(
-    BLSCT_RESULT result
-) {
-    MALLOC_BYTES(BlsctRetVal, p, sizeof(BlsctRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(p);
-
-    p->result = result;
-    p->value = nullptr;
-    return p;
+template <typename R>
+static inline R typed_err_as(const char* msg, BLSCT_RESULT result)
+{
+    if (msg) {
+        fputs(msg, stderr);
+        fputc('\n', stderr);
+    }
+    return typed_err<R>(result);
 }
 
-BlsctBoolRetVal* succ_bool(
-    const bool value
-) {
-    MALLOC_BYTES(BlsctBoolRetVal, p, sizeof(BlsctBoolRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(p);
-
-    p->result = BLSCT_SUCCESS;
-    p->value = value;
-    return p;
-}
-
-BlsctBoolRetVal* err_bool(
-    const BLSCT_RESULT result
-) {
-    MALLOC_BYTES(BlsctBoolRetVal, p, sizeof(BlsctBoolRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(p);
-
-    p->result = result;
-    p->value = false;
-    return p;
+static inline BlsctBoolResult succ_bool(bool value)
+{
+    return {BLSCT_SUCCESS, value};
 }
 
 // TODO: need to investigate why this was not being used
@@ -146,31 +190,6 @@ static blsct::PrivateKey blsct_scalar_to_priv_key(
     return priv_key;
 }
 
-// TODO: need to investigate why this was not being used
-[[maybe_unused]] static inline const char* data_stream_to_malloced_hex(DataStream& st)
-{
-    // TODO: need to investigate why this was not being used
-    [[maybe_unused]] auto data = reinterpret_cast<uint8_t*>(st.data());
-    MALLOC_BYTES(uint8_t, buf, st.size());
-    return buf == nullptr ? nullptr : SerializeToHex(buf, st.size());
-}
-
-// TODO: need to investigate why this was not being used
-[[maybe_unused]] static inline void UnserializeCMutableTx(
-    CMutableTransaction& ctx,
-    const uint8_t* ser_ctx,
-    const size_t ser_ctx_size)
-{
-    DataStream st{};
-    TransactionSerParams params{.allow_witness = true};
-    ParamsStream ps{params, st};
-
-    for (size_t i = 0; i < ser_ctx_size; ++i) {
-        ps << ser_ctx[i];
-    }
-    ctx.Unserialize(ps);
-}
-
 static inline bool AmountFromUint64Checked(
     const uint64_t amount,
     CAmount& out)
@@ -182,32 +201,19 @@ static inline bool AmountFromUint64Checked(
     return true;
 }
 
-template <typename T>
-static const char* SerializeSerializableObject(const T& obj)
-{
-    DataStream st{};
-    st << obj;
-    return StrToAllocCStr(HexStr(MakeByteSpan(st)));
-}
 
 template <typename T>
-static BlsctRetVal* DeserializeSerializableObject(const char* hex)
+static std::optional<T> DeserializeObj(const char* hex)
 {
     std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
-    }
-
+    if (!TryParseHexWrap(hex, vec)) return std::nullopt;
     try {
         DataStream st{vec};
-        auto* obj = new (std::nothrow) T{};
-        if (obj == nullptr) {
-            return err(BLSCT_MEM_ALLOC_FAILED);
-        }
-        st >> *obj;
-        return succ(static_cast<void*>(obj), sizeof(T));
+        T obj{};
+        st >> obj;
+        return obj;
     } catch (const std::exception&) {
-        return err(BLSCT_DESER_FAILED);
+        return std::nullopt;
     }
 }
 
@@ -247,33 +253,29 @@ static std::optional<blsct::ParsedPredicate> ParseOpaquePredicate(
     }
 }
 
-static std::map<std::string, std::string> StringMapFromOpaque(const void* vp_string_map)
+static std::map<std::string, std::string> StringMapFromArrays(
+    const char* const* keys, const char* const* values, size_t count)
 {
-    if (vp_string_map == nullptr) return {};
-    return *static_cast<const std::map<std::string, std::string>*>(vp_string_map);
-}
-
-static void* CloneStringMap(const std::map<std::string, std::string>& src)
-{
-    auto* copy = new (std::nothrow) std::map<std::string, std::string>(src);
-    return static_cast<void*>(copy);
-}
-
-static const char* StringMapEntryAt(const void* vp_string_map, const size_t idx, const bool want_key)
-{
-    RETURN_RET_VAL_IF_NULL(vp_string_map, nullptr);
-
-    const auto* map_ptr = static_cast<const std::map<std::string, std::string>*>(vp_string_map);
-    if (idx >= map_ptr->size()) {
-        return nullptr;
+    std::map<std::string, std::string> result;
+    if (keys == nullptr || values == nullptr) return result;
+    for (size_t i = 0; i < count; ++i) {
+        if (keys[i] != nullptr && values[i] != nullptr)
+            result[keys[i]] = values[i];
     }
-
-    auto it = map_ptr->cbegin();
-    std::advance(it, idx);
-    return StrToAllocCStr(want_key ? it->first : it->second);
+    return result;
 }
 
-static std::optional<blsct::UnsignedInput> UnsignedInputFromC(const BlsctTxIn& tx_in)
+static void InvokeCallbackForMap(
+    const std::map<std::string, std::string>& m,
+    BlsctStringMapCallback cb, void* user_data)
+{
+    if (cb == nullptr) return;
+    for (const auto& [k, v] : m)
+        cb(k.c_str(), v.c_str(), user_data);
+}
+
+
+static std::optional<blsct::UnsignedInput> UnsignedInputFromC(const BlsctTxInData& tx_in)
 {
     CAmount amount;
     if (!AmountFromUint64Checked(tx_in.amount, amount)) {
@@ -300,7 +302,7 @@ static std::optional<blsct::UnsignedInput> UnsignedInputFromC(const BlsctTxIn& t
     return input;
 }
 
-static std::optional<blsct::UnsignedOutput> UnsignedOutputFromC(const BlsctTxOut& tx_out)
+static std::optional<blsct::UnsignedOutput> UnsignedOutputFromC(const BlsctTxOutData& tx_out)
 {
     CAmount amount;
     if (!AmountFromUint64Checked(tx_out.amount, amount)) {
@@ -340,14 +342,12 @@ static std::optional<blsct::UnsignedOutput> UnsignedOutputFromC(const BlsctTxOut
         min_stake);
 }
 
-static BlsctRetVal* MallocAndCopyUint256(const uint256& value)
+static BlsctUint256Result MallocAndCopyUint256(const uint256& value)
 {
-    MALLOC_BYTES(BlsctUint256, blsct_uint256, UINT256_SIZE);
-    if (blsct_uint256 == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-    std::memcpy(blsct_uint256, value.begin(), UINT256_SIZE);
-    return succ(blsct_uint256, UINT256_SIZE);
+    BlsctUint256Result r{};
+    std::memcpy(r.value, value.begin(), UINT256_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 //---------------------
@@ -357,31 +357,27 @@ void free_obj(void* x)
     if (x != nullptr) free(x);
 }
 
-void free_amounts_ret_val(BlsctAmountsRetVal* rv)
-{
-    auto result_vec = static_cast<const std::vector<BlsctAmountRecoveryResult>*>(rv->value);
 
-    for (auto res : *result_vec) {
-        free(res.msg);
-    }
-    delete result_vec;
-    free(rv);
+BlsctSizeTResult serialize_raw_obj(const uint8_t* ser_obj, size_t ser_obj_size, char* buf, size_t buf_size)
+{
+    if (ser_obj == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, WriteHexBuf(ser_obj, ser_obj_size, buf, buf_size)};
 }
 
-const char* serialize_raw_obj(const uint8_t* ser_obj, const size_t ser_obj_size)
+BLSCT_RESULT deserialize_raw_obj(const char* hex, uint8_t* buf, size_t buf_size, size_t* out_len)
 {
-    return SerializeToHex(ser_obj, ser_obj_size);
-}
-
-BlsctRetVal* deserialize_raw_obj(const char* hex)
-{
+    if (hex == nullptr) return BLSCT_FAILURE;
     size_t ser_obj_size = std::strlen(hex) / 2;
-    void* obj = DeserializeFromHex(hex, ser_obj_size);
-    return succ(obj, ser_obj_size);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != ser_obj_size) return BLSCT_FAILURE;
+    if (out_len) *out_len = ser_obj_size;
+    if (buf != nullptr && buf_size >= ser_obj_size)
+        std::memcpy(buf, vec.data(), ser_obj_size);
+    return BLSCT_SUCCESS;
 }
 
 // address
-BlsctRetVal* decode_address(
+BlsctDoublePubKeyResult decode_address(
     const char* blsct_enc_addr)
 {
     try {
@@ -392,25 +388,27 @@ BlsctRetVal* decode_address(
             auto dpk = maybe_dpk.value();
             if (dpk.IsValid()) {
                 auto buf = dpk.GetVch();
-                MALLOC_BYTES(BlsctDoublePubKey, dec_addr, DOUBLE_PUBLIC_KEY_SIZE);
-                RETURN_ERR_IF_MEM_ALLOC_FAILED(dec_addr);
-                std::memcpy(dec_addr, &buf[0], DOUBLE_PUBLIC_KEY_SIZE);
-
-                return succ(dec_addr, DOUBLE_PUBLIC_KEY_SIZE);
+                BlsctDoublePubKeyResult r{};
+                std::memcpy(r.value, &buf[0], DOUBLE_PUBLIC_KEY_SIZE);
+                r.result = BLSCT_SUCCESS;
+                return r;
             }
         }
     } catch (...) {
     }
 
-    return err(BLSCT_EXCEPTION);
+    return typed_err<BlsctDoublePubKeyResult>(BLSCT_EXCEPTION);
 }
 
-BlsctRetVal* encode_address(
+BLSCT_RESULT encode_address(
     const void* void_blsct_dpk,
-    const enum AddressEncoding encoding)
+    enum AddressEncoding encoding,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
     if (encoding != Bech32 && encoding != Bech32M) {
-        return err(BLSCT_UNKNOWN_ENCODING);
+        return BLSCT_UNKNOWN_ENCODING;
     }
     try {
         UNVOID(BlsctDoublePubKey, blsct_dpk);
@@ -424,60 +422,37 @@ BlsctRetVal* encode_address(
                                    bech32_mod::Encoding::BECH32M;
         auto& chain = get_chain();
         auto enc_dpk_str = EncodeDoublePublicKey(chain, bech32_encoding, dpk);
-        size_t BUF_SIZE = enc_dpk_str.size() + 1;
-        MALLOC_BYTES(char, enc_addr, BUF_SIZE);
-        RETURN_ERR_IF_MEM_ALLOC_FAILED(enc_addr);
-        std::memcpy(enc_addr, enc_dpk_str.c_str(), BUF_SIZE); // also copies null at the end
 
-        return succ(enc_addr, BUF_SIZE);
+        if (out_len != nullptr) *out_len = enc_dpk_str.size();
+        WriteStrBuf(enc_dpk_str, buf, buf_size);
+        return BLSCT_SUCCESS;
 
     } catch (...) {
     }
 
-    return err(BLSCT_EXCEPTION);
+    return BLSCT_EXCEPTION;
 }
 
 // amount recovery
-BlsctAmountRecoveryReq* gen_amount_recovery_req(
-    const void* vp_blsct_range_proof,
-    const size_t range_proof_size,
-    const void* vp_blsct_nonce,
-    const void* vp_blsct_token_id)
+BLSCT_RESULT recover_amount(
+    const BlsctAmountRecoveryReq* reqs,
+    size_t n,
+    BlsctAmountRecoveryResult* results)
 {
-    auto req = new (std::nothrow) BlsctAmountRecoveryReq;
-    RETURN_IF_MEM_ALLOC_FAILED(req);
-
-    req->range_proof = (BlsctRangeProof*)malloc(range_proof_size);
-    RETURN_IF_MEM_ALLOC_FAILED(req->range_proof);
-
-    BLSCT_COPY_BYTES(vp_blsct_range_proof, req->range_proof, range_proof_size);
-    req->range_proof_size = range_proof_size;
-    BLSCT_COPY(vp_blsct_nonce, req->nonce);
-    if (vp_blsct_token_id == nullptr) {
-        SERIALIZE_AND_COPY_WITH_STREAM(TokenId(), req->token_id);
-    } else {
-        BLSCT_COPY(vp_blsct_token_id, req->token_id);
-    }
-    return req;
-}
-
-BlsctAmountsRetVal* recover_amount(
-    void* vp_amt_recovery_req_vec
-) {
-    MALLOC_BYTES(BlsctAmountsRetVal, rv, sizeof(BlsctAmountsRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(rv);
+    std::shared_lock<std::shared_mutex> lock(g_rpl_mutex);
+    if (g_rpl == nullptr) return BLSCT_INIT_NOT_CALLED;
+    if (reqs == nullptr || n == 0 || results == nullptr) return BLSCT_SUCCESS;
     try {
-        auto amt_recovery_req_vec =
-            static_cast<const std::vector<BlsctAmountRecoveryReq>*>(vp_amt_recovery_req_vec);
+        std::vector<bulletproofs_plus::AmountRecoveryRequest<Mcl>> cpp_reqs;
 
-        // construct AmountRecoveryRequest vector
-        std::vector<bulletproofs_plus::AmountRecoveryRequest<Mcl>> reqs;
+        for (size_t i = 0; i < n; ++i) {
+            const auto& ar_req = reqs[i];
+            if (ar_req.range_proof == nullptr)
+                return BLSCT_FAILURE;
 
-        for (size_t i = 0; i < amt_recovery_req_vec->size(); ++i) {
-            const auto& ar_req = amt_recovery_req_vec->at(i);
             bulletproofs_plus::RangeProof<Mcl> range_proof;
             UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(ar_req.range_proof, ar_req.range_proof_size, range_proof);
- 
+
             Mcl::Point nonce;
             UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(ar_req.nonce, POINT_SIZE, nonce);
 
@@ -485,212 +460,66 @@ BlsctAmountsRetVal* recover_amount(
             UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(ar_req.token_id, TOKEN_ID_SIZE, token_id);
 
             auto proof_w_seed = bulletproofs_plus::RangeProofWithSeed<Mcl>(range_proof, token_id);
-            auto req = bulletproofs_plus::AmountRecoveryRequest<Mcl>::of(
-                proof_w_seed,
-                nonce,
-                i);
-            reqs.push_back(req);
+            cpp_reqs.push_back(bulletproofs_plus::AmountRecoveryRequest<Mcl>::of(proof_w_seed, nonce, i));
         }
 
-        // try recover amount for all requests
-        // vector containing only the successful results is returned
-        auto recovery_results = g_rpl->RecoverAmounts(reqs);
+        auto recovery_results = g_rpl->RecoverAmounts(cpp_reqs);
 
-        // return error if it failed in the middle
         if (!recovery_results.is_completed) {
-            rv->result = BLSCT_DID_NOT_RUN_TO_COMPLETION;
-            return rv;
+            return BLSCT_DID_NOT_RUN_TO_COMPLETION;
         }
 
-        // the vector to return has the same size as the request vector
-        auto result_vec = new (std::nothrow) std::vector<BlsctAmountRecoveryResult>;
-        RETURN_ERR_IF_MEM_ALLOC_FAILED(result_vec);
-        result_vec->resize(amt_recovery_req_vec->size());
-
-        // mark all the results as failed
-        for (auto &result : *result_vec) {
-            result.is_succ = false;
+        for (size_t i = 0; i < n; ++i) {
+            results[i].is_succ = false;
         }
 
-        // write successful recovery results to the corresponding
-        // index of the return vector
         for (size_t i = 0; i < recovery_results.amounts.size(); ++i) {
-            // get the successful recovery result
-            auto succ_res = recovery_results.amounts[i];
+            auto& succ_res = recovery_results.amounts[i];
+            auto& result = results[succ_res.id];
 
-            // get the entry of the return vector corresponding
-            // to the successful result
-            auto& result = result_vec->at(succ_res.id);
-
-            // mark the result as success and set the amount
             result.is_succ = true;
-
-            // write amount to the result
             result.amount = succ_res.amount;
 
-            // write message to the result
-            result.msg = (char*)malloc(succ_res.message.size() + 1);
-            std::memcpy(
-                result.msg,
-                succ_res.message.c_str(),
-                succ_res.message.size() + 1);
+            size_t msg_len = std::min(succ_res.message.size(), (size_t)MAX_MEMO_LEN);
+            std::memcpy(result.msg, succ_res.message.c_str(), msg_len);
+            result.msg[msg_len] = '\0';
 
             SERIALIZE_AND_COPY(succ_res.gamma, result.gamma);
         }
 
-        rv->result = BLSCT_SUCCESS;
-        rv->value = TO_VOID(result_vec);
-        return rv;
+        return BLSCT_SUCCESS;
 
     } catch (...) {
     }
 
-    rv->result = BLSCT_EXCEPTION;
-    return rv;
-}
-
-void* create_amount_recovery_req_vec()
-{
-    auto vec = new (std::nothrow) std::vector<BlsctAmountRecoveryReq>;
-    RETURN_RET_VAL_IF_NULL(vec, nullptr);
-    return static_cast<void*>(vec);
-}
-
-void add_to_amount_recovery_req_vec(
-    void* vp_amt_recovery_req_vec,
-    void* vp_amt_recovery_req)
-{
-    RETURN_IF_NULL(vp_amt_recovery_req_vec);
-    RETURN_IF_NULL(vp_amt_recovery_req);
-
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryReq>*>(vp_amt_recovery_req_vec);
-    auto req = static_cast<BlsctAmountRecoveryReq*>(vp_amt_recovery_req);
-    vec->push_back(*req);
-}
-
-void delete_amount_recovery_req_vec(void* vp_amt_recovery_req_vec)
-{
-    RETURN_IF_NULL(vp_amt_recovery_req_vec);
-    auto vec = static_cast<const std::vector<BlsctAmountRecoveryReq>*>(vp_amt_recovery_req_vec);
-    for (auto& req : *vec) {
-        free(req.range_proof);
-    }
-    delete vec;
-}
-
-// functions to retrieve attrs of amount recovery result
-size_t get_amount_recovery_result_size(
-    void* vp_amt_recovery_res_vec)
-{
-    if (vp_amt_recovery_res_vec == nullptr) {
-        return -1;
-    }
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryResult>*>(vp_amt_recovery_res_vec);
-
-    return vec->size();
-}
-
-bool get_amount_recovery_result_is_succ(
-    void* vp_amt_recovery_req_vec,
-    size_t idx)
-{
-    RETURN_RET_VAL_IF_NULL(vp_amt_recovery_req_vec, false);
-
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryResult>*>(vp_amt_recovery_req_vec);
-
-    return vec->at(idx).is_succ;
-}
-
-uint64_t get_amount_recovery_result_amount(
-    void* vp_amt_recovery_req_vec,
-    size_t idx)
-{
-    RETURN_RET_VAL_IF_NULL(vp_amt_recovery_req_vec, -1);
-
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryResult>*>(vp_amt_recovery_req_vec);
-
-    return vec->at(idx).amount;
-}
-
-const char* get_amount_recovery_result_msg(
-    void* vp_amt_recovery_req_vec,
-    size_t idx)
-{
-    RETURN_RET_VAL_IF_NULL(vp_amt_recovery_req_vec, nullptr);
-
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryResult>*>(vp_amt_recovery_req_vec);
-
-    return vec->at(idx).msg;
-}
-
-const BlsctScalar* get_amount_recovery_result_gamma(
-    void* vp_amt_recovery_req_vec,
-    size_t idx)
-{
-    RETURN_RET_VAL_IF_NULL(vp_amt_recovery_req_vec, nullptr);
-
-    auto vec = static_cast<std::vector<BlsctAmountRecoveryResult>*>(vp_amt_recovery_req_vec);
-
-    return &vec->at(idx).gamma;
+    return BLSCT_EXCEPTION;
 }
 
 // ctx
-void* create_tx_in_vec()
+BlsctCTxResult build_ctx(
+    const BlsctTxInData* tx_ins,
+    size_t tx_ins_len,
+    const BlsctTxOutData* tx_outs,
+    size_t tx_outs_len,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    auto* tx_in_vec = new (std::nothrow) std::vector<BlsctTxIn>;
-    return reinterpret_cast<void*>(tx_in_vec);
-}
-
-void add_to_tx_in_vec(void* vp_tx_in_vec, const BlsctTxIn* tx_in)
-{
-    auto* tx_in_vec = reinterpret_cast<std::vector<BlsctTxIn>*>(vp_tx_in_vec);
-    tx_in_vec->push_back(*tx_in);
-}
-
-void delete_tx_in_vec(void* vp_tx_in_vec)
-{
-    auto* tx_in_vec = reinterpret_cast<std::vector<BlsctTxIn>*>(vp_tx_in_vec);
-    delete tx_in_vec;
-}
-
-void* create_tx_out_vec()
-{
-    auto* tx_out_vec = new (std::nothrow) std::vector<BlsctTxOut>;
-    return reinterpret_cast<void*>(tx_out_vec);
-}
-
-void add_to_tx_out_vec(void* vp_tx_out_vec, const BlsctTxOut* tx_out)
-{
-    auto* tx_out_vec = reinterpret_cast<std::vector<BlsctTxOut>*>(vp_tx_out_vec);
-    tx_out_vec->push_back(*tx_out);
-}
-
-void delete_tx_out_vec(void* vp_tx_out_vec)
-{
-    auto* tx_out_vec = reinterpret_cast<std::vector<BlsctTxOut>*>(vp_tx_out_vec);
-    delete tx_out_vec;
-}
-
-BlsctCTxRetVal* build_ctx(
-    const void* void_tx_ins,
-    const void* void_tx_outs)
-{
-    UNVOID(std::vector<BlsctTxIn>, tx_ins);
-    UNVOID(std::vector<BlsctTxOut>, tx_outs);
+    if (tx_ins == nullptr || tx_ins_len == 0 || tx_outs == nullptr || tx_outs_len == 0)
+        return typed_err<BlsctCTxResult>(BLSCT_FAILURE);
 
     blsct::TxFactoryBase psbt;
-    MALLOC_BYTES(BlsctCTxRetVal, rv, sizeof(BlsctCTxRetVal));
-    RETURN_IF_MEM_ALLOC_FAILED(rv);
 
-    for (size_t i = 0; i < tx_ins->size(); ++i) {
+    for (size_t i = 0; i < tx_ins_len; ++i) {
         // unserialize tx_in fields and add to TxFactoryBase
-        const BlsctTxIn& tx_in = tx_ins->at(i);
+        const BlsctTxInData& tx_in = tx_ins[i];
 
         // check if the amount is within the range
         // amount is uint64_t and not serialized
         if (tx_in.amount > std::numeric_limits<int64_t>::max()) {
-            rv->result = BLSCT_IN_AMOUNT_ERROR;
-            rv->in_amount_err_index = i;
+            BlsctCTxResult rv{};
+            rv.result = BLSCT_IN_AMOUNT_ERROR;
+            rv.in_amount_err_index = i;
             return rv;
         }
 
@@ -722,15 +551,16 @@ BlsctCTxRetVal* build_ctx(
             tx_in.rbf);
     }
 
-    for (size_t i = 0; i < tx_outs->size(); ++i) {
+    for (size_t i = 0; i < tx_outs_len; ++i) {
         // unserialize tx_out fields and add to TxFactoryBase
-        const BlsctTxOut& tx_out = tx_outs->at(i);
+        const BlsctTxOutData& tx_out = tx_outs[i];
 
         // check if the amount is within the range
         // amount is uint64_t and not serialized
         if (tx_out.amount > std::numeric_limits<int64_t>::max()) {
-            rv->result = BLSCT_OUT_AMOUNT_ERROR;
-            rv->out_amount_err_index = i;
+            BlsctCTxResult rv{};
+            rv.result = BLSCT_OUT_AMOUNT_ERROR;
+            rv.out_amount_err_index = i;
             return rv;
         }
 
@@ -754,15 +584,13 @@ BlsctCTxRetVal* build_ctx(
         } else if (tx_out.output_type == TxOutputType::StakedCommitment) {
             out_type = blsct::CreateTransactionType::STAKED_COMMITMENT;
         } else {
-            rv->result = BLSCT_BAD_OUT_TYPE;
-            return rv;
+            return typed_err<BlsctCTxResult>(BLSCT_BAD_OUT_TYPE);
         }
 
         // unserialize blinding key
         Scalar blinding_key;
         UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(
-            tx_out.blinding_key, SCALAR_SIZE, blinding_key
-        );
+            tx_out.blinding_key, SCALAR_SIZE, blinding_key);
 
         // add all to TxFactoryBase
         psbt.AddOutput(
@@ -773,145 +601,211 @@ BlsctCTxRetVal* build_ctx(
             out_type,
             tx_out.min_stake,
             tx_out.subtract_fee_from_amount,
-            blinding_key
-        );
+            blinding_key);
     }
 
     // build ctx
     blsct::DoublePublicKey change_amt_dest;
     auto maybe_ctx = psbt.BuildTx(change_amt_dest);
     if (!maybe_ctx.has_value()) {
-        rv->result = BLSCT_FAILURE;
-        return rv;
+        return typed_err<BlsctCTxResult>(BLSCT_FAILURE);
     }
 
-    // move the ctx to newly created ctx in heap
-    CMutableTransaction* ctx_in_heap = new (std::nothrow) CMutableTransaction;
-    *ctx_in_heap = std::move(maybe_ctx.value());
-
-    rv->result = BLSCT_SUCCESS;
-    rv->ctx = static_cast<void*>(ctx_in_heap);
-
+    CMutableTransaction ctx = std::move(maybe_ctx.value());
+    size_t sz = SerializeCtxToHexBuf(ctx, buf, buf_size);
+    if (out_len) *out_len = sz;
+    BlsctCTxResult rv{};
+    rv.result = BLSCT_SUCCESS;
     return rv;
 }
 
-const char* get_ctx_id(void* vp_ctx)
+static std::optional<CMutableTransaction> DeserializeCtx(const char* hex)
 {
-    CMutableTransaction* ctx = reinterpret_cast<CMutableTransaction*>(vp_ctx);
-    Txid ctxid = ctx->GetHash();
-    std::string ctxid_hex = ctxid.GetHex();
-
-    return StrToAllocCStr(ctxid_hex);
-}
-
-const void* get_ctx_ins(void* vp_ctx)
-{
-    CMutableTransaction* ctx = reinterpret_cast<CMutableTransaction*>(vp_ctx);
-    return &ctx->vin;
-}
-
-const void* get_ctx_outs(void* vp_ctx)
-{
-    CMutableTransaction* ctx = reinterpret_cast<CMutableTransaction*>(vp_ctx);
-    return &ctx->vout;
-}
-
-void delete_ctx(void* vp_ctx)
-{
-    auto ctx = reinterpret_cast<CMutableTransaction*>(vp_ctx);
-    delete ctx;
-}
-
-const char* serialize_ctx(void* vp_ctx)
-{
-    DataStream st{};
-    TransactionSerParams params{.allow_witness = true};
-    ParamsStream ps{params, st};
-
-    auto ctx = reinterpret_cast<CMutableTransaction*>(vp_ctx);
-    ctx->Serialize(ps);
-
-    return SerializeToHex(
-        reinterpret_cast<uint8_t*>(st.data()),
-        st.size());
-}
-
-BlsctRetVal* deserialize_ctx(const char* hex)
-{
-    CMutableTransaction* ctx = new CMutableTransaction();
-
-    std::string hex_str(hex);
-
+    if (!hex) return std::nullopt;
     std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex_str, vec)) {
-        delete ctx;
-        return err(BLSCT_FAILURE);
-    }
-
+    if (!TryParseHexWrap(std::string(hex), vec)) return std::nullopt;
     try {
+        CMutableTransaction tx;
         DataStream st;
         TransactionSerParams params{.allow_witness = true};
         ParamsStream ps{params, st};
         st.write(MakeByteSpan(vec));
-        ctx->Unserialize(ps);
+        tx.Unserialize(ps);
+        return tx;
     } catch (const std::exception&) {
-        delete ctx;
-        return err(BLSCT_DESER_FAILED);
+        return std::nullopt;
     }
+}
 
-    // the object will be deleted after use. the size will not be used
-    return succ(ctx, 0);
+BlsctCTxIdHexResult get_ctx_id(const char* hex)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx) return typed_err<BlsctCTxIdHexResult>(BLSCT_FAILURE);
+    std::string id_hex = tx->GetHash().GetHex();
+    BlsctCTxIdHexResult r{};
+    std::memcpy(r.value, id_hex.c_str(), id_hex.size() + 1);
+    r.result = BLSCT_SUCCESS;
+    return r;
+}
+
+bool are_ctx_ins_equal(const char* hex_a, const char* hex_b)
+{
+    if (!hex_a || !hex_b) return false;
+    auto a = DeserializeCtx(hex_a);
+    auto b = DeserializeCtx(hex_b);
+    if (!a || !b) return false;
+    return a->vin == b->vin;
+}
+
+BlsctSizeTResult get_ctx_ins_size(const char* hex)
+{
+    if (hex == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    auto tx = DeserializeCtx(hex);
+    if (!tx) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx->vin.size()};
+}
+
+bool are_ctx_outs_equal(const char* hex_a, const char* hex_b)
+{
+    if (!hex_a || !hex_b) return false;
+    auto a = DeserializeCtx(hex_a);
+    auto b = DeserializeCtx(hex_b);
+    if (!a || !b) return false;
+    return a->vout == b->vout;
+}
+
+BlsctSizeTResult get_ctx_outs_size(const char* hex)
+{
+    if (hex == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    auto tx = DeserializeCtx(hex);
+    if (!tx) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx->vout.size()};
+}
+
+BlsctCTxIdResult get_ctx_in_prev_out_hash_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vin.size()) return typed_err<BlsctCTxIdResult>(BLSCT_FAILURE);
+    return get_ctx_in_prev_out_hash(&tx->vin[i]);
+}
+
+BlsctScriptResult get_ctx_in_script_sig_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vin.size()) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
+    return get_ctx_in_script_sig(&tx->vin[i]);
+}
+
+BlsctUint32Result get_ctx_in_sequence_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vin.size()) return typed_err<BlsctUint32Result>(BLSCT_FAILURE);
+    return get_ctx_in_sequence(&tx->vin[i]);
+}
+
+BlsctScriptResult get_ctx_in_script_witness_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vin.size()) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
+    return get_ctx_in_script_witness(&tx->vin[i]);
+}
+
+BlsctUint64Result get_ctx_out_value_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return get_ctx_out_value(&tx->vout[i]);
+}
+
+BlsctScriptResult get_ctx_out_script_pub_key_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
+    return get_ctx_out_script_pub_key(&tx->vout[i]);
+}
+
+BlsctTokenIdResult get_ctx_out_token_id_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctTokenIdResult>(BLSCT_FAILURE);
+    return get_ctx_out_token_id(&tx->vout[i]);
+}
+
+BLSCT_RESULT get_ctx_out_vector_predicate_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return BLSCT_FAILURE;
+    return get_ctx_out_vector_predicate(&tx->vout[i], buf, buf_size, out_len);
+}
+
+BlsctPointResult get_ctx_out_spending_key_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
+    return get_ctx_out_spending_key(&tx->vout[i]);
+}
+
+BlsctPointResult get_ctx_out_ephemeral_key_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
+    return get_ctx_out_ephemeral_key(&tx->vout[i]);
+}
+
+BlsctPointResult get_ctx_out_blinding_key_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
+    return get_ctx_out_blinding_key(&tx->vout[i]);
+}
+
+BLSCT_RESULT get_ctx_out_range_proof_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return BLSCT_FAILURE;
+    return get_ctx_out_range_proof(&tx->vout[i], buf, buf_size, out_len);
+}
+
+BlsctUint16Result get_ctx_out_view_tag_at(const char* hex, size_t i)
+{
+    auto tx = DeserializeCtx(hex);
+    if (!tx || i >= tx->vout.size()) return typed_err<BlsctUint16Result>(BLSCT_FAILURE);
+    return get_ctx_out_view_tag(&tx->vout[i]);
 }
 
 // ctx id
-const char* serialize_ctx_id(const BlsctCTxId* blsct_ctx_id)
+BlsctCTxIdHexResult serialize_ctx_id(const BlsctCTxId* blsct_ctx_id)
 {
-    return SerializeToHex(*blsct_ctx_id, CTX_ID_SIZE);
+    BlsctCTxIdHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_ctx_id, CTX_ID_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_ctx_id(const char* hex)
+BlsctCTxIdResult deserialize_ctx_id(const char* hex)
 {
-    BlsctCTxId* blsct_ctx_id = static_cast<BlsctCTxId*>(
-        DeserializeFromHex(hex, CTX_ID_SIZE));
-    return succ(blsct_ctx_id, CTX_ID_SIZE);
-}
-
-void* create_tx_hex_vec()
-{
-    auto* tx_hex_vec = new (std::nothrow) std::vector<std::string>;
-    return static_cast<void*>(tx_hex_vec);
-}
-
-void add_to_tx_hex_vec(void* vp_tx_hex_vec, const char* tx_hex)
-{
-    RETURN_IF_NULL(vp_tx_hex_vec);
-    RETURN_IF_NULL(tx_hex);
-    auto* tx_hex_vec = static_cast<std::vector<std::string>*>(vp_tx_hex_vec);
-    tx_hex_vec->emplace_back(tx_hex);
-}
-
-void delete_tx_hex_vec(void* vp_tx_hex_vec)
-{
-    if (vp_tx_hex_vec == nullptr) return;
-    delete static_cast<std::vector<std::string>*>(vp_tx_hex_vec);
-}
-
-BlsctRetVal* aggregate_transactions(const void* vp_tx_hex_vec)
-{
-    RETURN_RET_VAL_IF_NULL(vp_tx_hex_vec, err(BLSCT_FAILURE));
-
-    const auto* tx_hex_vec = static_cast<const std::vector<std::string>*>(vp_tx_hex_vec);
-    if (tx_hex_vec->empty()) {
-        return err(BLSCT_FAILURE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != CTX_ID_SIZE) {
+        return typed_err<BlsctCTxIdResult>(BLSCT_BAD_SIZE);
     }
+    BlsctCTxIdResult r{};
+    std::memcpy(r.value, vec.data(), CTX_ID_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
+}
+
+BLSCT_RESULT aggregate_transactions(const char* const* tx_hexes, size_t tx_count, char* buf, size_t buf_size, size_t* out_len)
+{
+    if (tx_hexes == nullptr || tx_count == 0) return BLSCT_FAILURE;
 
     std::vector<CTransactionRef> txs;
-    txs.reserve(tx_hex_vec->size());
+    txs.reserve(tx_count);
 
-    for (const auto& tx_hex : *tx_hex_vec) {
+    for (size_t i = 0; i < tx_count; ++i) {
+        const std::string tx_hex = tx_hexes[i] ? tx_hexes[i] : "";
         std::vector<uint8_t> tx_bytes;
         if (!TryParseHexWrap(tx_hex, tx_bytes) || tx_bytes.empty()) {
-            return err(BLSCT_DESER_FAILED);
+            return BLSCT_DESER_FAILED;
         }
 
         CMutableTransaction mutable_tx;
@@ -922,7 +816,7 @@ BlsctRetVal* aggregate_transactions(const void* vp_tx_hex_vec)
             st.write(MakeByteSpan(tx_bytes));
             mutable_tx.Unserialize(ps);
         } catch (const std::exception&) {
-            return err(BLSCT_DESER_FAILED);
+            return BLSCT_DESER_FAILED;
         }
 
         txs.push_back(MakeTransactionRef(std::move(mutable_tx)));
@@ -935,203 +829,193 @@ BlsctRetVal* aggregate_transactions(const void* vp_tx_hex_vec)
         TransactionSerParams params{.allow_witness = true};
         ParamsStream ps{params, st};
         aggregated_tx->Serialize(ps);
-        const char* hex_c_str = SerializeToHex(
-            reinterpret_cast<uint8_t*>(st.data()),
-            st.size());
-        if (hex_c_str == nullptr) {
-            return err(BLSCT_MEM_ALLOC_FAILED);
-        }
-        return succ(const_cast<char*>(hex_c_str), st.size() * 2 + 1);
+
+        const auto hex = HexStr(MakeByteSpan(st));
+        if (out_len != nullptr) *out_len = hex.size();
+        WriteStrBuf(hex, buf, buf_size);
+        return BLSCT_SUCCESS;
     } catch (const std::exception&) {
-        return err(BLSCT_FAILURE);
+        return BLSCT_FAILURE;
     }
-}
-
-// ctx ins
-bool are_ctx_ins_equal(const void* vp_a, const void* vp_b)
-{
-    auto* a = static_cast<const std::vector<CTxIn>*>(vp_a);
-    auto* b = static_cast<const std::vector<CTxIn>*>(vp_b);
-    return a == b;
-}
-
-size_t get_ctx_ins_size(const void* vp_ctx_ins)
-{
-    auto* ctx_ins = static_cast<const std::vector<CTxIn>*>(vp_ctx_ins);
-    return ctx_ins->size();
-}
-
-const void* get_ctx_in_at(const void* vp_ctx_ins, const size_t i)
-{
-    auto* ctx_ins = static_cast<const std::vector<CTxIn>*>(vp_ctx_ins);
-    const CTxIn* ctx_in = &ctx_ins->at(i);
-    return static_cast<const void*>(ctx_in);
 }
 
 // ctx in
 bool are_ctx_in_equal(const void* vp_a, const void* vp_b)
 {
+    if (vp_a == nullptr || vp_b == nullptr) return false;
     auto* a = static_cast<const CTxIn*>(vp_a);
     auto* b = static_cast<const CTxIn*>(vp_b);
     return *a == *b;
 }
 
-const BlsctCTxId* get_ctx_in_prev_out_hash(const void* vp_ctx_in)
+BlsctCTxIdResult get_ctx_in_prev_out_hash(const void* vp_ctx_in)
 {
+    if (vp_ctx_in == nullptr) return typed_err<BlsctCTxIdResult>(BLSCT_FAILURE);
     auto* ctx_in = static_cast<const CTxIn*>(vp_ctx_in);
-    auto copy = static_cast<BlsctCTxId*>(malloc(CTX_ID_SIZE));
-    std::memcpy(copy, &ctx_in->prevout.hash, CTX_ID_SIZE);
-    return copy;
+    BlsctCTxIdResult r{};
+    r.result = BLSCT_SUCCESS;
+    std::memcpy(r.value, &ctx_in->prevout.hash, CTX_ID_SIZE);
+    return r;
 }
 
-const BlsctScript* get_ctx_in_script_sig(const void* vp_ctx_in)
+BlsctScriptResult get_ctx_in_script_sig(const void* vp_ctx_in)
 {
+    if (vp_ctx_in == nullptr) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
     auto* ctx_in = static_cast<const CTxIn*>(vp_ctx_in);
-    auto copy = static_cast<BlsctScript*>(malloc(SCRIPT_SIZE));
-    std::memcpy(copy, &ctx_in->scriptSig, SCRIPT_SIZE);
-    return copy;
+    if (ctx_in->scriptSig.size() > SCRIPT_SIZE)
+        return typed_err<BlsctScriptResult>(BLSCT_BAD_SIZE);
+    BlsctScriptResult r{};
+    std::memcpy(r.value, ctx_in->scriptSig.data(), ctx_in->scriptSig.size());
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-uint32_t get_ctx_in_sequence(const void* vp_ctx_in)
+BlsctUint32Result get_ctx_in_sequence(const void* vp_ctx_in)
 {
+    if (vp_ctx_in == nullptr) return typed_err<BlsctUint32Result>(BLSCT_FAILURE);
     auto* ctx_in = static_cast<const CTxIn*>(vp_ctx_in);
-    return ctx_in->nSequence;
+    return {BLSCT_SUCCESS, ctx_in->nSequence};
 }
 
-const BlsctScript* get_ctx_in_script_witness(const void* vp_ctx_in)
+BlsctScriptResult get_ctx_in_script_witness(const void* vp_ctx_in)
 {
+    if (vp_ctx_in == nullptr) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
     auto* ctx_in = static_cast<const CTxIn*>(vp_ctx_in);
-    auto copy = static_cast<BlsctScript*>(malloc(SCRIPT_SIZE));
-    std::memcpy(copy, &ctx_in->scriptWitness, SCRIPT_SIZE);
-    return copy;
-}
-
-// ctx outs
-bool are_ctx_outs_equal(const void* vp_a, const void* vp_b)
-{
-    auto* a = static_cast<const std::vector<CTxOut>*>(vp_a);
-    auto* b = static_cast<const std::vector<CTxOut>*>(vp_b);
-    return a == b;
-}
-
-size_t get_ctx_outs_size(const void* vp_ctx_outs)
-{
-    auto* ctx_outs = static_cast<const std::vector<CTxOut>*>(vp_ctx_outs);
-    return ctx_outs->size();
-}
-
-const void* get_ctx_out_at(const void* vp_ctx_outs, const size_t i)
-{
-    auto* ctx_outs = static_cast<const std::vector<CTxOut>*>(vp_ctx_outs);
-    const CTxOut* ctx_out = &ctx_outs->at(i);
-    return static_cast<const void*>(ctx_out);
+    const auto& stack = ctx_in->scriptWitness.stack;
+    if (!stack.empty() && !stack[0].empty()) {
+        if (stack[0].size() > SCRIPT_SIZE)
+            return typed_err<BlsctScriptResult>(BLSCT_BAD_SIZE);
+        BlsctScriptResult r{};
+        std::memcpy(r.value, stack[0].data(), stack[0].size());
+        r.result = BLSCT_SUCCESS;
+        return r;
+    }
+    BlsctScriptResult r{};
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // ctx out
 bool are_ctx_out_equal(const void* vp_a, const void* vp_b)
 {
+    if (vp_a == nullptr || vp_b == nullptr) return false;
     auto* a = static_cast<const CTxOut*>(vp_a);
     auto* b = static_cast<const CTxOut*>(vp_b);
     return *a == *b;
 }
 
-uint64_t get_ctx_out_value(const void* vp_ctx_out)
+BlsctUint64Result get_ctx_out_value(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    return ctx_out->nValue;
+    return {BLSCT_SUCCESS, static_cast<uint64_t>(ctx_out->nValue)};
 }
 
-const BlsctScript* get_ctx_out_script_pub_key(const void* vp_ctx_out)
+BlsctScriptResult get_ctx_out_script_pub_key(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctScriptResult>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    auto copy = static_cast<BlsctScript*>(malloc(SCRIPT_SIZE));
-    std::memcpy(copy, &ctx_out->scriptPubKey, SCRIPT_SIZE);
-    return copy;
+    if (ctx_out->scriptPubKey.size() > SCRIPT_SIZE)
+        return typed_err<BlsctScriptResult>(BLSCT_BAD_SIZE);
+    BlsctScriptResult r{};
+    std::memcpy(r.value, ctx_out->scriptPubKey.data(), ctx_out->scriptPubKey.size());
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const BlsctPoint* get_ctx_out_spending_key(const void* vp_ctx_out)
+BlsctPointResult get_ctx_out_spending_key(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    auto copy = static_cast<BlsctPoint*>(malloc(POINT_SIZE));
-    auto org = ctx_out->blsctData.spendingKey.GetVch();
-    std::memcpy(copy, &org[0], POINT_SIZE);
-    return copy;
+    BlsctPointResult r{};
+    r.result = BLSCT_SUCCESS;
+    SERIALIZE_AND_COPY(ctx_out->blsctData.spendingKey, r.value);
+    return r;
 }
 
-const BlsctPoint* get_ctx_out_ephemeral_key(const void* vp_ctx_out)
+BlsctPointResult get_ctx_out_ephemeral_key(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    auto copy = static_cast<BlsctPoint*>(malloc(POINT_SIZE));
-    auto org = ctx_out->blsctData.ephemeralKey.GetVch();
-    std::memcpy(copy, &org[0], POINT_SIZE);
-    return copy;
+    BlsctPointResult r{};
+    r.result = BLSCT_SUCCESS;
+    SERIALIZE_AND_COPY(ctx_out->blsctData.ephemeralKey, r.value);
+    return r;
 }
 
-const BlsctPoint* get_ctx_out_blinding_key(const void* vp_ctx_out)
+BlsctPointResult get_ctx_out_blinding_key(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctPointResult>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    auto copy = static_cast<BlsctPoint*>(malloc(POINT_SIZE));
-    auto org = ctx_out->blsctData.blindingKey.GetVch();
-    std::memcpy(copy, &org[0], POINT_SIZE);
-    return copy;
+    BlsctPointResult r{};
+    r.result = BLSCT_SUCCESS;
+    SERIALIZE_AND_COPY(ctx_out->blsctData.blindingKey, r.value);
+    return r;
 }
 
-const BlsctRetVal* get_ctx_out_range_proof(const void* vp_ctx_out)
+BLSCT_RESULT get_ctx_out_range_proof(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len)
 {
+    if (vp_ctx_out == nullptr) return BLSCT_FAILURE;
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    DataStream st{};
-    ctx_out->blsctData.rangeProof.Serialize(st);
-    auto copy = static_cast<BlsctRangeProof*>(malloc(st.size()));
-    std::memcpy(copy, st.data(), st.size());
-    return succ(copy, st.size());
-    ;
-};
-
-uint16_t get_ctx_out_view_tag(const void* vp_ctx_out)
-{
-    auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    return ctx_out->blsctData.viewTag;
+    size_t sz = SerializeObjToByteBuf(ctx_out->blsctData.rangeProof, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-const BlsctTokenId* get_ctx_out_token_id(const void* vp_ctx_out)
+BlsctUint16Result get_ctx_out_view_tag(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctUint16Result>(BLSCT_FAILURE);
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
-    auto copy = static_cast<BlsctTokenId*>(malloc(TOKEN_ID_SIZE));
-    std::memcpy(copy, &ctx_out->tokenId, TOKEN_ID_SIZE);
-    return copy;
+    return {BLSCT_SUCCESS, ctx_out->blsctData.viewTag};
 }
 
-BlsctRetVal* get_ctx_out_vector_predicate(const void* vp_ctx_out)
+BlsctTokenIdResult get_ctx_out_token_id(const void* vp_ctx_out)
 {
+    if (vp_ctx_out == nullptr) return typed_err<BlsctTokenIdResult>(BLSCT_FAILURE);
+    auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
+    BlsctTokenIdResult r{};
+    r.result = BLSCT_SUCCESS;
+    std::memcpy(r.value, &ctx_out->tokenId, TOKEN_ID_SIZE);
+    return r;
+}
+
+BLSCT_RESULT get_ctx_out_vector_predicate(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len)
+{
+    if (vp_ctx_out == nullptr) return BLSCT_FAILURE;
     auto* ctx_out = static_cast<const CTxOut*>(vp_ctx_out);
     auto& pred = ctx_out->predicate;
-    MALLOC_BYTES(uint8_t, buf, pred.size());
-    RETURN_IF_MEM_ALLOC_FAILED(buf)
-
-    std::memcpy(buf, pred.data(), pred.size());
-    return succ(buf, pred.size());
+    if (out_len) *out_len = pred.size();
+    if (buf != nullptr && buf_size >= pred.size())
+        std::memcpy(buf, pred.data(), pred.size());
+    return BLSCT_SUCCESS;
 }
 
 // delegators of blsct/wallet/helpers
-uint64_t calc_view_tag(
+BlsctUint64Result calc_view_tag(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* blsct_view_key)
 {
+    if (blsct_blinding_pub_key == nullptr || blsct_view_key == nullptr)
+        return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+
     blsct::PublicKey blinding_pub_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_blinding_pub_key, PUBLIC_KEY_SIZE, blinding_pub_key);
 
     Scalar view_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_view_key, SCALAR_SIZE, view_key);
 
-    return blsct::CalculateViewTag(
-        blinding_pub_key.GetG1Point(),
-        view_key);
+    return {BLSCT_SUCCESS, blsct::CalculateViewTag(
+                               blinding_pub_key.GetG1Point(),
+                               view_key)};
 }
 
-BlsctPoint* calc_nonce(
+BlsctPointResult calc_nonce(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* blsct_view_key)
 {
+    if (blsct_blinding_pub_key == nullptr || blsct_view_key == nullptr)
+        return typed_err<BlsctPointResult>(BLSCT_FAILURE);
+
     blsct::PublicKey blinding_pub_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_blinding_pub_key, PUBLIC_KEY_SIZE, blinding_pub_key);
 
@@ -1141,15 +1025,14 @@ BlsctPoint* calc_nonce(
     auto nonce = blsct::CalculateNonce(
         blinding_pub_key.GetG1Point(),
         view_key);
-    BlsctPoint* blsct_nonce = static_cast<BlsctPoint*>(
-        malloc(POINT_SIZE));
-    SERIALIZE_AND_COPY(nonce, blsct_nonce);
-
-    return blsct_nonce;
+    BlsctPointResult r{};
+    SERIALIZE_AND_COPY(nonce, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // double public key
-BlsctRetVal* gen_double_pub_key(
+BlsctDoublePubKeyResult gen_double_pub_key(
     const BlsctPubKey* blsct_pk1,
     const BlsctPubKey* blsct_pk2)
 {
@@ -1166,15 +1049,14 @@ BlsctRetVal* gen_double_pub_key(
     pk1.SetVch(blsct_pk1_vec);
     pk2.SetVch(blsct_pk2_vec);
 
-    MALLOC_BYTES(BlsctDoublePubKey, blsct_dpk, DOUBLE_PUBLIC_KEY_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_dpk);
     blsct::DoublePublicKey dpk(pk1, pk2);
-    SERIALIZE_AND_COPY(dpk, blsct_dpk);
-
-    return succ(blsct_dpk, sizeof(BlsctDoublePubKey));
+    BlsctDoublePubKeyResult r{};
+    SERIALIZE_AND_COPY(dpk, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* dpk_to_sub_addr(
+BlsctSubAddrResult dpk_to_sub_addr(
     const BlsctDoublePubKey* blsct_dpk)
 {
     // unserialize double public key
@@ -1185,38 +1067,28 @@ BlsctRetVal* dpk_to_sub_addr(
     // create sub address from dpk
     blsct::SubAddress sub_addr(dpk);
 
-    // allocate memory for serialized sub address
-    MALLOC_BYTES(BlsctSubAddr, blsct_sub_addr, SUB_ADDR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_sub_addr);
-
-    // serialize sub address
-    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr, blsct_sub_addr);
-
-    return succ(blsct_sub_addr, sizeof(blsct::SubAddress));
+    BlsctSubAddrResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctDoublePubKey* sub_addr_to_dpk(
-    const BlsctSubAddr* blsct_sub_addr
-) {
+BlsctDoublePubKeyResult sub_addr_to_dpk(
+    const BlsctSubAddr* blsct_sub_addr)
+{
     // unserialize sub address
     blsct::SubAddress sub_addr;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(
-        blsct_sub_addr, SUB_ADDR_SIZE, sub_addr
-    );
-
-    // allocate memory for serialized double public key
-    MALLOC_BYTES(BlsctDoublePubKey, blsct_dpk, DOUBLE_PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_dpk);
+        blsct_sub_addr, SUB_ADDR_SIZE, sub_addr);
 
     blsct::DoublePublicKey dpk = sub_addr.GetKeys();
-
-    // serialize double public key
-    SERIALIZE_AND_COPY_WITH_STREAM(dpk, blsct_dpk);
-
-    return blsct_dpk;
+    BlsctDoublePubKeyResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(dpk, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctDoublePubKey* gen_dpk_with_keys_acct_addr(
+BlsctDoublePubKeyResult gen_dpk_with_keys_acct_addr(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const int64_t account,
@@ -1232,27 +1104,34 @@ BlsctDoublePubKey* gen_dpk_with_keys_acct_addr(
     blsct::SubAddress sub_addr(view_key, spending_pub_key, sub_addr_id);
 
     auto dpk = std::get<blsct::DoublePublicKey>(sub_addr.GetDestination());
-    BlsctDoublePubKey* blsct_dpk = static_cast<BlsctDoublePubKey*>(
-        malloc(DOUBLE_PUBLIC_KEY_SIZE));
-    SERIALIZE_AND_COPY_WITH_STREAM(dpk, blsct_dpk);
-
-    return blsct_dpk;
+    BlsctDoublePubKeyResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(dpk, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_dpk(const BlsctDoublePubKey* blsct_dpk)
+BlsctDoublePubKeyHexResult serialize_dpk(const BlsctDoublePubKey* blsct_dpk)
 {
-    return SerializeToHex(*blsct_dpk, DOUBLE_PUBLIC_KEY_SIZE);
+    BlsctDoublePubKeyHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_dpk, DOUBLE_PUBLIC_KEY_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_dpk(const char* hex)
+BlsctDoublePubKeyResult deserialize_dpk(const char* hex)
 {
-    BlsctDoublePubKey* blsct_dpk = static_cast<BlsctDoublePubKey*>(
-        DeserializeFromHex(hex, DOUBLE_PUBLIC_KEY_SIZE));
-    return succ(blsct_dpk, DOUBLE_PUBLIC_KEY_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != DOUBLE_PUBLIC_KEY_SIZE) {
+        return typed_err<BlsctDoublePubKeyResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctDoublePubKeyResult r{};
+    std::memcpy(r.value, vec.data(), DOUBLE_PUBLIC_KEY_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // key id
-BlsctKeyId* calc_key_id(
+BlsctKeyIdResult calc_key_id(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctScalar* blsct_view_key)
@@ -1270,103 +1149,116 @@ BlsctKeyId* calc_key_id(
         blinding_pub_key.GetG1Point(),
         spending_pub_key.GetG1Point(),
         view_key);
-    BlsctKeyId* blsct_key_id = static_cast<BlsctKeyId*>(
-        malloc(KEY_ID_SIZE));
-    SERIALIZE_AND_COPY_WITH_STREAM(key_id, blsct_key_id);
-
-    return blsct_key_id;
+    BlsctKeyIdResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(key_id, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_key_id(
+BlsctKeyIdHexResult serialize_key_id(
     const BlsctKeyId* blsct_key_id)
 {
-    return SerializeToHex(*blsct_key_id, KEY_ID_SIZE);
+    BlsctKeyIdHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_key_id, KEY_ID_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_key_id(const char* hex)
+BlsctKeyIdResult deserialize_key_id(const char* hex)
 {
-    BlsctKeyId* blsct_key_id = static_cast<BlsctKeyId*>(
-        DeserializeFromHex(hex, KEY_ID_SIZE));
-    return succ(blsct_key_id, KEY_ID_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != KEY_ID_SIZE) {
+        return typed_err<BlsctKeyIdResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctKeyIdResult r{};
+    std::memcpy(r.value, vec.data(), KEY_ID_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // out point
-BlsctRetVal* gen_out_point(
+BlsctOutPointResult gen_out_point(
     const char* ctx_id_c_str)
 {
-    MALLOC_BYTES(BlsctOutPoint, blsct_out_point, OUT_POINT_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_out_point);
+    if (ctx_id_c_str == nullptr || std::strlen(ctx_id_c_str) != CTX_ID_STR_LEN)
+        return typed_err<BlsctOutPointResult>(BLSCT_FAILURE);
 
     std::string ctx_id_str(ctx_id_c_str, CTX_ID_STR_LEN);
 
     auto ctx_id = TxidFromString(ctx_id_str);
     COutPoint out_point{ctx_id};
 
-    SERIALIZE_AND_COPY_WITH_STREAM(
-        out_point,
-        blsct_out_point);
-    return succ(blsct_out_point, OUT_POINT_SIZE);
+    BlsctOutPointResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(out_point, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_out_point(const BlsctOutPoint* blsct_out_point)
+BlsctOutPointHexResult serialize_out_point(const BlsctOutPoint* blsct_out_point)
 {
-    return SerializeToHex(*blsct_out_point, OUT_POINT_SIZE);
+    BlsctOutPointHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_out_point, OUT_POINT_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_out_point(const char* hex)
+BlsctOutPointResult deserialize_out_point(const char* hex)
 {
-    BlsctOutPoint* blsct_out_point =
-        static_cast<BlsctOutPoint*>(DeserializeFromHex(hex, OUT_POINT_SIZE));
-    return succ(blsct_out_point, OUT_POINT_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != OUT_POINT_SIZE) {
+        return typed_err<BlsctOutPointResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctOutPointResult r{};
+    std::memcpy(r.value, vec.data(), OUT_POINT_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // point
-BlsctRetVal* gen_base_point() {
-    MALLOC_BYTES(BlsctPoint, blsct_point, POINT_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_point);
-
+BlsctPointResult gen_base_point()
+{
+    BlsctPointResult r{};
     auto x = Point::GetBasePoint();
-    SERIALIZE_AND_COPY(x, blsct_point);
-
-    return succ(blsct_point, POINT_SIZE);
+    SERIALIZE_AND_COPY(x, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* gen_random_point() {
-    MALLOC_BYTES(BlsctPoint, blsct_point, POINT_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_point);
-
+BlsctPointResult gen_random_point()
+{
+    BlsctPointResult r{};
     auto x = Point::Rand();
-    SERIALIZE_AND_COPY(x, blsct_point);
-
-    return succ(blsct_point, POINT_SIZE);
+    SERIALIZE_AND_COPY(x, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_point(const BlsctPoint* blsct_point)
+BlsctPointHexResult serialize_point(const BlsctPoint* blsct_point)
 {
     Point point;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_point, POINT_SIZE, point);
     auto ser_point = point.GetVch();
-    auto hex = HexStr(ser_point);
-
-    return StrToAllocCStr(hex);
+    BlsctPointHexResult r{};
+    FillHexBuf(ser_point.data(), ser_point.size(), r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_point(const char* hex)
+BlsctPointResult deserialize_point(const char* hex)
 {
     std::vector<uint8_t> vec;
     if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
+        return typed_err<BlsctPointResult>(BLSCT_FAILURE);
     }
     Point point;
     if (!point.SetVch(vec)) {
-        return err(BLSCT_DESER_FAILED);
+        return typed_err<BlsctPointResult>(BLSCT_DESER_FAILED);
     }
 
-    MALLOC_BYTES(BlsctPoint, blsct_point, POINT_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_point);
-    SERIALIZE_AND_COPY(point, blsct_point);
-
-    return succ(blsct_point, POINT_SIZE);
+    BlsctPointResult r{};
+    SERIALIZE_AND_COPY(point, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 int are_point_equal(const BlsctPoint* blsct_a, const BlsctPoint* blsct_b)
@@ -1380,10 +1272,10 @@ int are_point_equal(const BlsctPoint* blsct_a, const BlsctPoint* blsct_b)
     return a == b ? 1 : 0;
 }
 
-BlsctPoint* scalar_muliply_point(
+BlsctPointResult scalar_muliply_point(
     const BlsctPoint* blsct_point,
-    const BlsctScalar* blsct_scalar
-) {
+    const BlsctScalar* blsct_scalar)
+{
     Point p;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_point, POINT_SIZE, p);
 
@@ -1392,21 +1284,21 @@ BlsctPoint* scalar_muliply_point(
 
     Point sp = p * s;
 
-    MALLOC_BYTES(BlsctPoint, blsct_sp, POINT_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_sp);
-    SERIALIZE_AND_COPY(sp, blsct_sp);
-
-    return blsct_sp;
+    BlsctPointResult r{};
+    SERIALIZE_AND_COPY(sp, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* point_to_str(const BlsctPoint* blsct_point) {
+BlsctSizeTResult point_to_str(const BlsctPoint* blsct_point, char* buf, size_t buf_size)
+{
+    if (blsct_point == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
     Point point;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_point, POINT_SIZE, point);
-    auto str = point.GetString();
-    return StrToAllocCStr(str);
+    return {BLSCT_SUCCESS, WriteStrBuf(point.GetString(), buf, buf_size)};
 }
 
-BlsctPoint* point_from_scalar(const BlsctScalar* blsct_scalar)
+BlsctPointResult point_from_scalar(const BlsctScalar* blsct_scalar)
 {
     Scalar scalar;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_scalar, SCALAR_SIZE, scalar);
@@ -1414,16 +1306,16 @@ BlsctPoint* point_from_scalar(const BlsctScalar* blsct_scalar)
     Point g = Point::GetBasePoint();
     Point point = g * scalar;
 
-    MALLOC_BYTES(BlsctPoint, blsct_point, POINT_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_point);
-    SERIALIZE_AND_COPY(point, blsct_point);
-
-    return blsct_point;
+    BlsctPointResult r{};
+    SERIALIZE_AND_COPY(point, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 bool is_valid_point(
     const BlsctPoint* blsct_point)
 {
+    if (blsct_point == nullptr) return false;
     Point point;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_point, POINT_SIZE, point);
 
@@ -1431,89 +1323,90 @@ bool is_valid_point(
 }
 
 // public key
-BlsctRetVal* gen_random_public_key()
+BlsctPubKeyResult gen_random_public_key()
 {
     auto vec = Point::Rand().GetVch();
     blsct::PublicKey pub_key(vec);
 
-    MALLOC_BYTES(BlsctPubKey, blsct_pub_key, PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_pub_key);
-    SERIALIZE_AND_COPY(pub_key, blsct_pub_key);
-
-    return succ(blsct_pub_key, PUBLIC_KEY_SIZE);
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(pub_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctPoint* get_public_key_point(const BlsctPubKey* blsct_pub_key)
+BlsctPointResult get_public_key_point(const BlsctPubKey* blsct_pub_key)
 {
     blsct::PublicKey pub_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_pub_key, PUBLIC_KEY_SIZE, pub_key);
     auto point = pub_key.GetG1Point();
 
-    MALLOC_BYTES(BlsctPoint, blsct_point, POINT_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_point);
-    SERIALIZE_AND_COPY(point, blsct_point);
-
-    return blsct_point;
+    BlsctPointResult r{};
+    r.result = BLSCT_SUCCESS;
+    SERIALIZE_AND_COPY(point, r.value);
+    return r;
 }
 
-BlsctPubKey* point_to_public_key(const BlsctPoint* blsct_point)
+BlsctPubKeyResult point_to_public_key(const BlsctPoint* blsct_point)
 {
     Point point;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_point, POINT_SIZE, point);
     blsct::PublicKey pub_key(point);
 
-    MALLOC_BYTES(BlsctPubKey, blsct_pub_key, PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_pub_key);
-    SERIALIZE_AND_COPY(pub_key, blsct_pub_key);
-
-    return blsct_pub_key;
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(pub_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_public_key(const BlsctPubKey* blsct_pubkey)
+BlsctPointHexResult serialize_public_key(const BlsctPoint* blsct_pubkey)
 {
     blsct::PublicKey pubkey;
-
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_pubkey, PUBLIC_KEY_SIZE, pubkey);
     auto ser_pubkey = pubkey.GetVch();
-    auto hex = HexStr(ser_pubkey);
-
-    return StrToAllocCStr(hex);
+    BlsctPointHexResult r{};
+    FillHexBuf(ser_pubkey.data(), ser_pubkey.size(), r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_public_key(const char* hex)
+BlsctPubKeyResult deserialize_public_key(const char* hex)
 {
     std::vector<uint8_t> vec;
     if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
+        return typed_err<BlsctPubKeyResult>(BLSCT_FAILURE);
     }
     blsct::PublicKey pubkey;
     if (!pubkey.SetVch(vec)) {
-        return err(BLSCT_DESER_FAILED);
+        return typed_err<BlsctPubKeyResult>(BLSCT_DESER_FAILED);
     }
 
-    MALLOC_BYTES(BlsctPubKey, blsct_pubkey, PUBLIC_KEY_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_pubkey);
-    SERIALIZE_AND_COPY(pubkey, blsct_pubkey);
-
-    return succ(blsct_pubkey, PUBLIC_KEY_SIZE);
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(pubkey, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // range proof
-BlsctRetVal* build_range_proof(
-    const void* vp_uint64_vec,
+BLSCT_RESULT build_range_proof(
+    const uint64_t* amounts,
+    size_t amounts_len,
     const BlsctPoint* blsct_nonce,
     const char* blsct_msg,
-    const BlsctTokenId* blsct_token_id)
+    const BlsctTokenId* blsct_token_id,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
+    std::shared_lock<std::shared_mutex> lock(g_rpl_mutex);
+    if (g_rpl == nullptr) return BLSCT_INIT_NOT_CALLED;
+    if (amounts == nullptr || amounts_len == 0) return BLSCT_FAILURE;
     try {
-        auto uint64_vec = static_cast<const std::vector<uint64_t>*>(vp_uint64_vec);
-        // uint64_t to Scalar
         Scalars vs;
-        for (uint64_t v : *uint64_vec) {
-            if (v > INT64_MAX) {
-                return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
+        for (size_t i = 0; i < amounts_len; ++i) {
+            if (amounts[i] > INT64_MAX) {
+                return BLSCT_VALUE_OUTSIDE_THE_RANGE;
             }
-            Mcl::Scalar x(static_cast<int64_t>(v));
+            Mcl::Scalar x(static_cast<int64_t>(amounts[i]));
             vs.Add(x);
         }
 
@@ -1533,39 +1426,36 @@ BlsctRetVal* build_range_proof(
         auto blsct_token_id_u8 = U8C(blsct_token_id);
         UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id_u8, TOKEN_ID_SIZE, token_id);
 
-        // range_proof to blsct_range_proof
-        auto range_proof = g_rpl->Prove(
-            vs,
-            nonce,
-            msg_vec,
-            token_id);
-        DataStream size_st{};
-        range_proof.Serialize(size_st);
-        size_t range_proof_size = size_st.size();
-
-        MALLOC_BYTES(BlsctRangeProof, blsct_range_proof, range_proof_size);
-        RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_range_proof);
-        SERIALIZE_AND_COPY_WITH_STREAM(range_proof, blsct_range_proof);
-
-        return succ(blsct_range_proof, range_proof_size);
+        auto range_proof = g_rpl->Prove(vs, nonce, msg_vec, token_id);
+        size_t sz = SerializeObjToByteBuf(range_proof, buf, buf_size);
+        if (out_len) *out_len = sz;
+        return BLSCT_SUCCESS;
 
     } catch (...) {
     }
 
-    return err(BLSCT_EXCEPTION);
+    return BLSCT_EXCEPTION;
 }
 
-BlsctBoolRetVal* verify_range_proofs(
-    const void* vp_range_proofs)
+BlsctBoolResult verify_range_proofs(
+    const BlsctRangeProof* const* proofs,
+    const size_t* proof_sizes,
+    size_t proof_count)
 {
+    std::shared_lock<std::shared_mutex> lock(g_rpl_mutex);
+    if (g_rpl == nullptr) return typed_err<BlsctBoolResult>(BLSCT_INIT_NOT_CALLED);
+    if (proofs == nullptr || proof_sizes == nullptr || proof_count == 0) return typed_err<BlsctBoolResult>(BLSCT_FAILURE);
     try {
-        auto range_proofs = static_cast<const std::vector<bulletproofs_plus::RangeProof<Mcl>>*>(vp_range_proofs);
-
         std::vector<bulletproofs_plus::RangeProofWithSeed<Mcl>> range_proof_w_seeds;
 
-        for (const auto& rp : *range_proofs) {
-            auto rp_w_seed = bulletproofs_plus::RangeProofWithSeed<Mcl>(rp);
-            range_proof_w_seeds.push_back(rp_w_seed);
+        for (size_t i = 0; i < proof_count; ++i) {
+            bulletproofs_plus::RangeProof<Mcl> rp;
+            DataStream st{};
+            for (size_t j = 0; j < proof_sizes[i]; ++j) {
+                st << proofs[i][j];
+            }
+            rp.Unserialize(st);
+            range_proof_w_seeds.push_back(bulletproofs_plus::RangeProofWithSeed<Mcl>(rp));
         }
         bool is_valid = g_rpl->Verify(range_proof_w_seeds);
         return succ_bool(is_valid);
@@ -1573,18 +1463,18 @@ BlsctBoolRetVal* verify_range_proofs(
     } catch (...) {
     }
 
-    return err_bool(BLSCT_EXCEPTION);
+    return typed_err<BlsctBoolResult>(BLSCT_EXCEPTION);
 }
 
-#define DEFINE_RANGE_PROOF_POINT_GETTER(field)                                                                   \
-    BlsctPoint* get_range_proof_##field(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size) \
-    {                                                                                                            \
-        bulletproofs_plus::RangeProof<Mcl> range_proof;                                                          \
-        UNSERIALIZE_AND_COPY_WITH_STREAM(blsct_range_proof, range_proof_size, range_proof);                      \
-        auto copy = static_cast<BlsctPoint*>(malloc(POINT_SIZE));                                                \
-        auto org = range_proof.field.GetVch();                                                                   \
-        std::memcpy(copy, &org[0], POINT_SIZE);                                                                  \
-        return copy;                                                                                             \
+#define DEFINE_RANGE_PROOF_POINT_GETTER(field)                                                                        \
+    BlsctPointResult get_range_proof_##field(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size) \
+    {                                                                                                                 \
+        bulletproofs_plus::RangeProof<Mcl> range_proof;                                                               \
+        UNSERIALIZE_AND_COPY_WITH_STREAM(blsct_range_proof, range_proof_size, range_proof);                           \
+        BlsctPointResult r{};                                                                                         \
+        SERIALIZE_AND_COPY(range_proof.field, r.value);                                                               \
+        r.result = BLSCT_SUCCESS;                                                                                     \
+        return r;                                                                                                     \
     }
 
 DEFINE_RANGE_PROOF_POINT_GETTER(A)
@@ -1593,15 +1483,15 @@ DEFINE_RANGE_PROOF_POINT_GETTER(B)
 
 #undef DEFINE_RANGE_PROOF_POINT_GETTER
 
-#define DEFINE_RANGE_PROOF_SCALAR_GETTER(field)                                                                   \
-    BlsctScalar* get_range_proof_##field(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size) \
-    {                                                                                                             \
-        bulletproofs_plus::RangeProof<Mcl> range_proof;                                                           \
-        UNSERIALIZE_AND_COPY_WITH_STREAM(blsct_range_proof, range_proof_size, range_proof);                       \
-        auto copy = static_cast<BlsctScalar*>(malloc(SCALAR_SIZE));                                               \
-        auto org = range_proof.field.GetVch();                                                                    \
-        std::memcpy(copy, &org[0], SCALAR_SIZE);                                                                  \
-        return copy;                                                                                              \
+#define DEFINE_RANGE_PROOF_SCALAR_GETTER(field)                                                                        \
+    BlsctScalarResult get_range_proof_##field(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size) \
+    {                                                                                                                  \
+        bulletproofs_plus::RangeProof<Mcl> range_proof;                                                                \
+        UNSERIALIZE_AND_COPY_WITH_STREAM(blsct_range_proof, range_proof_size, range_proof);                            \
+        BlsctScalarResult r{};                                                                                         \
+        SERIALIZE_AND_COPY(range_proof.field, r.value);                                                                \
+        r.result = BLSCT_SUCCESS;                                                                                      \
+        return r;                                                                                                      \
     }
 
 DEFINE_RANGE_PROOF_SCALAR_GETTER(r_prime)
@@ -1612,106 +1502,83 @@ DEFINE_RANGE_PROOF_SCALAR_GETTER(tau_x)
 
 #undef DEFINE_RANGE_PROOF_SCALAR_GETTER
 
-const char* serialize_range_proof(
+BlsctSizeTResult serialize_range_proof(
     const BlsctRangeProof* blsct_range_proof,
-    const size_t range_proof_size)
+    size_t range_proof_size,
+    char* buf,
+    size_t buf_size)
 {
-    return SerializeToHex(blsct_range_proof, range_proof_size);
+    if (blsct_range_proof == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, WriteHexBuf(reinterpret_cast<const uint8_t*>(blsct_range_proof), range_proof_size, buf, buf_size)};
 }
 
-BlsctRetVal* deserialize_range_proof(
+BLSCT_RESULT deserialize_range_proof(
     const char* hex,
-    const size_t range_proof_size)
+    const size_t range_proof_size,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    BlsctRangeProof* blsct_range_proof =
-        static_cast<BlsctRangeProof*>(DeserializeFromHex(hex, range_proof_size));
-    return succ(blsct_range_proof, range_proof_size);
-}
-
-void* create_range_proof_vec()
-{
-    auto vec = new (std::nothrow) std::vector<bulletproofs_plus::RangeProof<Mcl>>;
-    HANDLE_MEM_ALLOC_FAILURE(vec);
-    return static_cast<void*>(vec);
-}
-
-void add_to_range_proof_vec(
-    void* vp_range_proofs,
-    const BlsctRangeProof* blsct_range_proof,
-    size_t blsct_range_proof_size)
-{
-    auto range_proofs = static_cast<std::vector<bulletproofs_plus::RangeProof<Mcl>>*>(vp_range_proofs);
-    // unserialize range proof
-    bulletproofs_plus::RangeProof<Mcl> range_proof;
-
-    DataStream st{};
-    for (size_t i = 0; i < blsct_range_proof_size; ++i) {
-        st << blsct_range_proof[i];
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != range_proof_size) {
+        return BLSCT_BAD_SIZE;
     }
-    range_proof.Unserialize(st);
-
-    // and move to the vector
-    range_proofs->push_back(std::move(range_proof));
+    if (out_len) *out_len = range_proof_size;
+    if (buf != nullptr && buf_size >= range_proof_size)
+        std::memcpy(buf, vec.data(), range_proof_size);
+    return BLSCT_SUCCESS;
 }
 
-void delete_range_proof_vec(const void* vp_range_proofs)
-{
-    if (vp_range_proofs == nullptr) return;
-    auto range_proofs = static_cast<const std::vector<bulletproofs_plus::RangeProof<Mcl>>*>(vp_range_proofs);
-    delete range_proofs;
-}
 
 // scalar
-BlsctRetVal* gen_random_scalar() {
-    MALLOC_BYTES(BlsctScalar, blsct_scalar, SCALAR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_scalar);
-
+BlsctScalarResult gen_random_scalar()
+{
+    BlsctScalarResult r{};
     auto x = Scalar::Rand(true);
-    SERIALIZE_AND_COPY(x, blsct_scalar);
-
-    return succ(blsct_scalar, SCALAR_SIZE);
+    SERIALIZE_AND_COPY(x, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* gen_scalar(
+BlsctScalarResult gen_scalar(
     const uint64_t n)
 {
+    BlsctScalarResult r{};
     Scalar scalar(n);
-    MALLOC_BYTES(BlsctScalar, blsct_scalar, SCALAR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_scalar);
-    SERIALIZE_AND_COPY(scalar, blsct_scalar);
-
-    return succ(blsct_scalar, SCALAR_SIZE);
+    SERIALIZE_AND_COPY(scalar, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-uint64_t scalar_to_uint64(const BlsctScalar* blsct_scalar)
+BlsctUint64Result scalar_to_uint64(const BlsctScalar* blsct_scalar)
 {
+    if (blsct_scalar == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
     Scalar scalar;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_scalar, SCALAR_SIZE, scalar);
-    return scalar.GetUint64();
+    return {BLSCT_SUCCESS, scalar.GetUint64()};
 }
 
-const char* serialize_scalar(const BlsctScalar* blsct_scalar)
+BlsctScalarHexResult serialize_scalar(const BlsctScalar* blsct_scalar)
 {
-    Scalar scalar;
-    UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_scalar, SCALAR_SIZE, scalar);
-    auto hex = scalar.GetString();
-    return StrToAllocCStr(hex);
+    BlsctScalarHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_scalar, SCALAR_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_scalar(const char* hex)
+BlsctScalarResult deserialize_scalar(const char* hex)
 {
     std::vector<uint8_t> vec;
     if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
     }
     Scalar scalar;
     scalar.SetVch(vec);
 
-    MALLOC_BYTES(BlsctScalar, blsct_scalar, SCALAR_SIZE);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(blsct_scalar);
-    SERIALIZE_AND_COPY(scalar, blsct_scalar);
-
-    return succ(blsct_scalar, SCALAR_SIZE);
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(scalar, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 int are_scalar_equal(const BlsctScalar* blsct_a, const BlsctScalar* blsct_b)
@@ -1725,15 +1592,15 @@ int are_scalar_equal(const BlsctScalar* blsct_a, const BlsctScalar* blsct_b)
     return a == b ? 1 : 0;
 }
 
-const char* scalar_to_str(const BlsctScalar* blsct_scalar)
+BlsctSizeTResult scalar_to_str(const BlsctScalar* blsct_scalar, char* buf, size_t buf_size)
 {
+    if (blsct_scalar == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
     Scalar scalar;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_scalar, SCALAR_SIZE, scalar);
-    auto str = scalar.GetString(10);
-    return StrToAllocCStr(str);
+    return {BLSCT_SUCCESS, WriteStrBuf(scalar.GetString(10), buf, buf_size)};
 }
 
-BlsctPubKey* scalar_to_pub_key(
+BlsctPubKeyResult scalar_to_pub_key(
     const BlsctScalar* blsct_scalar)
 {
     Scalar scalar;
@@ -1742,39 +1609,55 @@ BlsctPubKey* scalar_to_pub_key(
     auto priv_key = blsct::PrivateKey(scalar);
     auto pub_key = priv_key.GetPublicKey();
 
-    BlsctPubKey* blsct_pub_key = static_cast<BlsctPubKey*>(
-        malloc(PUBLIC_KEY_SIZE));
-    SERIALIZE_AND_COPY(pub_key, blsct_pub_key);
-    return blsct_pub_key;
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(pub_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // script
-const char* serialize_script(const BlsctScript* blsct_script)
+BlsctScriptHexResult serialize_script(const BlsctScript* blsct_script)
 {
-    return SerializeToHex(*blsct_script, SCRIPT_SIZE);
+    BlsctScriptHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_script, SCRIPT_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_script(const char* hex)
+BlsctScriptResult deserialize_script(const char* hex)
 {
-    BlsctScript* blsct_script =
-        static_cast<BlsctScript*>(DeserializeFromHex(hex, SCRIPT_SIZE));
-    return succ(blsct_script, SCRIPT_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != SCRIPT_SIZE) {
+        return typed_err<BlsctScriptResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctScriptResult r{};
+    std::memcpy(r.value, vec.data(), SCRIPT_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_signature(const BlsctSignature* blsct_signature)
+BlsctSignatureHexResult serialize_signature(const BlsctSignature* blsct_signature)
 {
-    return SerializeToHex(*blsct_signature, SIGNATURE_SIZE);
+    BlsctSignatureHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_signature, SIGNATURE_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_signature(const char* hex)
+BlsctSignatureResult deserialize_signature(const char* hex)
 {
-    BlsctSignature* blsct_signature =
-        static_cast<BlsctSignature*>(DeserializeFromHex(hex, SIGNATURE_SIZE));
-    return succ(blsct_signature, SIGNATURE_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != SIGNATURE_SIZE) {
+        return typed_err<BlsctSignatureResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctSignatureResult r{};
+    std::memcpy(r.value, vec.data(), SIGNATURE_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // signature
-const BlsctSignature* sign_message(
+BlsctSignatureResult sign_message(
     const BlsctScalar* blsct_priv_key,
     const char* blsct_msg)
 {
@@ -1787,11 +1670,10 @@ const BlsctSignature* sign_message(
     blsct::Message msg(msg_str.begin(), msg_str.end());
     blsct::Signature sig = priv_key.Sign(msg);
 
-    BlsctSignature* blsct_sig = static_cast<BlsctSignature*>(
-        malloc(SIGNATURE_SIZE));
-    SERIALIZE_AND_COPY(sig, blsct_sig);
-
-    return blsct_sig;
+    BlsctSignatureResult r{};
+    SERIALIZE_AND_COPY(sig, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 bool verify_msg_sig(
@@ -1799,6 +1681,7 @@ bool verify_msg_sig(
     const char* blsct_msg,
     const BlsctSignature* blsct_signature)
 {
+    if (blsct_pub_key == nullptr || blsct_msg == nullptr || blsct_signature == nullptr) return false;
     blsct::PublicKey pub_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_pub_key, PUBLIC_KEY_SIZE, pub_key);
 
@@ -1812,7 +1695,7 @@ bool verify_msg_sig(
 }
 
 // sub addr
-BlsctSubAddr* derive_sub_address(
+BlsctSubAddrResult derive_sub_address(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctSubAddrId* blsct_sub_addr_id)
@@ -1827,27 +1710,34 @@ BlsctSubAddr* derive_sub_address(
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_sub_addr_id, SUB_ADDR_ID_SIZE, sub_addr_id);
 
     auto sub_addr = blsct::DeriveSubAddress(view_key, spending_pub_key, sub_addr_id);
-    BlsctSubAddr* blsct_sub_addr = static_cast<BlsctSubAddr*>(
-        malloc(SUB_ADDR_SIZE));
-    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr, blsct_sub_addr);
-
-    return blsct_sub_addr;
+    BlsctSubAddrResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_sub_addr(const BlsctSubAddr* blsct_sub_addr)
+BlsctSubAddrHexResult serialize_sub_addr(const BlsctSubAddr* blsct_sub_addr)
 {
-    return SerializeToHex(*blsct_sub_addr, SUB_ADDR_SIZE);
+    BlsctSubAddrHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_sub_addr, SUB_ADDR_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_sub_addr(const char* hex)
+BlsctSubAddrResult deserialize_sub_addr(const char* hex)
 {
-    BlsctSubAddr* blsct_sub_addr =
-        static_cast<BlsctSubAddr*>(DeserializeFromHex(hex, SUB_ADDR_SIZE));
-    return succ(blsct_sub_addr, SUB_ADDR_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != SUB_ADDR_SIZE) {
+        return typed_err<BlsctSubAddrResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctSubAddrResult r{};
+    std::memcpy(r.value, vec.data(), SUB_ADDR_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // sub addr id
-BlsctSubAddrId* gen_sub_addr_id(
+BlsctSubAddrIdResult gen_sub_addr_id(
     const int64_t account,
     const uint64_t address)
 {
@@ -1855,43 +1745,52 @@ BlsctSubAddrId* gen_sub_addr_id(
     sub_addr_id.account = account;
     sub_addr_id.address = address;
 
-    MALLOC_BYTES(BlsctSubAddrId, blsct_sub_addr_id, SUB_ADDR_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_sub_addr_id);
-    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr_id, blsct_sub_addr_id);
-
-    return blsct_sub_addr_id;
+    BlsctSubAddrIdResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(sub_addr_id, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const char* serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id)
+BlsctSubAddrIdHexResult serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id)
 {
-    return SerializeToHex(*blsct_sub_addr_id, SUB_ADDR_ID_SIZE);
+    BlsctSubAddrIdHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_sub_addr_id, SUB_ADDR_ID_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_sub_addr_id(const char* hex)
+BlsctSubAddrIdResult deserialize_sub_addr_id(const char* hex)
 {
-    BlsctSubAddrId* blsct_sub_addr_id =
-        static_cast<BlsctSubAddrId*>(DeserializeFromHex(hex, SUB_ADDR_ID_SIZE));
-    return succ(blsct_sub_addr_id, SUB_ADDR_ID_SIZE);
+    std::vector<uint8_t> vec;
+    if (!TryParseHexWrap(hex, vec) || vec.size() != SUB_ADDR_ID_SIZE) {
+        return typed_err<BlsctSubAddrIdResult>(BLSCT_BAD_SIZE);
+    }
+    BlsctSubAddrIdResult r{};
+    std::memcpy(r.value, vec.data(), SUB_ADDR_ID_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-int64_t get_sub_addr_id_account(
+BlsctInt64Result get_sub_addr_id_account(
     const BlsctSubAddrId* blsct_sub_addr_id)
 {
+    if (blsct_sub_addr_id == nullptr) return typed_err<BlsctInt64Result>(BLSCT_FAILURE);
     blsct::SubAddressIdentifier sub_addr_id;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_sub_addr_id, SUB_ADDR_ID_SIZE, sub_addr_id);
-    return sub_addr_id.account;
+    return {BLSCT_SUCCESS, sub_addr_id.account};
 }
 
-uint64_t get_sub_addr_id_address(
+BlsctUint64Result get_sub_addr_id_address(
     const BlsctSubAddrId* blsct_sub_addr_id)
 {
+    if (blsct_sub_addr_id == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
     blsct::SubAddressIdentifier sub_addr_id;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_sub_addr_id, SUB_ADDR_ID_SIZE, sub_addr_id);
-    return sub_addr_id.address;
+    return {BLSCT_SUCCESS, sub_addr_id.address};
 }
 
 // token id
-BlsctRetVal* gen_token_id_with_token_and_subid(
+BlsctTokenIdResult gen_token_id_with_token_and_subid(
     const uint64_t token,
     const uint64_t subid)
 {
@@ -1903,14 +1802,13 @@ BlsctRetVal* gen_token_id_with_token_and_subid(
         n >>= 8; // Shift the value right by 8 bits to process the next byte
     }
     TokenId token_id(token_uint256, subid);
-    MALLOC_BYTES(BlsctTokenId, blsct_token_id, TOKEN_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_token_id);
-    SERIALIZE_AND_COPY_WITH_STREAM(token_id, blsct_token_id);
-
-    return succ(blsct_token_id, TOKEN_ID_SIZE);
+    BlsctTokenIdResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(token_id, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* gen_token_id(
+BlsctTokenIdResult gen_token_id(
     const uint64_t token)
 {
     return gen_token_id_with_token_and_subid(
@@ -1918,183 +1816,135 @@ BlsctRetVal* gen_token_id(
         UINT64_MAX);
 }
 
-BlsctRetVal* gen_default_token_id()
+BlsctTokenIdResult gen_default_token_id()
 {
     TokenId token_id;
-    MALLOC_BYTES(BlsctTokenId, blsct_token_id, TOKEN_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_token_id);
-    SERIALIZE_AND_COPY_WITH_STREAM(token_id, blsct_token_id);
-
-    return succ(blsct_token_id, TOKEN_ID_SIZE);
+    BlsctTokenIdResult r{};
+    SERIALIZE_AND_COPY_WITH_STREAM(token_id, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-uint64_t get_token_id_token(const BlsctTokenId* blsct_token_id)
+BlsctUint64Result get_token_id_token(const BlsctTokenId* blsct_token_id)
 {
-    TokenId token_id;
-    UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id, TOKEN_ID_SIZE, token_id);
-    return token_id.token.GetUint64(0);
-}
-
-uint64_t get_token_id_subid(const BlsctTokenId* blsct_token_id)
-{
+    if (blsct_token_id == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
     TokenId token_id;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id, TOKEN_ID_SIZE, token_id);
-    return token_id.subid;
+    return {BLSCT_SUCCESS, token_id.token.GetUint64(0)};
 }
 
-const char* serialize_token_id(const BlsctTokenId* blsct_token_id)
+BlsctUint64Result get_token_id_subid(const BlsctTokenId* blsct_token_id)
 {
-    // BlsctTokenId is a serialization of TokenId
-    // so just need to convert it to hex
-    std::vector<uint8_t> vec((*blsct_token_id), (*blsct_token_id) + TOKEN_ID_SIZE);
-    auto hex_str = HexStr(vec);
-    return StrToAllocCStr(hex_str);
+    if (blsct_token_id == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    TokenId token_id;
+    UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id, TOKEN_ID_SIZE, token_id);
+    return {BLSCT_SUCCESS, token_id.subid};
 }
 
-BlsctRetVal* deserialize_token_id(const char* hex)
+BlsctTokenIdHexResult serialize_token_id(const BlsctTokenId* blsct_token_id)
+{
+    BlsctTokenIdHexResult r{};
+    FillHexBuf((const uint8_t*)blsct_token_id, TOKEN_ID_SIZE, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
+}
+
+BlsctTokenIdResult deserialize_token_id(const char* hex)
 {
     std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
+    if (!TryParseHexWrap(hex, vec) || vec.size() != TOKEN_ID_SIZE) {
+        return typed_err<BlsctTokenIdResult>(BLSCT_BAD_SIZE);
     }
-    MALLOC_BYTES(BlsctTokenId, blsct_token_id, TOKEN_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_token_id);
-    std::memcpy(blsct_token_id, &vec[0], vec.size());
-
-    return succ(blsct_token_id, TOKEN_ID_SIZE);
-}
-
-// generic string map helpers
-void* create_string_map()
-{
-    auto* string_map = new (std::nothrow) std::map<std::string, std::string>;
-    return static_cast<void*>(string_map);
-}
-
-void add_to_string_map(void* vp_string_map, const char* key, const char* value)
-{
-    RETURN_IF_NULL(vp_string_map);
-    RETURN_IF_NULL(key);
-    RETURN_IF_NULL(value);
-    auto* string_map = static_cast<std::map<std::string, std::string>*>(vp_string_map);
-    (*string_map)[key] = value;
-}
-
-void delete_string_map(const void* vp_string_map)
-{
-    if (vp_string_map == nullptr) return;
-    delete static_cast<const std::map<std::string, std::string>*>(vp_string_map);
-}
-
-size_t get_string_map_size(const void* vp_string_map)
-{
-    RETURN_RET_VAL_IF_NULL(vp_string_map, 0);
-    return static_cast<const std::map<std::string, std::string>*>(vp_string_map)->size();
-}
-
-const char* get_string_map_key_at(const void* vp_string_map, size_t idx)
-{
-    return StringMapEntryAt(vp_string_map, idx, /*want_key=*/true);
-}
-
-const char* get_string_map_value_at(const void* vp_string_map, size_t idx)
-{
-    return StringMapEntryAt(vp_string_map, idx, /*want_key=*/false);
+    BlsctTokenIdResult r{};
+    std::memcpy(r.value, vec.data(), TOKEN_ID_SIZE);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // token info helpers
-BlsctRetVal* build_token_info(
+BLSCT_RESULT build_token_info(
     enum BlsctTokenType type,
     const BlsctPubKey* blsct_public_key,
-    const void* vp_metadata,
-    const uint64_t total_supply)
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    const uint64_t total_supply,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_public_key, err(BLSCT_FAILURE));
+    if (blsct_public_key == nullptr) return BLSCT_FAILURE;
 
     CAmount supply;
-    if (!AmountFromUint64Checked(total_supply, supply)) {
-        return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
-    }
+    if (!AmountFromUint64Checked(total_supply, supply)) return BLSCT_VALUE_OUTSIDE_THE_RANGE;
 
     blsct::PublicKey public_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_public_key, PUBLIC_KEY_SIZE, public_key);
 
-    auto* token_info = new (std::nothrow) blsct::TokenInfo{
-        TokenTypeFromC(type),
-        public_key,
-        StringMapFromOpaque(vp_metadata),
-        supply};
-    if (token_info == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(token_info), sizeof(blsct::TokenInfo));
+    blsct::TokenInfo token_info{TokenTypeFromC(type), public_key, StringMapFromArrays(metadata_keys, metadata_values, metadata_count), supply};
+    size_t sz = SerializeObjToHexBuf(token_info, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-void delete_token_info(void* vp_token_info)
+BlsctTokenTypeResult get_token_info_type(const char* hex)
 {
-    if (vp_token_info == nullptr) return;
-    delete static_cast<blsct::TokenInfo*>(vp_token_info);
+    if (hex == nullptr) return typed_err<BlsctTokenTypeResult>(BLSCT_FAILURE);
+    auto info = DeserializeObj<blsct::TokenInfo>(hex);
+    if (!info.has_value()) return typed_err<BlsctTokenTypeResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, TokenTypeToC(info->type)};
 }
 
-const char* serialize_token_info(const void* vp_token_info)
+BlsctPubKeyResult get_token_info_public_key(const char* hex)
 {
-    RETURN_RET_VAL_IF_NULL(vp_token_info, nullptr);
-    return SerializeSerializableObject(*static_cast<const blsct::TokenInfo*>(vp_token_info));
+    auto info = DeserializeObj<blsct::TokenInfo>(hex);
+    if (!info.has_value()) return typed_err<BlsctPubKeyResult>(BLSCT_FAILURE);
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(info->publicKey, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctRetVal* deserialize_token_info(const char* hex)
+BlsctUint64Result get_token_info_total_supply(const char* hex)
 {
-    return DeserializeSerializableObject<blsct::TokenInfo>(hex);
+    auto info = DeserializeObj<blsct::TokenInfo>(hex);
+    if (!info.has_value()) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, static_cast<uint64_t>(info->nTotalSupply)};
 }
 
-enum BlsctTokenType get_token_info_type(const void* vp_token_info)
+void get_token_info_metadata(const char* hex, BlsctStringMapCallback cb, void* user_data)
 {
-    RETURN_RET_VAL_IF_NULL(vp_token_info, BlsctToken);
-    return TokenTypeToC(static_cast<const blsct::TokenInfo*>(vp_token_info)->type);
-}
-
-const BlsctPubKey* get_token_info_public_key(const void* vp_token_info)
-{
-    RETURN_RET_VAL_IF_NULL(vp_token_info, nullptr);
-    MALLOC_BYTES(BlsctPubKey, blsct_pub_key, PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_pub_key);
-    SERIALIZE_AND_COPY(static_cast<const blsct::TokenInfo*>(vp_token_info)->publicKey, blsct_pub_key);
-    return blsct_pub_key;
-}
-
-uint64_t get_token_info_total_supply(const void* vp_token_info)
-{
-    RETURN_RET_VAL_IF_NULL(vp_token_info, 0);
-    return static_cast<uint64_t>(static_cast<const blsct::TokenInfo*>(vp_token_info)->nTotalSupply);
-}
-
-void* get_token_info_metadata(const void* vp_token_info)
-{
-    RETURN_RET_VAL_IF_NULL(vp_token_info, nullptr);
-    return CloneStringMap(static_cast<const blsct::TokenInfo*>(vp_token_info)->mapMetadata);
+    auto info = DeserializeObj<blsct::TokenInfo>(hex);
+    if (!info.has_value()) return;
+    InvokeCallbackForMap(info->mapMetadata, cb, user_data);
 }
 
 // collection token hash and token key derivation
-BlsctRetVal* calc_collection_token_hash(
-    const void* vp_metadata,
+BlsctUint256Result calc_collection_token_hash(
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
     const uint64_t total_supply)
 {
     CAmount supply;
     if (!AmountFromUint64Checked(total_supply, supply)) {
-        return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
+        return typed_err<BlsctUint256Result>(BLSCT_VALUE_OUTSIDE_THE_RANGE);
     }
 
-    const uint256 hash = (HashWriter{} << StringMapFromOpaque(vp_metadata) << supply).GetHash();
+    const uint256 hash = (HashWriter{} << StringMapFromArrays(metadata_keys, metadata_values, metadata_count) << supply).GetHash();
     return MallocAndCopyUint256(hash);
 }
 
-BlsctRetVal* derive_collection_token_key(
+BlsctScalarResult derive_collection_token_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_master_token_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_collection_token_hash, err(BLSCT_FAILURE));
+    if (blsct_master_token_key == nullptr) {
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+    }
+    if (blsct_collection_token_hash == nullptr) {
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+    }
 
     Scalar master_token_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_master_token_key, SCALAR_SIZE, master_token_key);
@@ -2103,98 +1953,102 @@ BlsctRetVal* derive_collection_token_key(
     std::memcpy(collection_hash.begin(), blsct_collection_token_hash, UINT256_SIZE);
 
     Scalar token_key = BLS12_381_KeyGen::derive_child_SK_hash(master_token_key, collection_hash);
-    MALLOC_BYTES(BlsctScalar, blsct_token_key, SCALAR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_token_key);
-    SERIALIZE_AND_COPY(token_key, blsct_token_key);
-
-    return succ(blsct_token_key, SCALAR_SIZE);
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(token_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const BlsctPubKey* derive_collection_token_public_key(
+BlsctPubKeyResult derive_collection_token_public_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash)
 {
     auto token_key_rv = derive_collection_token_key(blsct_master_token_key, blsct_collection_token_hash);
-    if (token_key_rv == nullptr || token_key_rv->result != BLSCT_SUCCESS) {
-        if (token_key_rv != nullptr) {
-            free(token_key_rv);
-        }
-        return nullptr;
+    if (token_key_rv.result != BLSCT_SUCCESS) {
+        return typed_err<BlsctPubKeyResult>(BLSCT_FAILURE);
     }
 
-    const auto* pub_key = scalar_to_pub_key(static_cast<const BlsctScalar*>(token_key_rv->value));
-    free_obj(token_key_rv->value);
-    free(token_key_rv);
-    return pub_key;
+    return scalar_to_pub_key(&token_key_rv.value);
 }
 
 // tx_in
-BlsctRetVal* build_tx_in(
+BlsctTxInResult build_tx_in(
     const uint64_t amount,
     const BlsctScalar* gamma,
     const BlsctScalar* spending_key,
     const BlsctTokenId* token_id,
     const BlsctOutPoint* out_point,
     const bool staked_commitment,
-    const bool rbf
-) {
-    MALLOC_BYTES(BlsctTxIn, tx_in, sizeof(BlsctTxIn));
-    RETURN_IF_MEM_ALLOC_FAILED(tx_in);
-
-    tx_in->amount = amount;
-    BLSCT_COPY(gamma, tx_in->gamma);
-    BLSCT_COPY(spending_key, tx_in->spending_key);
-    BLSCT_COPY(token_id, tx_in->token_id);
-    BLSCT_COPY(out_point, tx_in->out_point);
-    tx_in->staked_commitment = staked_commitment;
-    tx_in->rbf = rbf;
-
-    return succ(tx_in, sizeof(BlsctTxIn));
-}
-
-uint64_t get_tx_in_amount(const BlsctTxIn* tx_in)
+    const bool rbf)
 {
-    return tx_in->amount;
+    BlsctTxInResult r{};
+    r.result = BLSCT_SUCCESS;
+    r.value.amount = amount;
+    BLSCT_COPY(gamma, r.value.gamma);
+    BLSCT_COPY(spending_key, r.value.spending_key);
+    BLSCT_COPY(token_id, r.value.token_id);
+    BLSCT_COPY(out_point, r.value.out_point);
+    r.value.staked_commitment = staked_commitment;
+    r.value.rbf = rbf;
+    return r;
 }
 
-const BlsctScalar* get_tx_in_gamma(const BlsctTxIn* tx_in)
+BlsctUint64Result get_tx_in_amount(const BlsctTxInData* tx_in)
 {
-    return &tx_in->gamma;
+    if (tx_in == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_in->amount};
 }
 
-const BlsctScalar* get_tx_in_spending_key(const BlsctTxIn* tx_in) {
-    MALLOC_BYTES(BlsctScalar, spending_key, SCALAR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(spending_key);
-    BLSCT_COPY(tx_in->spending_key, *spending_key);
-    return spending_key;
-}
-
-const BlsctTokenId* get_tx_in_token_id(const BlsctTxIn* tx_in) {
-    MALLOC_BYTES(BlsctTokenId, token_id, TOKEN_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(token_id);
-    BLSCT_COPY(tx_in->token_id, *token_id);
-    return token_id;
-}
-
-const BlsctOutPoint* get_tx_in_out_point(const BlsctTxIn* tx_in) {
-    MALLOC_BYTES(BlsctOutPoint, out_point, OUT_POINT_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(out_point);
-    BLSCT_COPY(tx_in->out_point, *out_point);
-    return out_point;
-}
-
-bool get_tx_in_staked_commitment(const BlsctTxIn* tx_in)
+BlsctScalarResult get_tx_in_gamma(const BlsctTxInData* tx_in)
 {
-    return tx_in->staked_commitment;
+    if (tx_in == nullptr) return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+    BlsctScalarResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_in->gamma, r.value);
+    return r;
 }
 
-bool get_tx_in_rbf(const BlsctTxIn* tx_in)
+BlsctScalarResult get_tx_in_spending_key(const BlsctTxInData* tx_in)
 {
-    return tx_in->rbf;
+    if (tx_in == nullptr) return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+    BlsctScalarResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_in->spending_key, r.value);
+    return r;
+}
+
+BlsctTokenIdResult get_tx_in_token_id(const BlsctTxInData* tx_in)
+{
+    if (tx_in == nullptr) return typed_err<BlsctTokenIdResult>(BLSCT_FAILURE);
+    BlsctTokenIdResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_in->token_id, r.value);
+    return r;
+}
+
+BlsctOutPointResult get_tx_in_out_point(const BlsctTxInData* tx_in)
+{
+    if (tx_in == nullptr) return typed_err<BlsctOutPointResult>(BLSCT_FAILURE);
+    BlsctOutPointResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_in->out_point, r.value);
+    return r;
+}
+
+BlsctBoolResult get_tx_in_staked_commitment(const BlsctTxInData* tx_in)
+{
+    if (tx_in == nullptr) return typed_err<BlsctBoolResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_in->staked_commitment};
+}
+
+BlsctBoolResult get_tx_in_rbf(const BlsctTxInData* tx_in)
+{
+    if (tx_in == nullptr) return typed_err<BlsctBoolResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_in->rbf};
 }
 
 // tx out
-BlsctRetVal* build_tx_out(
+BlsctTxOutResult build_tx_out(
     const BlsctSubAddr* blsct_dest,
     const uint64_t amount,
     const char* memo_c_str,
@@ -2202,166 +2056,143 @@ BlsctRetVal* build_tx_out(
     const TxOutputType output_type,
     const uint64_t min_stake,
     const bool subtract_fee_from_amount,
-    const BlsctScalar* blsct_blinding_key
-) {
-    MALLOC_BYTES(BlsctTxOut, tx_out, sizeof(BlsctTxOut));
-    RETURN_IF_MEM_ALLOC_FAILED(tx_out);
-
-    BLSCT_COPY(blsct_dest, tx_out->dest);
-    tx_out->amount = amount;
-
-    // copy memo to tx_out
+    const BlsctScalar* blsct_blinding_key)
+{
+    if (blsct_dest == nullptr || memo_c_str == nullptr || blsct_token_id == nullptr || blsct_blinding_key == nullptr)
+        return typed_err<BlsctTxOutResult>(BLSCT_FAILURE);
     size_t memo_c_str_len = std::strlen(memo_c_str);
     if (memo_c_str_len > MAX_MEMO_LEN) {
-        return err(BLSCT_MEMO_TOO_LONG);
+        return typed_err<BlsctTxOutResult>(BLSCT_MEMO_TOO_LONG);
     }
-    std::memcpy(tx_out->memo_c_str, memo_c_str, memo_c_str_len + 1);
 
-    BLSCT_COPY(blsct_token_id, tx_out->token_id);
-    tx_out->output_type = output_type;
-    tx_out->min_stake = min_stake;
-    tx_out->subtract_fee_from_amount = subtract_fee_from_amount;
-    BLSCT_COPY(blsct_blinding_key, tx_out->blinding_key);
-
-    return succ(tx_out, sizeof(BlsctTxOut));
+    BlsctTxOutResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(blsct_dest, r.value.dest);
+    r.value.amount = amount;
+    std::memcpy(r.value.memo_c_str, memo_c_str, memo_c_str_len);
+    r.value.memo_c_str[memo_c_str_len] = '\0';
+    BLSCT_COPY(blsct_token_id, r.value.token_id);
+    r.value.output_type = output_type;
+    r.value.min_stake = min_stake;
+    r.value.subtract_fee_from_amount = subtract_fee_from_amount;
+    BLSCT_COPY(blsct_blinding_key, r.value.blinding_key);
+    return r;
 }
 
-const BlsctSubAddr* get_tx_out_destination(const BlsctTxOut* tx_out) {
-    MALLOC_BYTES(BlsctSubAddr, sub_addr, SUB_ADDR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(sub_addr);
-    BLSCT_COPY(tx_out->dest, *sub_addr);
-    return sub_addr;
-}
-
-uint64_t get_tx_out_amount(const BlsctTxOut* tx_out)
+BlsctSubAddrResult get_tx_out_destination(const BlsctTxOutData* tx_out)
 {
-    return tx_out->amount;
+    if (tx_out == nullptr) return typed_err<BlsctSubAddrResult>(BLSCT_FAILURE);
+    BlsctSubAddrResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_out->dest, r.value);
+    return r;
 }
 
-const char* get_tx_out_memo(const BlsctTxOut* tx_out)
+BlsctUint64Result get_tx_out_amount(const BlsctTxOutData* tx_out)
 {
-    size_t memo_c_str_len = std::strlen(tx_out->memo_c_str);
-    char* memo_c_str = (char*)malloc(memo_c_str_len + 1);
-    RETURN_IF_MEM_ALLOC_FAILED(memo_c_str);
-    std::memcpy(memo_c_str, tx_out->memo_c_str, memo_c_str_len + 1);
-    return memo_c_str;
+    if (tx_out == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_out->amount};
 }
 
-const BlsctTokenId* get_tx_out_token_id(const BlsctTxOut* tx_out) {
-    MALLOC_BYTES(BlsctTokenId, token_id, TOKEN_ID_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(token_id);
-    BLSCT_COPY(tx_out->token_id, *token_id);
-    return token_id;
-}
-
-TxOutputType get_tx_out_output_type(const BlsctTxOut* tx_out)
+BlsctStrResult get_tx_out_memo(const BlsctTxOutData* tx_out)
 {
-    return tx_out->output_type;
+    if (tx_out == nullptr) return typed_err<BlsctStrResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_out->memo_c_str};
 }
 
-uint64_t get_tx_out_min_stake(const BlsctTxOut* tx_out)
+BlsctTokenIdResult get_tx_out_token_id(const BlsctTxOutData* tx_out)
 {
-    return tx_out->min_stake;
+    if (tx_out == nullptr) return typed_err<BlsctTokenIdResult>(BLSCT_FAILURE);
+    BlsctTokenIdResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_out->token_id, r.value);
+    return r;
 }
 
-bool get_tx_out_subtract_fee_from_amount(const BlsctTxOut* tx_out) {
-    return tx_out->subtract_fee_from_amount;
+BlsctTxOutputTypeResult get_tx_out_output_type(const BlsctTxOutData* tx_out)
+{
+    if (tx_out == nullptr) return typed_err<BlsctTxOutputTypeResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_out->output_type};
 }
 
-const BlsctScalar* get_tx_out_blinding_key(const BlsctTxOut* tx_out) {
-    MALLOC_BYTES(BlsctScalar, blinding_key, SCALAR_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blinding_key);
-    BLSCT_COPY(tx_out->blinding_key, *blinding_key);
-    return blinding_key;
+BlsctUint64Result get_tx_out_min_stake(const BlsctTxOutData* tx_out)
+{
+    if (tx_out == nullptr) return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_out->min_stake};
+}
+
+BlsctBoolResult get_tx_out_subtract_fee_from_amount(const BlsctTxOutData* tx_out)
+{
+    if (tx_out == nullptr) return typed_err<BlsctBoolResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, tx_out->subtract_fee_from_amount};
+}
+
+BlsctScalarResult get_tx_out_blinding_key(const BlsctTxOutData* tx_out)
+{
+    if (tx_out == nullptr) return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+    BlsctScalarResult r{};
+    r.result = BLSCT_SUCCESS;
+    BLSCT_COPY(tx_out->blinding_key, r.value);
+    return r;
 }
 
 // unsigned input/output/transaction helpers
-BlsctRetVal* build_unsigned_input(const BlsctTxIn* tx_in)
+BLSCT_RESULT build_unsigned_input(const BlsctTxInData* tx_in, char* buf, size_t buf_size, size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(tx_in, err(BLSCT_FAILURE));
-
+    if (tx_in == nullptr) return BLSCT_FAILURE;
     auto input = UnsignedInputFromC(*tx_in);
-    if (!input.has_value()) {
-        return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
-    }
-
-    auto* unsigned_input = new (std::nothrow) blsct::UnsignedInput(std::move(input.value()));
-    if (unsigned_input == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_input), sizeof(blsct::UnsignedInput));
+    if (!input.has_value()) return BLSCT_VALUE_OUTSIDE_THE_RANGE;
+    size_t sz = SerializeObjToHexBuf(input.value(), buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-void delete_unsigned_input(void* vp_unsigned_input)
+BLSCT_RESULT build_unsigned_output(const BlsctTxOutData* tx_out, char* buf, size_t buf_size, size_t* out_len)
 {
-    if (vp_unsigned_input == nullptr) return;
-    delete static_cast<blsct::UnsignedInput*>(vp_unsigned_input);
-}
-
-const char* serialize_unsigned_input(const void* vp_unsigned_input)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_input, nullptr);
-    return SerializeSerializableObject(*static_cast<const blsct::UnsignedInput*>(vp_unsigned_input));
-}
-
-BlsctRetVal* deserialize_unsigned_input(const char* hex)
-{
-    return DeserializeSerializableObject<blsct::UnsignedInput>(hex);
-}
-
-BlsctRetVal* build_unsigned_output(const BlsctTxOut* tx_out)
-{
-    RETURN_RET_VAL_IF_NULL(tx_out, err(BLSCT_FAILURE));
-
+    if (tx_out == nullptr) return BLSCT_FAILURE;
     auto output = UnsignedOutputFromC(*tx_out);
-    if (!output.has_value()) {
-        return err(BLSCT_BAD_OUT_TYPE);
-    }
-
-    auto* unsigned_output = new (std::nothrow) blsct::UnsignedOutput(std::move(output.value()));
-    if (unsigned_output == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_output), sizeof(blsct::UnsignedOutput));
+    if (!output.has_value()) return BLSCT_BAD_OUT_TYPE;
+    size_t sz = SerializeObjToHexBuf(output.value(), buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* build_unsigned_create_token_output(
+BLSCT_RESULT build_unsigned_create_token_output(
     const BlsctScalar* blsct_token_key,
-    const void* vp_token_info)
+    const char* token_info_hex,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_token_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(vp_token_info, err(BLSCT_FAILURE));
-
+    if (blsct_token_key == nullptr) return BLSCT_FAILURE;
+    if (token_info_hex == nullptr) return BLSCT_FAILURE;
+    auto token_info = DeserializeObj<blsct::TokenInfo>(token_info_hex);
+    if (!token_info.has_value()) return BLSCT_DESER_FAILED;
     Scalar token_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_key, SCALAR_SIZE, token_key);
-
-    auto* unsigned_output = new (std::nothrow) blsct::UnsignedOutput(
-        blsct::CreateOutput(token_key, *static_cast<const blsct::TokenInfo*>(vp_token_info)));
-    if (unsigned_output == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_output), sizeof(blsct::UnsignedOutput));
+    blsct::UnsignedOutput unsigned_output(blsct::CreateOutput(token_key, *token_info));
+    size_t sz = SerializeObjToHexBuf(unsigned_output, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* build_unsigned_mint_token_output(
+BLSCT_RESULT build_unsigned_mint_token_output(
     const BlsctSubAddr* blsct_dest,
     const uint64_t amount,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
-    const BlsctPubKey* blsct_token_public_key)
+    const BlsctPubKey* blsct_token_public_key,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_dest, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_blinding_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_token_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_token_public_key, err(BLSCT_FAILURE));
+    if (blsct_dest == nullptr) return BLSCT_FAILURE;
+    if (blsct_blinding_key == nullptr) return BLSCT_FAILURE;
+    if (blsct_token_key == nullptr) return BLSCT_FAILURE;
+    if (blsct_token_public_key == nullptr) return BLSCT_FAILURE;
 
     CAmount mint_amount;
-    if (!AmountFromUint64Checked(amount, mint_amount)) {
-        return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
-    }
+    if (!AmountFromUint64Checked(amount, mint_amount)) return BLSCT_VALUE_OUTSIDE_THE_RANGE;
 
     blsct::SubAddress destination;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_dest, SUB_ADDR_SIZE, destination);
@@ -2375,27 +2206,30 @@ BlsctRetVal* build_unsigned_mint_token_output(
     blsct::PublicKey token_public_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_public_key, PUBLIC_KEY_SIZE, token_public_key);
 
-    auto* unsigned_output = new (std::nothrow) blsct::UnsignedOutput(
+    blsct::UnsignedOutput unsigned_output(
         blsct::CreateOutput(destination.GetKeys(), mint_amount, blinding_key, token_key, token_public_key));
-    if (unsigned_output == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_output), sizeof(blsct::UnsignedOutput));
+    size_t sz = SerializeObjToHexBuf(unsigned_output, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* build_unsigned_mint_nft_output(
+BLSCT_RESULT build_unsigned_mint_nft_output(
     const BlsctSubAddr* blsct_dest,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
     const BlsctPubKey* blsct_token_public_key,
     const uint64_t nft_id,
-    const void* vp_metadata)
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_dest, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_blinding_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_token_key, err(BLSCT_FAILURE));
-    RETURN_RET_VAL_IF_NULL(blsct_token_public_key, err(BLSCT_FAILURE));
+    if (blsct_dest == nullptr) return BLSCT_FAILURE;
+    if (blsct_blinding_key == nullptr) return BLSCT_FAILURE;
+    if (blsct_token_key == nullptr) return BLSCT_FAILURE;
+    if (blsct_token_public_key == nullptr) return BLSCT_FAILURE;
 
     blsct::SubAddress destination;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_dest, SUB_ADDR_SIZE, destination);
@@ -2409,126 +2243,42 @@ BlsctRetVal* build_unsigned_mint_nft_output(
     blsct::PublicKey token_public_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_public_key, PUBLIC_KEY_SIZE, token_public_key);
 
-    auto* unsigned_output = new (std::nothrow) blsct::UnsignedOutput(
-        blsct::CreateOutput(destination.GetKeys(), blinding_key, token_key, token_public_key, nft_id, StringMapFromOpaque(vp_metadata)));
-    if (unsigned_output == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_output), sizeof(blsct::UnsignedOutput));
+    blsct::UnsignedOutput unsigned_output(
+        blsct::CreateOutput(destination.GetKeys(), blinding_key, token_key, token_public_key, nft_id, StringMapFromArrays(metadata_keys, metadata_values, metadata_count)));
+    size_t sz = SerializeObjToHexBuf(unsigned_output, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-void delete_unsigned_output(void* vp_unsigned_output)
+BLSCT_RESULT sign_unsigned_transaction(
+    const char* const* input_hexes, size_t n_inputs,
+    const char* const* output_hexes, size_t n_outputs,
+    uint64_t fee,
+    char* buf, size_t buf_size, size_t* out_len)
 {
-    if (vp_unsigned_output == nullptr) return;
-    delete static_cast<blsct::UnsignedOutput*>(vp_unsigned_output);
-}
-
-const char* serialize_unsigned_output(const void* vp_unsigned_output)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_output, nullptr);
-    return SerializeSerializableObject(*static_cast<const blsct::UnsignedOutput*>(vp_unsigned_output));
-}
-
-BlsctRetVal* deserialize_unsigned_output(const char* hex)
-{
-    return DeserializeSerializableObject<blsct::UnsignedOutput>(hex);
-}
-
-void* create_unsigned_transaction()
-{
-    auto* unsigned_tx = new (std::nothrow) blsct::UnsignedTransaction{};
-    return static_cast<void*>(unsigned_tx);
-}
-
-void add_unsigned_transaction_input(void* vp_unsigned_transaction, const void* vp_unsigned_input)
-{
-    RETURN_IF_NULL(vp_unsigned_transaction);
-    RETURN_IF_NULL(vp_unsigned_input);
-    auto* unsigned_tx = static_cast<blsct::UnsignedTransaction*>(vp_unsigned_transaction);
-    unsigned_tx->AddInput(*static_cast<const blsct::UnsignedInput*>(vp_unsigned_input));
-}
-
-void add_unsigned_transaction_output(void* vp_unsigned_transaction, const void* vp_unsigned_output)
-{
-    RETURN_IF_NULL(vp_unsigned_transaction);
-    RETURN_IF_NULL(vp_unsigned_output);
-    auto* unsigned_tx = static_cast<blsct::UnsignedTransaction*>(vp_unsigned_transaction);
-    unsigned_tx->AddOutput(*static_cast<const blsct::UnsignedOutput*>(vp_unsigned_output));
-}
-
-void set_unsigned_transaction_fee(void* vp_unsigned_transaction, const uint64_t fee)
-{
-    RETURN_IF_NULL(vp_unsigned_transaction);
-
-    CAmount tx_fee;
-    if (!AmountFromUint64Checked(fee, tx_fee)) {
-        return;
-    }
-
-    static_cast<blsct::UnsignedTransaction*>(vp_unsigned_transaction)->SetFee(tx_fee);
-}
-
-uint64_t get_unsigned_transaction_fee(const void* vp_unsigned_transaction)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_transaction, 0);
-    return static_cast<uint64_t>(static_cast<const blsct::UnsignedTransaction*>(vp_unsigned_transaction)->GetFee());
-}
-
-size_t get_unsigned_transaction_inputs_size(const void* vp_unsigned_transaction)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_transaction, 0);
-    return static_cast<const blsct::UnsignedTransaction*>(vp_unsigned_transaction)->GetInputs().size();
-}
-
-size_t get_unsigned_transaction_outputs_size(const void* vp_unsigned_transaction)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_transaction, 0);
-    return static_cast<const blsct::UnsignedTransaction*>(vp_unsigned_transaction)->GetOutputs().size();
-}
-
-void delete_unsigned_transaction(void* vp_unsigned_transaction)
-{
-    if (vp_unsigned_transaction == nullptr) return;
-    delete static_cast<blsct::UnsignedTransaction*>(vp_unsigned_transaction);
-}
-
-const char* serialize_unsigned_transaction(const void* vp_unsigned_transaction)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_transaction, nullptr);
-    const auto bytes = static_cast<const blsct::UnsignedTransaction*>(vp_unsigned_transaction)->Serialize();
-    return StrToAllocCStr(HexStr(bytes));
-}
-
-BlsctRetVal* deserialize_unsigned_transaction(const char* hex)
-{
-    std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
-    }
-
-    auto tx = blsct::UnsignedTransaction::Deserialize(vec);
-    if (!tx.has_value()) {
-        return err(BLSCT_DESER_FAILED);
-    }
-
-    auto* unsigned_tx = new (std::nothrow) blsct::UnsignedTransaction(std::move(tx.value()));
-    if (unsigned_tx == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-
-    return succ(static_cast<void*>(unsigned_tx), sizeof(blsct::UnsignedTransaction));
-}
-
-BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction)
-{
-    RETURN_RET_VAL_IF_NULL(vp_unsigned_transaction, err(BLSCT_FAILURE));
-
     try {
-        auto signed_tx = static_cast<const blsct::UnsignedTransaction*>(vp_unsigned_transaction)->Sign();
-        if (!signed_tx.has_value()) {
-            return err(BLSCT_FAILURE);
+        blsct::UnsignedTransaction utx;
+
+        CAmount tx_fee;
+        if (!AmountFromUint64Checked(fee, tx_fee)) return BLSCT_FAILURE;
+        utx.SetFee(tx_fee);
+
+        for (size_t i = 0; i < n_inputs; ++i) {
+            if (input_hexes == nullptr || input_hexes[i] == nullptr) return BLSCT_FAILURE;
+            auto input = DeserializeObj<blsct::UnsignedInput>(input_hexes[i]);
+            if (!input.has_value()) return BLSCT_DESER_FAILED;
+            utx.AddInput(*input);
         }
+
+        for (size_t i = 0; i < n_outputs; ++i) {
+            if (output_hexes == nullptr || output_hexes[i] == nullptr) return BLSCT_FAILURE;
+            auto output = DeserializeObj<blsct::UnsignedOutput>(output_hexes[i]);
+            if (!output.has_value()) return BLSCT_DESER_FAILED;
+            utx.AddOutput(*output);
+        }
+
+        auto signed_tx = utx.Sign();
+        if (!signed_tx.has_value()) return BLSCT_FAILURE;
 
         DataStream st{};
         TransactionSerParams params{.allow_witness = true};
@@ -2538,13 +2288,11 @@ BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction)
         mutable_tx.Serialize(ps);
 
         const auto hex = HexStr(st);
-        const char* hex_c_str = StrToAllocCStr(hex);
-        if (hex_c_str == nullptr) {
-            return err(BLSCT_MEM_ALLOC_FAILED);
-        }
-        return succ(const_cast<char*>(hex_c_str), hex.size() + 1);
+        if (out_len != nullptr) *out_len = hex.size();
+        WriteStrBuf(hex, buf, buf_size);
+        return BLSCT_SUCCESS;
     } catch (const std::exception&) {
-        return err(BLSCT_EXCEPTION);
+        return BLSCT_EXCEPTION;
     }
 }
 
@@ -2566,270 +2314,282 @@ int are_vector_predicate_equal(
     return 1;
 }
 
-const char* serialize_vector_predicate(
+BlsctSizeTResult serialize_vector_predicate(
     const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size)
+    size_t obj_size,
+    char* buf,
+    size_t buf_size)
 {
-    return SerializeToHex(
-        blsct_vector_predicate,
-        obj_size);
+    if (blsct_vector_predicate == nullptr) return typed_err<BlsctSizeTResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, WriteHexBuf(reinterpret_cast<const uint8_t*>(blsct_vector_predicate), obj_size, buf, buf_size)};
 }
 
-BlsctRetVal* deserialize_vector_predicate(
-    const char* hex)
+BLSCT_RESULT deserialize_vector_predicate(
+    const char* hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
     std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
-    }
-    size_t obj_size = vec.size();
-    MALLOC_BYTES(BlsctVectorPredicate, x, obj_size);
-    RETURN_ERR_IF_MEM_ALLOC_FAILED(x);
-
-    std::memcpy(x, &vec[0], obj_size);
-
-    return succ(x, obj_size);
+    if (!TryParseHexWrap(hex, vec)) return BLSCT_FAILURE;
+    if (out_len) *out_len = vec.size();
+    if (buf != nullptr && buf_size >= vec.size())
+        std::memcpy(buf, vec.data(), vec.size());
+    return BLSCT_SUCCESS;
 }
 
-enum BlsctPredicateType get_vector_predicate_type(
+BlsctPredicateTypeResult get_vector_predicate_type(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size)
 {
+    if (blsct_vector_predicate == nullptr) return typed_err<BlsctPredicateTypeResult>(BLSCT_FAILURE);
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
-    if (!predicate.has_value()) {
-        return BlsctInvalidPredicateType;
-    }
-    return PredicateTypeToC(predicate.value());
+    if (!predicate.has_value()) return typed_err<BlsctPredicateTypeResult>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, PredicateTypeToC(predicate.value())};
 }
 
-BlsctRetVal* build_create_token_predicate(
-    const void* vp_token_info)
+BLSCT_RESULT build_create_token_predicate(
+    const char* token_info_hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(vp_token_info, err(BLSCT_FAILURE));
-    auto predicate = blsct::CreateTokenPredicate(*static_cast<const blsct::TokenInfo*>(vp_token_info)).GetVch();
-
-    MALLOC_BYTES(BlsctVectorPredicate, blsct_predicate, predicate.size());
-    if (blsct_predicate == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-    std::memcpy(blsct_predicate, predicate.data(), predicate.size());
-    return succ(blsct_predicate, predicate.size());
+    if (token_info_hex == nullptr) return BLSCT_FAILURE;
+    auto token_info = DeserializeObj<blsct::TokenInfo>(token_info_hex);
+    if (!token_info.has_value()) return BLSCT_DESER_FAILED;
+    auto predicate = blsct::CreateTokenPredicate(*token_info).GetVch();
+    if (out_len) *out_len = predicate.size();
+    if (buf != nullptr && buf_size >= predicate.size())
+        std::memcpy(buf, predicate.data(), predicate.size());
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* build_mint_token_predicate(
+BLSCT_RESULT build_mint_token_predicate(
     const BlsctPubKey* blsct_token_public_key,
-    const uint64_t amount)
+    const uint64_t amount,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_token_public_key, err(BLSCT_FAILURE));
+    if (blsct_token_public_key == nullptr) return BLSCT_FAILURE;
 
     CAmount mint_amount;
-    if (!AmountFromUint64Checked(amount, mint_amount)) {
-        return err(BLSCT_VALUE_OUTSIDE_THE_RANGE);
-    }
+    if (!AmountFromUint64Checked(amount, mint_amount)) return BLSCT_VALUE_OUTSIDE_THE_RANGE;
 
     blsct::PublicKey token_public_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_public_key, PUBLIC_KEY_SIZE, token_public_key);
     auto predicate = blsct::MintTokenPredicate(token_public_key, mint_amount).GetVch();
-
-    MALLOC_BYTES(BlsctVectorPredicate, blsct_predicate, predicate.size());
-    if (blsct_predicate == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-    std::memcpy(blsct_predicate, predicate.data(), predicate.size());
-    return succ(blsct_predicate, predicate.size());
+    if (out_len) *out_len = predicate.size();
+    if (buf != nullptr && buf_size >= predicate.size())
+        std::memcpy(buf, predicate.data(), predicate.size());
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* build_mint_nft_predicate(
+BLSCT_RESULT build_mint_nft_predicate(
     const BlsctPubKey* blsct_token_public_key,
     const uint64_t nft_id,
-    const void* vp_metadata)
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
-    RETURN_RET_VAL_IF_NULL(blsct_token_public_key, err(BLSCT_FAILURE));
+    if (blsct_token_public_key == nullptr) return BLSCT_FAILURE;
 
     blsct::PublicKey token_public_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_public_key, PUBLIC_KEY_SIZE, token_public_key);
-    auto predicate = blsct::MintNftPredicate(token_public_key, nft_id, StringMapFromOpaque(vp_metadata)).GetVch();
-
-    MALLOC_BYTES(BlsctVectorPredicate, blsct_predicate, predicate.size());
-    if (blsct_predicate == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-    std::memcpy(blsct_predicate, predicate.data(), predicate.size());
-    return succ(blsct_predicate, predicate.size());
+    auto predicate = blsct::MintNftPredicate(token_public_key, nft_id, StringMapFromArrays(metadata_keys, metadata_values, metadata_count)).GetVch();
+    if (out_len) *out_len = predicate.size();
+    if (buf != nullptr && buf_size >= predicate.size())
+        std::memcpy(buf, predicate.data(), predicate.size());
+    return BLSCT_SUCCESS;
 }
 
-BlsctRetVal* get_create_token_predicate_token_info(
+BLSCT_RESULT get_create_token_predicate_token_info(
     const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size)
+    size_t obj_size,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len)
 {
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
-    if (!predicate.has_value() || !predicate->IsCreateTokenPredicate()) {
-        return err(BLSCT_FAILURE);
-    }
-
-    auto* token_info = new (std::nothrow) blsct::TokenInfo(predicate->GetTokenInfo());
-    if (token_info == nullptr) {
-        return err(BLSCT_MEM_ALLOC_FAILED);
-    }
-    return succ(static_cast<void*>(token_info), sizeof(blsct::TokenInfo));
+    if (!predicate.has_value() || !predicate->IsCreateTokenPredicate()) return BLSCT_FAILURE;
+    auto token_info = predicate->GetTokenInfo();
+    size_t sz = SerializeObjToHexBuf(token_info, buf, buf_size);
+    if (out_len) *out_len = sz;
+    return BLSCT_SUCCESS;
 }
 
-const BlsctPubKey* get_mint_token_predicate_public_key(
-    const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size)
-{
-    auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
-    if (!predicate.has_value() || !predicate->IsMintTokenPredicate()) {
-        return nullptr;
-    }
-
-    MALLOC_BYTES(BlsctPubKey, blsct_pub_key, PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_pub_key);
-    SERIALIZE_AND_COPY(predicate->GetPublicKey(), blsct_pub_key);
-    return blsct_pub_key;
-}
-
-uint64_t get_mint_token_predicate_amount(
+BlsctPubKeyResult get_mint_token_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size)
 {
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
     if (!predicate.has_value() || !predicate->IsMintTokenPredicate()) {
-        return 0;
+        return typed_err<BlsctPubKeyResult>(BLSCT_FAILURE);
     }
-    return static_cast<uint64_t>(predicate->GetAmount());
+
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(predicate->GetPublicKey(), r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-const BlsctPubKey* get_mint_nft_predicate_public_key(
+BlsctUint64Result get_mint_token_predicate_amount(
+    const BlsctVectorPredicate* blsct_vector_predicate,
+    size_t obj_size)
+{
+    auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
+    if (!predicate.has_value() || !predicate->IsMintTokenPredicate())
+        return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, static_cast<uint64_t>(predicate->GetAmount())};
+}
+
+BlsctPubKeyResult get_mint_nft_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size)
 {
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
     if (!predicate.has_value() || !predicate->IsMintNftPredicate()) {
-        return nullptr;
+        return typed_err<BlsctPubKeyResult>(BLSCT_FAILURE);
     }
 
-    MALLOC_BYTES(BlsctPubKey, blsct_pub_key, PUBLIC_KEY_SIZE);
-    RETURN_IF_MEM_ALLOC_FAILED(blsct_pub_key);
-    SERIALIZE_AND_COPY(predicate->GetPublicKey(), blsct_pub_key);
-    return blsct_pub_key;
+    BlsctPubKeyResult r{};
+    SERIALIZE_AND_COPY(predicate->GetPublicKey(), r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-uint64_t get_mint_nft_predicate_nft_id(
+BlsctUint64Result get_mint_nft_predicate_nft_id(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size)
 {
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
-    if (!predicate.has_value() || !predicate->IsMintNftPredicate()) {
-        return 0;
-    }
-    return predicate->GetNftId();
+    if (!predicate.has_value() || !predicate->IsMintNftPredicate())
+        return typed_err<BlsctUint64Result>(BLSCT_FAILURE);
+    return {BLSCT_SUCCESS, predicate->GetNftId()};
 }
 
-void* get_mint_nft_predicate_metadata(
+void get_mint_nft_predicate_metadata(
     const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size)
+    size_t obj_size,
+    BlsctStringMapCallback cb,
+    void* user_data)
 {
     auto predicate = ParseOpaquePredicate(blsct_vector_predicate, obj_size);
-    if (!predicate.has_value() || !predicate->IsMintNftPredicate()) {
-        return nullptr;
-    }
-    return CloneStringMap(predicate->GetNftMetaData());
+    if (!predicate.has_value() || !predicate->IsMintNftPredicate()) return;
+    InvokeCallbackForMap(predicate->GetNftMetaData(), cb, user_data);
 }
 
 // key derivation functions
 
-BlsctScalar* from_seed_to_child_key(
+BlsctScalarResult from_seed_to_child_key(
     const BlsctScalar* blsct_seed)
 {
+    if (blsct_seed == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar seed;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_seed, SCALAR_SIZE, seed);
 
     auto child_key = blsct::FromSeedToChildKey(seed);
-    BlsctScalar* blsct_child_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(child_key, blsct_child_key);
-
-    return blsct_child_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(child_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* from_child_key_to_blinding_key(
+BlsctScalarResult from_child_key_to_blinding_key(
     const BlsctScalar* blsct_child_key)
 {
+    if (blsct_child_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar child_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_child_key, SCALAR_SIZE, child_key);
 
     Scalar blinding_key = blsct::FromChildToBlindingKey(child_key);
-    BlsctScalar* blsct_blinding_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(blinding_key, blsct_blinding_key);
-
-    return blsct_blinding_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(blinding_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* from_child_key_to_token_key(
+BlsctScalarResult from_child_key_to_token_key(
     const BlsctScalar* blsct_child_key)
 {
+    if (blsct_child_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar child_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_child_key, SCALAR_SIZE, child_key);
 
     auto token_key = blsct::FromChildToTokenKey(child_key);
-    BlsctScalar* blsct_token_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(token_key, blsct_token_key);
-
-    return blsct_token_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(token_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* from_child_key_to_tx_key(
+BlsctScalarResult from_child_key_to_tx_key(
     const BlsctScalar* blsct_child_key)
 {
+    if (blsct_child_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar child_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_child_key, SCALAR_SIZE, child_key);
 
     auto tx_key = blsct::FromChildToTransactionKey(child_key);
-    BlsctScalar* blsct_tx_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(tx_key, blsct_tx_key);
-
-    return blsct_tx_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(tx_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* from_tx_key_to_view_key(
+BlsctScalarResult from_tx_key_to_view_key(
     const BlsctScalar* blsct_tx_key)
 {
+    if (blsct_tx_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar tx_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_tx_key, SCALAR_SIZE, tx_key);
 
     auto view_key = blsct::FromTransactionToViewKey(tx_key);
-    BlsctScalar* blsct_view_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(view_key, blsct_view_key);
-
-    return blsct_view_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(view_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* from_tx_key_to_spending_key(
+BlsctScalarResult from_tx_key_to_spending_key(
     const BlsctScalar* blsct_tx_key)
 {
+    if (blsct_tx_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     Scalar tx_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_tx_key, SCALAR_SIZE, tx_key);
 
     auto spending_key = blsct::FromTransactionToSpendKey(tx_key);
-    BlsctScalar* blsct_spending_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(spending_key, blsct_spending_key);
-
-    return blsct_spending_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(spending_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
-BlsctScalar* calc_priv_spending_key(
+BlsctScalarResult calc_priv_spending_key(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* blsct_view_key,
     const BlsctScalar* blsct_spending_key,
     const int64_t account,
     const uint64_t address)
 {
+    if (blsct_blinding_pub_key == nullptr || blsct_view_key == nullptr || blsct_spending_key == nullptr)
+        return typed_err<BlsctScalarResult>(BLSCT_FAILURE);
+
     blsct::PublicKey blinding_pub_key;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_blinding_pub_key, PUBLIC_KEY_SIZE, blinding_pub_key);
 
@@ -2845,75 +2605,15 @@ BlsctScalar* calc_priv_spending_key(
         spending_key,
         account,
         address);
-    BlsctScalar* blsct_priv_spending_key = static_cast<BlsctScalar*>(
-        malloc(SCALAR_SIZE));
-    SERIALIZE_AND_COPY(priv_spending_key, blsct_priv_spending_key);
-
-    return blsct_priv_spending_key;
+    BlsctScalarResult r{};
+    SERIALIZE_AND_COPY(priv_spending_key, r.value);
+    r.result = BLSCT_SUCCESS;
+    return r;
 }
 
 // Misc helper functions
 
-// uint64_t vector
-void* create_uint64_vec()
+size_t buf_to_hex(const uint8_t* buf, size_t size, char* out, size_t out_size)
 {
-    auto vec = new (std::nothrow) std::vector<uint64_t>;
-    HANDLE_MEM_ALLOC_FAILURE(vec);
-    return static_cast<void*>(vec);
-}
-
-void add_to_uint64_vec(void* vp_uint64_vec, const uint64_t n)
-{
-    RETURN_IF_NULL(vp_uint64_vec);
-    auto uint64_vec = static_cast<std::vector<uint64_t>*>(vp_uint64_vec);
-    uint64_vec->push_back(n);
-}
-
-void delete_uint64_vec(const void* vp_vec)
-{
-    if (vp_vec == nullptr) return;
-    auto vec = static_cast<const std::vector<uint64_t>*>(vp_vec);
-    delete vec;
-}
-
-// Tested in Rust bindings
-uint8_t* hex_to_malloced_buf(const char* hex)
-{
-    size_t hex_len = std::strlen(hex);
-    size_t buf_len = hex_len / 2;
-
-    uint8_t* buf = static_cast<uint8_t*>(malloc(buf_len));
-    const char* p = hex;
-
-    for (size_t i = 0; i < buf_len; ++i) {
-        uint8_t x = 0;
-        auto _ = std::from_chars(p, p + 2, x, 16);
-        buf[i] = x;
-        p += 2;
-    }
-    return buf;
-}
-
-// Tested in Rust bindings
-const char* buf_to_malloced_hex_c_str(const uint8_t* buf, size_t size)
-{
-    // +1 for null terminator at the end
-    size_t hex_str_len = size * 2 + 1;
-
-    char* hex_c_str = static_cast<char*>(malloc(hex_str_len));
-    if (hex_c_str == nullptr) {
-        return nullptr;
-    }
-
-    static const char hex_table[] = "0123456789abcdef";
-
-    for (size_t i = 0; i < size; ++i) {
-        uint8_t b = buf[i];
-        size_t p = 2 * i;
-        hex_c_str[p] = hex_table[b >> 4];       // high nibble
-        hex_c_str[p + 1] = hex_table[b & 0x0F]; // low nibble
-    }
-    hex_c_str[hex_str_len - 1] = '\0';
-
-    return hex_c_str;
+    return WriteHexBuf(buf, size, out, out_size);
 }

--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -2299,9 +2299,9 @@ BLSCT_RESULT sign_unsigned_transaction(
 // vector predicate
 int are_vector_predicate_equal(
     const BlsctVectorPredicate* a,
-    const size_t a_size,
+    size_t a_size,
     const BlsctVectorPredicate* b,
-    const size_t b_size)
+    size_t b_size)
 {
     if (a_size != b_size) {
         return 0;

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -35,6 +35,18 @@
 #define SIGNATURE_SIZE 96
 #define SCRIPT_SIZE 28
 #define MAX_MEMO_LEN 100
+
+#define BLSCT_SCALAR_HEX_SIZE (SCALAR_SIZE * 2 + 1)
+#define BLSCT_POINT_HEX_SIZE (POINT_SIZE * 2 + 1)
+#define BLSCT_DPK_HEX_SIZE (DOUBLE_PUBLIC_KEY_SIZE * 2 + 1)
+#define BLSCT_KEY_ID_HEX_SIZE (KEY_ID_SIZE * 2 + 1)
+#define BLSCT_SCRIPT_HEX_SIZE (SCRIPT_SIZE * 2 + 1)
+#define BLSCT_TOKEN_ID_HEX_SIZE (TOKEN_ID_SIZE * 2 + 1)
+#define BLSCT_CTX_ID_HEX_SIZE (CTX_ID_SIZE * 2 + 1)
+#define BLSCT_OUT_POINT_HEX_SIZE (OUT_POINT_SIZE * 2 + 1)
+#define BLSCT_SIGNATURE_HEX_SIZE (SIGNATURE_SIZE * 2 + 1)
+#define BLSCT_SUB_ADDR_HEX_SIZE (SUB_ADDR_SIZE * 2 + 1)
+#define BLSCT_SUB_ADDR_ID_HEX_SIZE (SUB_ADDR_ID_SIZE * 2 + 1)
 #define MEMO_BUF_SIZE MAX_MEMO_LEN + 1
 #define CTX_ID_SIZE UINT256_SIZE
 #define CTX_ID_STR_LEN CTX_ID_SIZE * 2
@@ -54,23 +66,7 @@
 #define BLSCT_MEMO_TOO_LONG 17
 #define BLSCT_MEM_ALLOC_FAILED 18
 #define BLSCT_DESER_FAILED 19
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct {
-    BLSCT_RESULT result;
-    void* value;
-    size_t value_size;
-} BlsctRetVal;
-
-BlsctRetVal* err(
-    BLSCT_RESULT result);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+#define BLSCT_INIT_NOT_CALLED 20
 
 #define TRY_DEFINE_MCL_POINT_FROM(src, dest)         \
     Point dest;                                      \
@@ -114,14 +110,12 @@ BlsctRetVal* err(
 
 #define BLSCT_COPY(src, dest) std::memcpy(dest, src, sizeof(dest))
 #define BLSCT_COPY_BYTES(src, dest, n) std::memcpy(dest, src, n)
-#define MALLOC_BYTES(T, name, n) T* name = (T*) malloc(n)
-#define RETURN_IF_MEM_ALLOC_FAILED(name) \
-if (name == nullptr) { \
-    fputs("Failed to allocate memory\n", stderr); \
-    return nullptr; \
-}
-#define RETURN_ERR_IF_MEM_ALLOC_FAILED(name) \
-    if (name == nullptr) err(BLSCT_MEM_ALLOC_FAILED);
+#define MALLOC_BYTES(T, name, n) T* name = (T*)malloc(n)
+#define RETURN_IF_MEM_ALLOC_FAILED(name)              \
+    if (name == nullptr) {                            \
+        fputs("Failed to allocate memory\n", stderr); \
+        return nullptr;                               \
+    }
 
 #define U8C(name) reinterpret_cast<const uint8_t*>(name)
 
@@ -141,51 +135,6 @@ inline bool TryParseHexWrap(
     return true;
 }
 
-inline const char* StrToAllocCStr(const std::string& s)
-{
-    size_t buf_size = s.size() + 1;
-    MALLOC_BYTES(char, cstr_buf, buf_size);
-    RETURN_IF_MEM_ALLOC_FAILED(cstr_buf);
-    std::memcpy(cstr_buf, s.c_str(), buf_size); // also copies null at the end
-    return cstr_buf;
-}
-
-inline const char* SerializeToHex(
-    const uint8_t* blsct_obj,
-    const size_t obj_size)
-{
-    if (blsct_obj == nullptr) return nullptr;
-
-    std::vector<uint8_t> vec;
-    vec.reserve(obj_size);
-    for (size_t i = 0; i < obj_size; ++i) {
-        vec.push_back(blsct_obj[i]);
-    }
-    auto hex_str = HexStr(vec);
-    return StrToAllocCStr(hex_str);
-}
-
-inline void* DeserializeFromHex(const char* hex, const size_t obj_size)
-{
-    std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
-    }
-
-    // check if the size is correct
-    if (vec.size() != obj_size) {
-        return err(BLSCT_BAD_SIZE);
-    }
-
-    void* blsct_obj = malloc(obj_size);
-    if (blsct_obj == nullptr) {
-        fputs("Failed to allocate memory\n", stderr);
-        return nullptr;
-    }
-    std::memcpy(blsct_obj, &vec[0], obj_size);
-
-    return blsct_obj;
-}
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,52 +189,121 @@ typedef uint8_t BlsctSubAddrId[SUB_ADDR_ID_SIZE];
 typedef uint8_t BlsctTokenId[TOKEN_ID_SIZE];
 typedef uint8_t BlsctUint256[UINT256_SIZE];
 
+typedef char BlsctScalarHex[BLSCT_SCALAR_HEX_SIZE];
+typedef char BlsctPointHex[BLSCT_POINT_HEX_SIZE];
+typedef char BlsctDoublePubKeyHex[BLSCT_DPK_HEX_SIZE];
+typedef char BlsctKeyIdHex[BLSCT_KEY_ID_HEX_SIZE];
+typedef char BlsctScriptHex[BLSCT_SCRIPT_HEX_SIZE];
+typedef char BlsctTokenIdHex[BLSCT_TOKEN_ID_HEX_SIZE];
+typedef char BlsctCTxIdHex[BLSCT_CTX_ID_HEX_SIZE];
+typedef char BlsctOutPointHex[BLSCT_OUT_POINT_HEX_SIZE];
+typedef char BlsctSignatureHex[BLSCT_SIGNATURE_HEX_SIZE];
+typedef char BlsctSubAddrHex[BLSCT_SUB_ADDR_HEX_SIZE];
+typedef char BlsctSubAddrIdHex[BLSCT_SUB_ADDR_ID_HEX_SIZE];
+
 typedef uint8_t BlsctCTx;
 typedef uint8_t BlsctRangeProof;
 typedef uint8_t BlsctVectorPredicate;
 
+/* Fixed-size typed result structs (value embedded inline) */
 typedef struct {
     BLSCT_RESULT result;
-    bool value;
-} BlsctBoolRetVal;
-
+    BlsctDoublePubKey value;
+} BlsctDoublePubKeyResult;
 typedef struct {
     BLSCT_RESULT result;
-    void* value; // = std::vector<BlsctAmountRecoveryResult>
-} BlsctAmountsRetVal;
-
+    BlsctKeyId value;
+} BlsctKeyIdResult;
 typedef struct {
     BLSCT_RESULT result;
-    void* ctx;
-
-    size_t in_amount_err_index;  // holds the first index of the tx_in whose amount exceeds the maximum
-    size_t out_amount_err_index; // holds the first index of the tx_out whose amount exceeds the maximum
-} BlsctCTxRetVal;
-
-BlsctRetVal* succ(
-    void* value,
-    size_t value_size);
-
-BlsctBoolRetVal* succ_bool(
-    bool value);
-
-BlsctBoolRetVal* err_bool(
-    BLSCT_RESULT result);
-
+    BlsctOutPoint value;
+} BlsctOutPointResult;
 typedef struct {
-    BlsctRangeProof* range_proof;
-    size_t range_proof_size;
-    BlsctPoint nonce;
-    BlsctTokenId token_id;
-} BlsctAmountRecoveryReq;
-
+    BLSCT_RESULT result;
+    BlsctPoint value;
+} BlsctPointResult;
 typedef struct {
-    bool is_succ;
-    char* msg;
-    uint64_t amount;
-    BlsctScalar gamma;
-} BlsctAmountRecoveryResult;
+    BLSCT_RESULT result;
+    BlsctPubKey value;
+} BlsctPubKeyResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScalar value;
+} BlsctScalarResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScript value;
+} BlsctScriptResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSignature value;
+} BlsctSignatureResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddr value;
+} BlsctSubAddrResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrId value;
+} BlsctSubAddrIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTokenId value;
+} BlsctTokenIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctUint256 value;
+} BlsctUint256Result;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctCTxId value;
+} BlsctCTxIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScalarHex value;
+} BlsctScalarHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctPointHex value;
+} BlsctPointHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctDoublePubKeyHex value;
+} BlsctDoublePubKeyHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctKeyIdHex value;
+} BlsctKeyIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScriptHex value;
+} BlsctScriptHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTokenIdHex value;
+} BlsctTokenIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctCTxIdHex value;
+} BlsctCTxIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctOutPointHex value;
+} BlsctOutPointHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSignatureHex value;
+} BlsctSignatureHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrHex value;
+} BlsctSubAddrHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrIdHex value;
+} BlsctSubAddrIdHexResult;
 
+/* Heap-pointer result structs (opaque C++ objects) */
 typedef struct {
     uint64_t amount;
     BlsctScalar gamma;
@@ -294,7 +312,7 @@ typedef struct {
     BlsctOutPoint out_point;
     bool staked_commitment;
     bool rbf;
-} BlsctTxIn;
+} BlsctTxInData;
 
 typedef struct {
     BlsctSubAddr dest;
@@ -305,231 +323,290 @@ typedef struct {
     uint64_t min_stake;
     bool subtract_fee_from_amount;
     BlsctScalar blinding_key;
-} BlsctTxOut;
+} BlsctTxOutData;
+
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTxInData value;
+} BlsctTxInResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTxOutData value;
+} BlsctTxOutResult;
+typedef struct {
+    BLSCT_RESULT result;
+    bool value;
+} BlsctBoolResult;
+typedef struct {
+    BLSCT_RESULT result;
+    int64_t value;
+} BlsctInt64Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint64_t value;
+} BlsctUint64Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint32_t value;
+} BlsctUint32Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint16_t value;
+} BlsctUint16Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    size_t value;
+} BlsctSizeTResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    enum BlsctTokenType value;
+} BlsctTokenTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    TxOutputType value;
+} BlsctTxOutputTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    enum BlsctPredicateType value;
+} BlsctPredicateTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    const char* value;
+} BlsctStrResult;
+
+typedef void (*BlsctStringMapCallback)(const char* key, const char* value, void* user_data);
+
+typedef struct {
+    BLSCT_RESULT result;
+    size_t in_amount_err_index;
+    size_t out_amount_err_index;
+} BlsctCTxResult;
+
+typedef struct {
+    BlsctRangeProof* range_proof;
+    size_t range_proof_size;
+    BlsctPoint nonce;
+    BlsctTokenId token_id;
+} BlsctAmountRecoveryReq;
+
+typedef struct {
+    bool is_succ;
+    char msg[MEMO_BUF_SIZE];
+    uint64_t amount;
+    BlsctScalar gamma;
+} BlsctAmountRecoveryResult;
 
 void free_obj(void* x);
-void free_amounts_ret_val(BlsctAmountsRetVal* rv); // free attrs as well
 void init();
+void uninit();
 
 enum BlsctChain get_blsct_chain();
 void set_blsct_chain(enum BlsctChain chain);
 
-const char* serialize_raw_obj(const uint8_t* ser_obj, const size_t ser_obj_size);
-BlsctRetVal* deserialize_raw_obj(const char* hex);
+BlsctSizeTResult serialize_raw_obj(const uint8_t* ser_obj, size_t ser_obj_size, char* buf, size_t buf_size);
+BLSCT_RESULT deserialize_raw_obj(const char* hex, uint8_t* buf, size_t buf_size, size_t* out_len);
 
 // address
-BlsctRetVal* decode_address(
+BlsctDoublePubKeyResult decode_address(
     const char* blsct_enc_addr);
 
-BlsctRetVal* encode_address(
+BLSCT_RESULT encode_address(
     const void* void_blsct_dpk,
-    const enum AddressEncoding encoding);
+    enum AddressEncoding encoding,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-// amount recovery request
-BlsctAmountRecoveryReq* gen_amount_recovery_req(
-    const void* vp_blsct_range_proof,
-    const size_t range_proof_size,
-    const void* vp_blsct_nonce,
-    const void* vp_blsct_token_id);
-void* create_amount_recovery_req_vec();
-void add_to_amount_recovery_req_vec(
-    void* vp_amt_recovery_req_vec,
-    void* vp_amt_recovery_req);
-void delete_amount_recovery_req_vec(void* vp_amt_recovery_req_vec);
-
-// amountry recovery and the result result
-
-// returns a structure whose value field is
-// a vector of the same size as the input vector
-BlsctAmountsRetVal* recover_amount(
-    void* vp_amt_recovery_req_vec);
-
-size_t get_amount_recovery_result_size(
-    void* vp_amt_recovery_res_vec);
-bool get_amount_recovery_result_is_succ(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-uint64_t get_amount_recovery_result_amount(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-const char* get_amount_recovery_result_msg(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-const BlsctScalar* get_amount_recovery_result_gamma(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
+// amount recovery
+// reqs[i].range_proof must point to caller-owned bytes (not freed by this function)
+// results must be an array of n elements; each entry is written inline
+BLSCT_RESULT recover_amount(
+    const BlsctAmountRecoveryReq* reqs,
+    size_t n,
+    BlsctAmountRecoveryResult* results);
 
 // ctx
-void* create_tx_in_vec();
-void add_to_tx_in_vec(void* vp_tx_in_vec, const BlsctTxIn* tx_in);
-void delete_tx_in_vec(void* vp_tx_in_vec);
-
-void* create_tx_out_vec();
-void add_to_tx_out_vec(void* vp_tx_out_vec, const BlsctTxOut* tx_out);
-void delete_tx_out_vec(void* vp_tx_out_vec);
-
-// returns a serialized CMutableTransaction
-BlsctCTxRetVal* build_ctx(
-    const void* void_tx_ins,
-    const void* void_tx_outs);
-// using void* instead of const void* to avoid const_cast
-const char* get_ctx_id(void* vp_ctx);
-const void* get_ctx_ins(void* vp_ctx);
-const void* get_ctx_outs(void* vp_ctx);
-void delete_ctx(void* vp_ctx);
-
-const char* serialize_ctx(void* vp_ctx);
-BlsctRetVal* deserialize_ctx(const char* hex);
+BlsctCTxResult build_ctx(
+    const BlsctTxInData* tx_ins,
+    size_t tx_ins_len,
+    const BlsctTxOutData* tx_outs,
+    size_t tx_outs_len,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctCTxIdHexResult get_ctx_id(const char* hex);
 
 // ctx id
-const char* serialize_ctx_id(const BlsctCTxId* blsct_ctx_id);
-BlsctRetVal* deserialize_ctx_id(const char* hex);
+BlsctCTxIdHexResult serialize_ctx_id(const BlsctCTxId* blsct_ctx_id);
+BlsctCTxIdResult deserialize_ctx_id(const char* hex);
 
 // signed transaction aggregation
-void* create_tx_hex_vec();
-void add_to_tx_hex_vec(void* vp_tx_hex_vec, const char* tx_hex);
-void delete_tx_hex_vec(void* vp_tx_hex_vec);
-BlsctRetVal* aggregate_transactions(const void* vp_tx_hex_vec);
+BLSCT_RESULT aggregate_transactions(const char* const* tx_hexes, size_t tx_count, char* buf, size_t buf_size, size_t* out_len);
 
-// ctx_ins
-bool are_ctx_ins_equal(const void* vp_a, const void* vp_b);
-size_t get_ctx_ins_size(const void* blsct_ctx_ins);
-const void* get_ctx_in_at(const void* vp_ctx_ins, const size_t i);
+// ctx_ins (indexed access via hex)
+bool are_ctx_ins_equal(const char* hex_a, const char* hex_b);
+BlsctSizeTResult get_ctx_ins_size(const char* hex);
 
-// ctx in
+// ctx in (raw pointer accessors — for direct C++ object use)
 bool are_ctx_in_equal(const void* vp_a, const void* vp_b);
-const BlsctCTxId* get_ctx_in_prev_out_hash(const void* vp_ctx_in);
-const BlsctScript* get_ctx_in_script_sig(const void* vp_ctx_in);
-uint32_t get_ctx_in_sequence(const void* vp_ctx_in);
-const BlsctScript* get_ctx_in_script_witness(const void* vp_ctx_in);
+BlsctCTxIdResult get_ctx_in_prev_out_hash(const void* vp_ctx_in);
+BlsctScriptResult get_ctx_in_script_sig(const void* vp_ctx_in);
+BlsctUint32Result get_ctx_in_sequence(const void* vp_ctx_in);
+BlsctScriptResult get_ctx_in_script_witness(const void* vp_ctx_in);
 
-// ctx_outs
-bool are_ctx_outs_equal(const void* vp_a, const void* vp_b);
-size_t get_ctx_outs_size(const void* vp_ctx_outs);
-const void* get_ctx_out_at(const void* vp_ctx_outs, const size_t i);
+// ctx in (indexed access via hex)
+BlsctCTxIdResult get_ctx_in_prev_out_hash_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_in_script_sig_at(const char* hex, size_t i);
+BlsctUint32Result get_ctx_in_sequence_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_in_script_witness_at(const char* hex, size_t i);
 
-// ctx out
+// ctx_outs (indexed access via hex)
+bool are_ctx_outs_equal(const char* hex_a, const char* hex_b);
+BlsctSizeTResult get_ctx_outs_size(const char* hex);
+
+// ctx out (raw pointer accessors — for direct C++ object use)
 bool are_ctx_out_equal(const void* vp_a, const void* vp_b);
-uint64_t get_ctx_out_value(const void* vp_ctx_out);
-const BlsctScript* get_ctx_out_script_pub_key(const void* vp_ctx_out);
-const BlsctTokenId* get_ctx_out_token_id(const void* vp_ctx_out);
-BlsctRetVal* get_ctx_out_vector_predicate(const void* vp_ctx_out);
+BlsctUint64Result get_ctx_out_value(const void* vp_ctx_out);
+BlsctScriptResult get_ctx_out_script_pub_key(const void* vp_ctx_out);
+BlsctTokenIdResult get_ctx_out_token_id(const void* vp_ctx_out);
+BLSCT_RESULT get_ctx_out_vector_predicate(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctPointResult get_ctx_out_spending_key(const void* vp_ctx_out);
+BlsctPointResult get_ctx_out_ephemeral_key(const void* vp_ctx_out);
+BlsctPointResult get_ctx_out_blinding_key(const void* vp_ctx_out);
+BLSCT_RESULT get_ctx_out_range_proof(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctUint16Result get_ctx_out_view_tag(const void* vp_ctx_out);
 
-// ctx out blsct data
-const BlsctPoint* get_ctx_out_spending_key(const void* vp_ctx_out);
-const BlsctPoint* get_ctx_out_ephemeral_key(const void* vp_jctx_out);
-const BlsctPoint* get_ctx_out_blinding_key(const void* vp_ctx_out);
-const BlsctRetVal* get_ctx_out_range_proof(const void* vp_ctx_out);
-uint16_t get_ctx_out_view_tag(const void* vp_ctx_out);
+// ctx out (indexed access via hex)
+BlsctUint64Result get_ctx_out_value_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_out_script_pub_key_at(const char* hex, size_t i);
+BlsctTokenIdResult get_ctx_out_token_id_at(const char* hex, size_t i);
+BLSCT_RESULT get_ctx_out_vector_predicate_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctPointResult get_ctx_out_spending_key_at(const char* hex, size_t i);
+BlsctPointResult get_ctx_out_ephemeral_key_at(const char* hex, size_t i);
+BlsctPointResult get_ctx_out_blinding_key_at(const char* hex, size_t i);
+BLSCT_RESULT get_ctx_out_range_proof_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctUint16Result get_ctx_out_view_tag_at(const char* hex, size_t i);
 
 // double public key
-BlsctRetVal* gen_double_pub_key(
+BlsctDoublePubKeyResult gen_double_pub_key(
     const BlsctPubKey* blsct_pk1,
     const BlsctPubKey* blsct_pk2);
 
-BlsctDoublePubKey* gen_dpk_with_keys_acct_addr(
+BlsctDoublePubKeyResult gen_dpk_with_keys_acct_addr(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const int64_t account,
     const uint64_t address);
 
 
-BlsctRetVal* dpk_to_sub_addr(
+BlsctSubAddrResult dpk_to_sub_addr(
     const BlsctDoublePubKey* blsct_dpk);
 
-const char* serialize_dpk(const BlsctDoublePubKey* blsct_dpk);
-BlsctRetVal* deserialize_dpk(const char* hex);
+BlsctDoublePubKeyHexResult serialize_dpk(const BlsctDoublePubKey* blsct_dpk);
+BlsctDoublePubKeyResult deserialize_dpk(const char* hex);
 
 // key id (=Hash ID)
-BlsctKeyId* calc_key_id(
+BlsctKeyIdResult calc_key_id(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctScalar* blsct_view_key);
 
-const char* serialize_key_id(const BlsctKeyId* blsct_key_id);
-BlsctRetVal* deserialize_key_id(const char* hex);
+BlsctKeyIdHexResult serialize_key_id(const BlsctKeyId* blsct_key_id);
+BlsctKeyIdResult deserialize_key_id(const char* hex);
 
 // out point
 // txid is 32 bytes and represented as 64-char hex str
-BlsctRetVal* gen_out_point(
+BlsctOutPointResult gen_out_point(
     const char* ctx_id_c_str);
-const char* serialize_out_point(const BlsctOutPoint* blsct_out_point);
-BlsctRetVal* deserialize_out_point(const char* hex);
+BlsctOutPointHexResult serialize_out_point(const BlsctOutPoint* blsct_out_point);
+BlsctOutPointResult deserialize_out_point(const char* hex);
 
 // point
 int are_point_equal(const BlsctPoint* a, const BlsctPoint* b);
-BlsctRetVal* gen_base_point();
-BlsctRetVal* gen_random_point();
-BlsctPoint* scalar_muliply_point(
+BlsctPointResult gen_base_point();
+BlsctPointResult gen_random_point();
+BlsctPointResult scalar_muliply_point(
     const BlsctPoint* blsct_point,
-    const BlsctScalar* blsct_scalar
-);
-const char* point_to_str(const BlsctPoint* blsct_point);
-BlsctPoint* point_from_scalar(const BlsctScalar* blsct_scalar);
+    const BlsctScalar* blsct_scalar);
+BlsctSizeTResult point_to_str(const BlsctPoint* blsct_point, char* buf, size_t buf_size);
+BlsctPointResult point_from_scalar(const BlsctScalar* blsct_scalar);
 bool is_valid_point(const BlsctPoint* blsct_point);
 
-const char* serialize_point(const BlsctPoint* blsct_point);
-BlsctRetVal* deserialize_point(const char* hex);
+BlsctPointHexResult serialize_point(const BlsctPoint* blsct_point);
+BlsctPointResult deserialize_point(const char* hex);
 
 // public key
-BlsctRetVal* gen_random_public_key();
-BlsctPoint* get_public_key_point(const BlsctPubKey* blsct_pub_key);
-BlsctPubKey* point_to_public_key(const BlsctPoint* blsct_point);
-const char* serialize_public_key(const BlsctPoint* blsct_point);
-BlsctRetVal* deserialize_public_key(const char* hex);
+BlsctPubKeyResult gen_random_public_key();
+BlsctPointResult get_public_key_point(const BlsctPubKey* blsct_pub_key);
+BlsctPubKeyResult point_to_public_key(const BlsctPoint* blsct_point);
+BlsctPointHexResult serialize_public_key(const BlsctPoint* blsct_point);
+BlsctPubKeyResult deserialize_public_key(const char* hex);
 
 // range proof
-BlsctRetVal* build_range_proof(
-    const void* vp_uint64_vec,
+BLSCT_RESULT build_range_proof(
+    const uint64_t* amounts,
+    size_t amounts_len,
     const BlsctPoint* blsct_nonce,
     const char* blsct_msg,
-    const BlsctTokenId* blsct_token_id);
+    const BlsctTokenId* blsct_token_id,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-BlsctBoolRetVal* verify_range_proofs(
-    const void* vp_range_proofs);
+BlsctBoolResult verify_range_proofs(
+    const BlsctRangeProof* const* proofs,
+    const size_t* proof_sizes,
+    size_t proof_count);
 
-BlsctPoint* get_range_proof_A(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctPoint* get_range_proof_A_wip(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctPoint* get_range_proof_B(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctPointResult get_range_proof_A(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctPointResult get_range_proof_A_wip(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctPointResult get_range_proof_B(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
 
-BlsctScalar* get_range_proof_r_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctScalar* get_range_proof_s_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctScalar* get_range_proof_delta_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctScalar* get_range_proof_alpha_hat(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
-BlsctScalar* get_range_proof_tau_x(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_r_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_s_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_delta_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_alpha_hat(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_tau_x(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
 
-void* create_range_proof_vec();
-void add_to_range_proof_vec(
-    void* vp_range_proofs,
+
+BlsctSizeTResult serialize_range_proof(
     const BlsctRangeProof* blsct_range_proof,
-    size_t blsct_range_proof_size);
-void delete_range_proof_vec(const void* vp_range_proofs);
-
-const char* serialize_range_proof(
-    const BlsctRangeProof* blsct_range_proof,
-    const size_t obj_size);
-BlsctRetVal* deserialize_range_proof(
+    size_t range_proof_size,
+    char* buf,
+    size_t buf_size);
+BLSCT_RESULT deserialize_range_proof(
     const char* hex,
-    const size_t obj_size);
+    const size_t range_proof_size,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
 
 // scalar
 int are_scalar_equal(const BlsctScalar* a, const BlsctScalar* b);
-BlsctRetVal* gen_random_scalar();
-BlsctRetVal* gen_scalar(const uint64_t n);
-uint64_t scalar_to_uint64(const BlsctScalar* blsct_scalar);
+BlsctScalarResult gen_random_scalar();
+BlsctScalarResult gen_scalar(const uint64_t n);
+BlsctUint64Result scalar_to_uint64(const BlsctScalar* blsct_scalar);
 
-const char* scalar_to_str(const BlsctScalar* blsct_scalar);
-BlsctPubKey* scalar_to_pub_key(const BlsctScalar* blsct_scalar);
+BlsctSizeTResult scalar_to_str(const BlsctScalar* blsct_scalar, char* buf, size_t buf_size);
+BlsctPubKeyResult scalar_to_pub_key(const BlsctScalar* blsct_scalar);
 
-const char* serialize_scalar(const BlsctScalar* blsct_scalar);
-BlsctRetVal* deserialize_scalar(const char* hex);
+BlsctScalarHexResult serialize_scalar(const BlsctScalar* blsct_scalar);
+BlsctScalarResult deserialize_scalar(const char* hex);
 
 // script
-const char* serialize_script(const BlsctScript* blsct_script);
-BlsctRetVal* deserialize_script(const char* hex);
+BlsctScriptHexResult serialize_script(const BlsctScript* blsct_script);
+BlsctScriptResult deserialize_script(const char* hex);
 
 // signature
-const BlsctSignature* sign_message(
+BlsctSignatureResult sign_message(
     const BlsctScalar* blsct_priv_key,
     const char* blsct_msg);
 
@@ -538,85 +615,80 @@ bool verify_msg_sig(
     const char* blsct_msg,
     const BlsctSignature* blsct_signature);
 
-const char* serialize_signature(const BlsctSignature* blsct_signature);
-BlsctRetVal* deserialize_signature(const char* hex);
+BlsctSignatureHexResult serialize_signature(const BlsctSignature* blsct_signature);
+BlsctSignatureResult deserialize_signature(const char* hex);
 
 // sub addr
-BlsctSubAddr* derive_sub_address(
+BlsctSubAddrResult derive_sub_address(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-BlsctDoublePubKey* sub_addr_to_dpk(
-    const BlsctSubAddr* blsct_sub_addr
-);
+BlsctDoublePubKeyResult sub_addr_to_dpk(
+    const BlsctSubAddr* blsct_sub_addr);
 
-const char* serialize_sub_addr(const BlsctSignature* blsct_sub_addr);
-BlsctRetVal* deserialize_sub_addr(const char* hex);
+BlsctSubAddrHexResult serialize_sub_addr(const BlsctSubAddr* blsct_sub_addr);
+BlsctSubAddrResult deserialize_sub_addr(const char* hex);
 
 // sub addr id
-BlsctSubAddrId* gen_sub_addr_id(
+BlsctSubAddrIdResult gen_sub_addr_id(
     const int64_t account,
     const uint64_t address);
 
-int64_t get_sub_addr_id_account(
+BlsctInt64Result get_sub_addr_id_account(
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-uint64_t get_sub_addr_id_address(
+BlsctUint64Result get_sub_addr_id_address(
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-const char* serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id);
-BlsctRetVal* deserialize_sub_addr_id(const char* hex);
+BlsctSubAddrIdHexResult serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id);
+BlsctSubAddrIdResult deserialize_sub_addr_id(const char* hex);
 
 // token id
-BlsctRetVal* gen_token_id_with_token_and_subid(
+BlsctTokenIdResult gen_token_id_with_token_and_subid(
     const uint64_t token,
     const uint64_t subid);
 
-BlsctRetVal* gen_token_id(
+BlsctTokenIdResult gen_token_id(
     const uint64_t token);
 
-BlsctRetVal* gen_default_token_id();
-uint64_t get_token_id_token(const BlsctTokenId* blsct_token_id);
-uint64_t get_token_id_subid(const BlsctTokenId* blsct_token_id);
-const char* serialize_token_id(const BlsctTokenId* blsct_token_id);
-BlsctRetVal* deserialize_token_id(const char* hex);
-
-// generic string map helpers
-void* create_string_map();
-void add_to_string_map(void* vp_string_map, const char* key, const char* value);
-void delete_string_map(const void* vp_string_map);
-size_t get_string_map_size(const void* vp_string_map);
-const char* get_string_map_key_at(const void* vp_string_map, size_t idx);
-const char* get_string_map_value_at(const void* vp_string_map, size_t idx);
+BlsctTokenIdResult gen_default_token_id();
+BlsctUint64Result get_token_id_token(const BlsctTokenId* blsct_token_id);
+BlsctUint64Result get_token_id_subid(const BlsctTokenId* blsct_token_id);
+BlsctTokenIdHexResult serialize_token_id(const BlsctTokenId* blsct_token_id);
+BlsctTokenIdResult deserialize_token_id(const char* hex);
 
 // token info helpers
-BlsctRetVal* build_token_info(
+BLSCT_RESULT build_token_info(
     enum BlsctTokenType type,
     const BlsctPubKey* blsct_public_key,
-    const void* vp_metadata,
-    const uint64_t total_supply);
-void delete_token_info(void* vp_token_info);
-const char* serialize_token_info(const void* vp_token_info);
-BlsctRetVal* deserialize_token_info(const char* hex);
-enum BlsctTokenType get_token_info_type(const void* vp_token_info);
-const BlsctPubKey* get_token_info_public_key(const void* vp_token_info);
-uint64_t get_token_info_total_supply(const void* vp_token_info);
-void* get_token_info_metadata(const void* vp_token_info);
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    const uint64_t total_supply,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctTokenTypeResult get_token_info_type(const char* hex);
+BlsctPubKeyResult get_token_info_public_key(const char* hex);
+BlsctUint64Result get_token_info_total_supply(const char* hex);
+void get_token_info_metadata(const char* hex, BlsctStringMapCallback cb, void* user_data);
 
 // collection token hash and token key derivation
-BlsctRetVal* calc_collection_token_hash(
-    const void* vp_metadata,
+BlsctUint256Result calc_collection_token_hash(
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
     const uint64_t total_supply);
-BlsctRetVal* derive_collection_token_key(
+BlsctScalarResult derive_collection_token_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash);
-const BlsctPubKey* derive_collection_token_public_key(
+BlsctPubKeyResult derive_collection_token_public_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash);
 
 // tx in
-BlsctRetVal* build_tx_in(
+BlsctTxInResult build_tx_in(
     const uint64_t amount,
     const BlsctScalar* gamma,
     const BlsctScalar* spending_key,
@@ -625,16 +697,16 @@ BlsctRetVal* build_tx_in(
     const bool staked_commitment,
     const bool rbf);
 
-uint64_t get_tx_in_amount(const BlsctTxIn* tx_in);
-const BlsctScalar* get_tx_in_gamma(const BlsctTxIn* tx_in);
-const BlsctScalar* get_tx_in_spending_key(const BlsctTxIn* tx_in);
-const BlsctTokenId* get_tx_in_token_id(const BlsctTxIn* tx_in);
-const BlsctOutPoint* get_tx_in_out_point(const BlsctTxIn* tx_in);
-bool get_tx_in_staked_commitment(const BlsctTxIn* tx_in);
-bool get_tx_in_rbf(const BlsctTxIn* tx_in);
+BlsctUint64Result get_tx_in_amount(const BlsctTxInData* tx_in);
+BlsctScalarResult get_tx_in_gamma(const BlsctTxInData* tx_in);
+BlsctScalarResult get_tx_in_spending_key(const BlsctTxInData* tx_in);
+BlsctTokenIdResult get_tx_in_token_id(const BlsctTxInData* tx_in);
+BlsctOutPointResult get_tx_in_out_point(const BlsctTxInData* tx_in);
+BlsctBoolResult get_tx_in_staked_commitment(const BlsctTxInData* tx_in);
+BlsctBoolResult get_tx_in_rbf(const BlsctTxInData* tx_in);
 
 // tx out
-BlsctRetVal* build_tx_out(
+BlsctTxOutResult build_tx_out(
     const BlsctSubAddr* blsct_dest,
     const uint64_t amount,
     const char* memo_c_str,
@@ -642,17 +714,16 @@ BlsctRetVal* build_tx_out(
     const TxOutputType output_type,
     const uint64_t min_stake,
     const bool subtract_fee_from_amount,
-    const BlsctScalar* blsct_blinding_key
-);
+    const BlsctScalar* blsct_blinding_key);
 
-const BlsctSubAddr* get_tx_out_destination(const BlsctTxOut* tx_out);
-uint64_t get_tx_out_amount(const BlsctTxOut* tx_out);
-const char* get_tx_out_memo(const BlsctTxOut* tx_out);
-const BlsctTokenId* get_tx_out_token_id(const BlsctTxOut* tx_out);
-TxOutputType get_tx_out_output_type(const BlsctTxOut* tx_out);
-uint64_t get_tx_out_min_stake(const BlsctTxOut* tx_out);
-bool get_tx_out_subtract_fee_from_amount(const BlsctTxOut* tx_out);
-const BlsctScalar* get_tx_out_blinding_key(const BlsctTxOut* tx_out);
+BlsctSubAddrResult get_tx_out_destination(const BlsctTxOutData* tx_out);
+BlsctUint64Result get_tx_out_amount(const BlsctTxOutData* tx_out);
+BlsctStrResult get_tx_out_memo(const BlsctTxOutData* tx_out);
+BlsctTokenIdResult get_tx_out_token_id(const BlsctTxOutData* tx_out);
+BlsctTxOutputTypeResult get_tx_out_output_type(const BlsctTxOutData* tx_out);
+BlsctUint64Result get_tx_out_min_stake(const BlsctTxOutData* tx_out);
+BlsctBoolResult get_tx_out_subtract_fee_from_amount(const BlsctTxOutData* tx_out);
+BlsctScalarResult get_tx_out_blinding_key(const BlsctTxOutData* tx_out);
 
 // vector predicate
 int are_vector_predicate_equal(
@@ -660,80 +731,104 @@ int are_vector_predicate_equal(
     const size_t a_size,
     const BlsctVectorPredicate* b,
     const size_t b_size);
-const char* serialize_vector_predicate(
+BlsctSizeTResult serialize_vector_predicate(
+    const BlsctVectorPredicate* blsct_vector_predicate,
+    size_t obj_size,
+    char* buf,
+    size_t buf_size);
+BLSCT_RESULT deserialize_vector_predicate(
+    const char* hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctPredicateTypeResult get_vector_predicate_type(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-BlsctRetVal* deserialize_vector_predicate(
-    const char* hex);
-enum BlsctPredicateType get_vector_predicate_type(
-    const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
-BlsctRetVal* build_create_token_predicate(
-    const void* vp_token_info);
-BlsctRetVal* build_mint_token_predicate(
+BLSCT_RESULT build_create_token_predicate(
+    const char* token_info_hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_mint_token_predicate(
     const BlsctPubKey* blsct_token_public_key,
-    const uint64_t amount);
-BlsctRetVal* build_mint_nft_predicate(
+    const uint64_t amount,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_mint_nft_predicate(
     const BlsctPubKey* blsct_token_public_key,
     const uint64_t nft_id,
-    const void* vp_metadata);
-BlsctRetVal* get_create_token_predicate_token_info(
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT get_create_token_predicate_token_info(
+    const BlsctVectorPredicate* blsct_vector_predicate,
+    size_t obj_size,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctPubKeyResult get_mint_token_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-const BlsctPubKey* get_mint_token_predicate_public_key(
+BlsctUint64Result get_mint_token_predicate_amount(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-uint64_t get_mint_token_predicate_amount(
+BlsctPubKeyResult get_mint_nft_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-const BlsctPubKey* get_mint_nft_predicate_public_key(
+BlsctUint64Result get_mint_nft_predicate_nft_id(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-uint64_t get_mint_nft_predicate_nft_id(
+void get_mint_nft_predicate_metadata(
     const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
-void* get_mint_nft_predicate_metadata(
-    const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
+    size_t obj_size,
+    BlsctStringMapCallback cb,
+    void* user_data);
 
 // unsigned input/output/transaction helpers
-BlsctRetVal* build_unsigned_input(const BlsctTxIn* tx_in);
-void delete_unsigned_input(void* vp_unsigned_input);
-const char* serialize_unsigned_input(const void* vp_unsigned_input);
-BlsctRetVal* deserialize_unsigned_input(const char* hex);
+BLSCT_RESULT build_unsigned_input(const BlsctTxInData* tx_in, char* buf, size_t buf_size, size_t* out_len);
 
-BlsctRetVal* build_unsigned_output(const BlsctTxOut* tx_out);
-BlsctRetVal* build_unsigned_create_token_output(
+BLSCT_RESULT build_unsigned_output(const BlsctTxOutData* tx_out, char* buf, size_t buf_size, size_t* out_len);
+BLSCT_RESULT build_unsigned_create_token_output(
     const BlsctScalar* blsct_token_key,
-    const void* vp_token_info);
-BlsctRetVal* build_unsigned_mint_token_output(
+    const char* token_info_hex,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_unsigned_mint_token_output(
     const BlsctSubAddr* blsct_dest,
     const uint64_t amount,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
-    const BlsctPubKey* blsct_token_public_key);
-BlsctRetVal* build_unsigned_mint_nft_output(
+    const BlsctPubKey* blsct_token_public_key,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_unsigned_mint_nft_output(
     const BlsctSubAddr* blsct_dest,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
     const BlsctPubKey* blsct_token_public_key,
     const uint64_t nft_id,
-    const void* vp_metadata);
-void delete_unsigned_output(void* vp_unsigned_output);
-const char* serialize_unsigned_output(const void* vp_unsigned_output);
-BlsctRetVal* deserialize_unsigned_output(const char* hex);
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-void* create_unsigned_transaction();
-void add_unsigned_transaction_input(void* vp_unsigned_transaction, const void* vp_unsigned_input);
-void add_unsigned_transaction_output(void* vp_unsigned_transaction, const void* vp_unsigned_output);
-void set_unsigned_transaction_fee(void* vp_unsigned_transaction, const uint64_t fee);
-uint64_t get_unsigned_transaction_fee(const void* vp_unsigned_transaction);
-size_t get_unsigned_transaction_inputs_size(const void* vp_unsigned_transaction);
-size_t get_unsigned_transaction_outputs_size(const void* vp_unsigned_transaction);
-void delete_unsigned_transaction(void* vp_unsigned_transaction);
-const char* serialize_unsigned_transaction(const void* vp_unsigned_transaction);
-BlsctRetVal* deserialize_unsigned_transaction(const char* hex);
-BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction);
+// Build and sign a transaction from caller-supplied hex arrays.
+// input_hexes: array of n_inputs serialized UnsignedInput hex strings
+// output_hexes: array of n_outputs serialized UnsignedOutput hex strings
+// fee: transaction fee in satoshis
+BLSCT_RESULT sign_unsigned_transaction(
+    const char* const* input_hexes, size_t n_inputs,
+    const char* const* output_hexes, size_t n_outputs,
+    uint64_t fee,
+    char* buf, size_t buf_size, size_t* out_len);
 
 // key derivation functions
 
@@ -746,28 +841,28 @@ BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction);
 //                     +----> spending key (scalar)
 
 // from seed
-BlsctScalar* from_seed_to_child_key(
+BlsctScalarResult from_seed_to_child_key(
     const BlsctScalar* blsct_seed);
 
 // from child_key
-BlsctScalar* from_child_key_to_blinding_key(
+BlsctScalarResult from_child_key_to_blinding_key(
     const BlsctScalar* blsct_child_key);
 
-BlsctScalar* from_child_key_to_token_key(
+BlsctScalarResult from_child_key_to_token_key(
     const BlsctScalar* blsct_child_key);
 
-BlsctScalar* from_child_key_to_tx_key(
+BlsctScalarResult from_child_key_to_tx_key(
     const BlsctScalar* blsct_child_key);
 
 // from tx key
-BlsctScalar* from_tx_key_to_view_key(
+BlsctScalarResult from_tx_key_to_view_key(
     const BlsctScalar* blsct_tx_key);
 
-BlsctScalar* from_tx_key_to_spending_key(
+BlsctScalarResult from_tx_key_to_spending_key(
     const BlsctScalar* blsct_tx_key);
 
 // from multiple keys and other info
-BlsctScalar* calc_priv_spending_key(
+BlsctScalarResult calc_priv_spending_key(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* blsct_view_key,
     const BlsctScalar* blsct_spending_key,
@@ -775,11 +870,11 @@ BlsctScalar* calc_priv_spending_key(
     const uint64_t address);
 
 // blsct/wallet/helpers delegators
-uint64_t calc_view_tag(
+BlsctUint64Result calc_view_tag(
     const BlsctPubKey* blinding_pub_key,
     const BlsctScalar* view_key);
 
-BlsctPoint* calc_nonce(
+BlsctPointResult calc_nonce(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* view_key);
 
@@ -801,14 +896,9 @@ BlsctPoint* calc_nonce(
         return;                          \
     }
 
-BlsctRetVal* deserialize_hex(const char* hex);
-uint8_t* hex_to_malloced_buf(const char* hex);
-const char* buf_to_malloced_hex_c_str(const uint8_t* buf, size_t size);
+size_t buf_to_hex(const uint8_t* buf, size_t size, char* out, size_t out_size);
 
 // uint64 vector
-void* create_uint64_vec();
-void add_to_uint64_vec(void* vp_uint64_vec, const uint64_t n);
-void delete_uint64_vec(const void* vp_vec);
 
 } // extern "C"
 

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -35,6 +35,18 @@
 #define SIGNATURE_SIZE 96
 #define SCRIPT_SIZE 28
 #define MAX_MEMO_LEN 100
+
+#define BLSCT_SCALAR_HEX_SIZE (SCALAR_SIZE * 2 + 1)
+#define BLSCT_POINT_HEX_SIZE (POINT_SIZE * 2 + 1)
+#define BLSCT_DPK_HEX_SIZE (DOUBLE_PUBLIC_KEY_SIZE * 2 + 1)
+#define BLSCT_KEY_ID_HEX_SIZE (KEY_ID_SIZE * 2 + 1)
+#define BLSCT_SCRIPT_HEX_SIZE (SCRIPT_SIZE * 2 + 1)
+#define BLSCT_TOKEN_ID_HEX_SIZE (TOKEN_ID_SIZE * 2 + 1)
+#define BLSCT_CTX_ID_HEX_SIZE (CTX_ID_SIZE * 2 + 1)
+#define BLSCT_OUT_POINT_HEX_SIZE (OUT_POINT_SIZE * 2 + 1)
+#define BLSCT_SIGNATURE_HEX_SIZE (SIGNATURE_SIZE * 2 + 1)
+#define BLSCT_SUB_ADDR_HEX_SIZE (SUB_ADDR_SIZE * 2 + 1)
+#define BLSCT_SUB_ADDR_ID_HEX_SIZE (SUB_ADDR_ID_SIZE * 2 + 1)
 #define MEMO_BUF_SIZE MAX_MEMO_LEN + 1
 #define CTX_ID_SIZE UINT256_SIZE
 #define CTX_ID_STR_LEN CTX_ID_SIZE * 2
@@ -54,23 +66,7 @@
 #define BLSCT_MEMO_TOO_LONG 17
 #define BLSCT_MEM_ALLOC_FAILED 18
 #define BLSCT_DESER_FAILED 19
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct {
-    BLSCT_RESULT result;
-    void* value;
-    size_t value_size;
-} BlsctRetVal;
-
-BlsctRetVal* err(
-    BLSCT_RESULT result);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+#define BLSCT_INIT_NOT_CALLED 20
 
 #define TRY_DEFINE_MCL_POINT_FROM(src, dest)         \
     Point dest;                                      \
@@ -114,14 +110,12 @@ BlsctRetVal* err(
 
 #define BLSCT_COPY(src, dest) std::memcpy(dest, src, sizeof(dest))
 #define BLSCT_COPY_BYTES(src, dest, n) std::memcpy(dest, src, n)
-#define MALLOC_BYTES(T, name, n) T* name = (T*) malloc(n)
-#define RETURN_IF_MEM_ALLOC_FAILED(name) \
-if (name == nullptr) { \
-    fputs("Failed to allocate memory\n", stderr); \
-    return nullptr; \
-}
-#define RETURN_ERR_IF_MEM_ALLOC_FAILED(name) \
-    if (name == nullptr) err(BLSCT_MEM_ALLOC_FAILED);
+#define MALLOC_BYTES(T, name, n) T* name = (T*)malloc(n)
+#define RETURN_IF_MEM_ALLOC_FAILED(name)              \
+    if (name == nullptr) {                            \
+        fputs("Failed to allocate memory\n", stderr); \
+        return nullptr;                               \
+    }
 
 #define U8C(name) reinterpret_cast<const uint8_t*>(name)
 
@@ -141,51 +135,6 @@ inline bool TryParseHexWrap(
     return true;
 }
 
-inline const char* StrToAllocCStr(const std::string& s)
-{
-    size_t buf_size = s.size() + 1;
-    MALLOC_BYTES(char, cstr_buf, buf_size);
-    RETURN_IF_MEM_ALLOC_FAILED(cstr_buf);
-    std::memcpy(cstr_buf, s.c_str(), buf_size); // also copies null at the end
-    return cstr_buf;
-}
-
-inline const char* SerializeToHex(
-    const uint8_t* blsct_obj,
-    const size_t obj_size)
-{
-    if (blsct_obj == nullptr) return nullptr;
-
-    std::vector<uint8_t> vec;
-    vec.reserve(obj_size);
-    for (size_t i = 0; i < obj_size; ++i) {
-        vec.push_back(blsct_obj[i]);
-    }
-    auto hex_str = HexStr(vec);
-    return StrToAllocCStr(hex_str);
-}
-
-inline void* DeserializeFromHex(const char* hex, const size_t obj_size)
-{
-    std::vector<uint8_t> vec;
-    if (!TryParseHexWrap(hex, vec)) {
-        return err(BLSCT_FAILURE);
-    }
-
-    // check if the size is correct
-    if (vec.size() != obj_size) {
-        return err(BLSCT_BAD_SIZE);
-    }
-
-    void* blsct_obj = malloc(obj_size);
-    if (blsct_obj == nullptr) {
-        fputs("Failed to allocate memory\n", stderr);
-        return nullptr;
-    }
-    std::memcpy(blsct_obj, &vec[0], obj_size);
-
-    return blsct_obj;
-}
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,52 +189,121 @@ typedef uint8_t BlsctSubAddrId[SUB_ADDR_ID_SIZE];
 typedef uint8_t BlsctTokenId[TOKEN_ID_SIZE];
 typedef uint8_t BlsctUint256[UINT256_SIZE];
 
+typedef char BlsctScalarHex[BLSCT_SCALAR_HEX_SIZE];
+typedef char BlsctPointHex[BLSCT_POINT_HEX_SIZE];
+typedef char BlsctDoublePubKeyHex[BLSCT_DPK_HEX_SIZE];
+typedef char BlsctKeyIdHex[BLSCT_KEY_ID_HEX_SIZE];
+typedef char BlsctScriptHex[BLSCT_SCRIPT_HEX_SIZE];
+typedef char BlsctTokenIdHex[BLSCT_TOKEN_ID_HEX_SIZE];
+typedef char BlsctCTxIdHex[BLSCT_CTX_ID_HEX_SIZE];
+typedef char BlsctOutPointHex[BLSCT_OUT_POINT_HEX_SIZE];
+typedef char BlsctSignatureHex[BLSCT_SIGNATURE_HEX_SIZE];
+typedef char BlsctSubAddrHex[BLSCT_SUB_ADDR_HEX_SIZE];
+typedef char BlsctSubAddrIdHex[BLSCT_SUB_ADDR_ID_HEX_SIZE];
+
 typedef uint8_t BlsctCTx;
 typedef uint8_t BlsctRangeProof;
 typedef uint8_t BlsctVectorPredicate;
 
+/* Fixed-size typed result structs (value embedded inline) */
 typedef struct {
     BLSCT_RESULT result;
-    bool value;
-} BlsctBoolRetVal;
-
+    BlsctDoublePubKey value;
+} BlsctDoublePubKeyResult;
 typedef struct {
     BLSCT_RESULT result;
-    void* value; // = std::vector<BlsctAmountRecoveryResult>
-} BlsctAmountsRetVal;
-
+    BlsctKeyId value;
+} BlsctKeyIdResult;
 typedef struct {
     BLSCT_RESULT result;
-    void* ctx;
-
-    size_t in_amount_err_index;  // holds the first index of the tx_in whose amount exceeds the maximum
-    size_t out_amount_err_index; // holds the first index of the tx_out whose amount exceeds the maximum
-} BlsctCTxRetVal;
-
-BlsctRetVal* succ(
-    void* value,
-    size_t value_size);
-
-BlsctBoolRetVal* succ_bool(
-    bool value);
-
-BlsctBoolRetVal* err_bool(
-    BLSCT_RESULT result);
-
+    BlsctOutPoint value;
+} BlsctOutPointResult;
 typedef struct {
-    BlsctRangeProof* range_proof;
-    size_t range_proof_size;
-    BlsctPoint nonce;
-    BlsctTokenId token_id;
-} BlsctAmountRecoveryReq;
-
+    BLSCT_RESULT result;
+    BlsctPoint value;
+} BlsctPointResult;
 typedef struct {
-    bool is_succ;
-    char* msg;
-    uint64_t amount;
-    BlsctScalar gamma;
-} BlsctAmountRecoveryResult;
+    BLSCT_RESULT result;
+    BlsctPubKey value;
+} BlsctPubKeyResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScalar value;
+} BlsctScalarResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScript value;
+} BlsctScriptResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSignature value;
+} BlsctSignatureResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddr value;
+} BlsctSubAddrResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrId value;
+} BlsctSubAddrIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTokenId value;
+} BlsctTokenIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctUint256 value;
+} BlsctUint256Result;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctCTxId value;
+} BlsctCTxIdResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScalarHex value;
+} BlsctScalarHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctPointHex value;
+} BlsctPointHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctDoublePubKeyHex value;
+} BlsctDoublePubKeyHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctKeyIdHex value;
+} BlsctKeyIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctScriptHex value;
+} BlsctScriptHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTokenIdHex value;
+} BlsctTokenIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctCTxIdHex value;
+} BlsctCTxIdHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctOutPointHex value;
+} BlsctOutPointHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSignatureHex value;
+} BlsctSignatureHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrHex value;
+} BlsctSubAddrHexResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctSubAddrIdHex value;
+} BlsctSubAddrIdHexResult;
 
+/* Heap-pointer result structs (opaque C++ objects) */
 typedef struct {
     uint64_t amount;
     BlsctScalar gamma;
@@ -294,7 +312,7 @@ typedef struct {
     BlsctOutPoint out_point;
     bool staked_commitment;
     bool rbf;
-} BlsctTxIn;
+} BlsctTxInData;
 
 typedef struct {
     BlsctSubAddr dest;
@@ -305,231 +323,290 @@ typedef struct {
     uint64_t min_stake;
     bool subtract_fee_from_amount;
     BlsctScalar blinding_key;
-} BlsctTxOut;
+} BlsctTxOutData;
+
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTxInData value;
+} BlsctTxInResult;
+typedef struct {
+    BLSCT_RESULT result;
+    BlsctTxOutData value;
+} BlsctTxOutResult;
+typedef struct {
+    BLSCT_RESULT result;
+    bool value;
+} BlsctBoolResult;
+typedef struct {
+    BLSCT_RESULT result;
+    int64_t value;
+} BlsctInt64Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint64_t value;
+} BlsctUint64Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint32_t value;
+} BlsctUint32Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    uint16_t value;
+} BlsctUint16Result;
+
+typedef struct {
+    BLSCT_RESULT result;
+    size_t value;
+} BlsctSizeTResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    enum BlsctTokenType value;
+} BlsctTokenTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    TxOutputType value;
+} BlsctTxOutputTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    enum BlsctPredicateType value;
+} BlsctPredicateTypeResult;
+
+typedef struct {
+    BLSCT_RESULT result;
+    const char* value;
+} BlsctStrResult;
+
+typedef void (*BlsctStringMapCallback)(const char* key, const char* value, void* user_data);
+
+typedef struct {
+    BLSCT_RESULT result;
+    size_t in_amount_err_index;
+    size_t out_amount_err_index;
+} BlsctCTxResult;
+
+typedef struct {
+    BlsctRangeProof* range_proof;
+    size_t range_proof_size;
+    BlsctPoint nonce;
+    BlsctTokenId token_id;
+} BlsctAmountRecoveryReq;
+
+typedef struct {
+    bool is_succ;
+    char msg[MEMO_BUF_SIZE];
+    uint64_t amount;
+    BlsctScalar gamma;
+} BlsctAmountRecoveryResult;
 
 void free_obj(void* x);
-void free_amounts_ret_val(BlsctAmountsRetVal* rv); // free attrs as well
 void init();
+void uninit();
 
 enum BlsctChain get_blsct_chain();
 void set_blsct_chain(enum BlsctChain chain);
 
-const char* serialize_raw_obj(const uint8_t* ser_obj, size_t ser_obj_size);
-BlsctRetVal* deserialize_raw_obj(const char* hex);
+BlsctSizeTResult serialize_raw_obj(const uint8_t* ser_obj, size_t ser_obj_size, char* buf, size_t buf_size);
+BLSCT_RESULT deserialize_raw_obj(const char* hex, uint8_t* buf, size_t buf_size, size_t* out_len);
 
 // address
-BlsctRetVal* decode_address(
+BlsctDoublePubKeyResult decode_address(
     const char* blsct_enc_addr);
 
-BlsctRetVal* encode_address(
+BLSCT_RESULT encode_address(
     const void* void_blsct_dpk,
-    enum AddressEncoding encoding);
+    enum AddressEncoding encoding,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-// amount recovery request
-BlsctAmountRecoveryReq* gen_amount_recovery_req(
-    const void* vp_blsct_range_proof,
-    size_t range_proof_size,
-    const void* vp_blsct_nonce,
-    const void* vp_blsct_token_id);
-void* create_amount_recovery_req_vec();
-void add_to_amount_recovery_req_vec(
-    void* vp_amt_recovery_req_vec,
-    void* vp_amt_recovery_req);
-void delete_amount_recovery_req_vec(void* vp_amt_recovery_req_vec);
-
-// amountry recovery and the result result
-
-// returns a structure whose value field is
-// a vector of the same size as the input vector
-BlsctAmountsRetVal* recover_amount(
-    void* vp_amt_recovery_req_vec);
-
-size_t get_amount_recovery_result_size(
-    void* vp_amt_recovery_res_vec);
-bool get_amount_recovery_result_is_succ(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-uint64_t get_amount_recovery_result_amount(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-const char* get_amount_recovery_result_msg(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
-const BlsctScalar* get_amount_recovery_result_gamma(
-    void* vp_amt_recovery_req_vec,
-    size_t idx);
+// amount recovery
+// reqs[i].range_proof must point to caller-owned bytes (not freed by this function)
+// results must be an array of n elements; each entry is written inline
+BLSCT_RESULT recover_amount(
+    const BlsctAmountRecoveryReq* reqs,
+    size_t n,
+    BlsctAmountRecoveryResult* results);
 
 // ctx
-void* create_tx_in_vec();
-void add_to_tx_in_vec(void* vp_tx_in_vec, const BlsctTxIn* tx_in);
-void delete_tx_in_vec(void* vp_tx_in_vec);
-
-void* create_tx_out_vec();
-void add_to_tx_out_vec(void* vp_tx_out_vec, const BlsctTxOut* tx_out);
-void delete_tx_out_vec(void* vp_tx_out_vec);
-
-// returns a serialized CMutableTransaction
-BlsctCTxRetVal* build_ctx(
-    const void* void_tx_ins,
-    const void* void_tx_outs);
-// using void* instead of const void* to avoid const_cast
-const char* get_ctx_id(void* vp_ctx);
-const void* get_ctx_ins(void* vp_ctx);
-const void* get_ctx_outs(void* vp_ctx);
-void delete_ctx(void* vp_ctx);
-
-const char* serialize_ctx(void* vp_ctx);
-BlsctRetVal* deserialize_ctx(const char* hex);
+BlsctCTxResult build_ctx(
+    const BlsctTxInData* tx_ins,
+    size_t tx_ins_len,
+    const BlsctTxOutData* tx_outs,
+    size_t tx_outs_len,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctCTxIdHexResult get_ctx_id(const char* hex);
 
 // ctx id
-const char* serialize_ctx_id(const BlsctCTxId* blsct_ctx_id);
-BlsctRetVal* deserialize_ctx_id(const char* hex);
+BlsctCTxIdHexResult serialize_ctx_id(const BlsctCTxId* blsct_ctx_id);
+BlsctCTxIdResult deserialize_ctx_id(const char* hex);
 
 // signed transaction aggregation
-void* create_tx_hex_vec();
-void add_to_tx_hex_vec(void* vp_tx_hex_vec, const char* tx_hex);
-void delete_tx_hex_vec(void* vp_tx_hex_vec);
-BlsctRetVal* aggregate_transactions(const void* vp_tx_hex_vec);
+BLSCT_RESULT aggregate_transactions(const char* const* tx_hexes, size_t tx_count, char* buf, size_t buf_size, size_t* out_len);
 
-// ctx_ins
-bool are_ctx_ins_equal(const void* vp_a, const void* vp_b);
-size_t get_ctx_ins_size(const void* blsct_ctx_ins);
-const void* get_ctx_in_at(const void* vp_ctx_ins, size_t i);
+// ctx_ins (indexed access via hex)
+bool are_ctx_ins_equal(const char* hex_a, const char* hex_b);
+BlsctSizeTResult get_ctx_ins_size(const char* hex);
 
-// ctx in
+// ctx in (raw pointer accessors — for direct C++ object use)
 bool are_ctx_in_equal(const void* vp_a, const void* vp_b);
-const BlsctCTxId* get_ctx_in_prev_out_hash(const void* vp_ctx_in);
-const BlsctScript* get_ctx_in_script_sig(const void* vp_ctx_in);
-uint32_t get_ctx_in_sequence(const void* vp_ctx_in);
-const BlsctScript* get_ctx_in_script_witness(const void* vp_ctx_in);
+BlsctCTxIdResult get_ctx_in_prev_out_hash(const void* vp_ctx_in);
+BlsctScriptResult get_ctx_in_script_sig(const void* vp_ctx_in);
+BlsctUint32Result get_ctx_in_sequence(const void* vp_ctx_in);
+BlsctScriptResult get_ctx_in_script_witness(const void* vp_ctx_in);
 
-// ctx_outs
-bool are_ctx_outs_equal(const void* vp_a, const void* vp_b);
-size_t get_ctx_outs_size(const void* vp_ctx_outs);
-const void* get_ctx_out_at(const void* vp_ctx_outs, size_t i);
+// ctx in (indexed access via hex)
+BlsctCTxIdResult get_ctx_in_prev_out_hash_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_in_script_sig_at(const char* hex, size_t i);
+BlsctUint32Result get_ctx_in_sequence_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_in_script_witness_at(const char* hex, size_t i);
 
-// ctx out
+// ctx_outs (indexed access via hex)
+bool are_ctx_outs_equal(const char* hex_a, const char* hex_b);
+BlsctSizeTResult get_ctx_outs_size(const char* hex);
+
+// ctx out (raw pointer accessors — for direct C++ object use)
 bool are_ctx_out_equal(const void* vp_a, const void* vp_b);
-uint64_t get_ctx_out_value(const void* vp_ctx_out);
-const BlsctScript* get_ctx_out_script_pub_key(const void* vp_ctx_out);
-const BlsctTokenId* get_ctx_out_token_id(const void* vp_ctx_out);
-BlsctRetVal* get_ctx_out_vector_predicate(const void* vp_ctx_out);
+BlsctUint64Result get_ctx_out_value(const void* vp_ctx_out);
+BlsctScriptResult get_ctx_out_script_pub_key(const void* vp_ctx_out);
+BlsctTokenIdResult get_ctx_out_token_id(const void* vp_ctx_out);
+BLSCT_RESULT get_ctx_out_vector_predicate(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctPointResult get_ctx_out_spending_key(const void* vp_ctx_out);
+BlsctPointResult get_ctx_out_ephemeral_key(const void* vp_ctx_out);
+BlsctPointResult get_ctx_out_blinding_key(const void* vp_ctx_out);
+BLSCT_RESULT get_ctx_out_range_proof(const void* vp_ctx_out, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctUint16Result get_ctx_out_view_tag(const void* vp_ctx_out);
 
-// ctx out blsct data
-const BlsctPoint* get_ctx_out_spending_key(const void* vp_ctx_out);
-const BlsctPoint* get_ctx_out_ephemeral_key(const void* vp_jctx_out);
-const BlsctPoint* get_ctx_out_blinding_key(const void* vp_ctx_out);
-const BlsctRetVal* get_ctx_out_range_proof(const void* vp_ctx_out);
-uint16_t get_ctx_out_view_tag(const void* vp_ctx_out);
+// ctx out (indexed access via hex)
+BlsctUint64Result get_ctx_out_value_at(const char* hex, size_t i);
+BlsctScriptResult get_ctx_out_script_pub_key_at(const char* hex, size_t i);
+BlsctTokenIdResult get_ctx_out_token_id_at(const char* hex, size_t i);
+BLSCT_RESULT get_ctx_out_vector_predicate_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctPointResult get_ctx_out_spending_key_at(const char* hex, size_t i);
+BlsctPointResult get_ctx_out_ephemeral_key_at(const char* hex, size_t i);
+BlsctPointResult get_ctx_out_blinding_key_at(const char* hex, size_t i);
+BLSCT_RESULT get_ctx_out_range_proof_at(const char* hex, size_t i, uint8_t* buf, size_t buf_size, size_t* out_len);
+BlsctUint16Result get_ctx_out_view_tag_at(const char* hex, size_t i);
 
 // double public key
-BlsctRetVal* gen_double_pub_key(
+BlsctDoublePubKeyResult gen_double_pub_key(
     const BlsctPubKey* blsct_pk1,
     const BlsctPubKey* blsct_pk2);
 
-BlsctDoublePubKey* gen_dpk_with_keys_acct_addr(
+BlsctDoublePubKeyResult gen_dpk_with_keys_acct_addr(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     int64_t account,
     uint64_t address);
 
 
-BlsctRetVal* dpk_to_sub_addr(
+BlsctSubAddrResult dpk_to_sub_addr(
     const BlsctDoublePubKey* blsct_dpk);
 
-const char* serialize_dpk(const BlsctDoublePubKey* blsct_dpk);
-BlsctRetVal* deserialize_dpk(const char* hex);
+BlsctDoublePubKeyHexResult serialize_dpk(const BlsctDoublePubKey* blsct_dpk);
+BlsctDoublePubKeyResult deserialize_dpk(const char* hex);
 
 // key id (=Hash ID)
-BlsctKeyId* calc_key_id(
+BlsctKeyIdResult calc_key_id(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctScalar* blsct_view_key);
 
-const char* serialize_key_id(const BlsctKeyId* blsct_key_id);
-BlsctRetVal* deserialize_key_id(const char* hex);
+BlsctKeyIdHexResult serialize_key_id(const BlsctKeyId* blsct_key_id);
+BlsctKeyIdResult deserialize_key_id(const char* hex);
 
 // out point
 // txid is 32 bytes and represented as 64-char hex str
-BlsctRetVal* gen_out_point(
+BlsctOutPointResult gen_out_point(
     const char* ctx_id_c_str);
-const char* serialize_out_point(const BlsctOutPoint* blsct_out_point);
-BlsctRetVal* deserialize_out_point(const char* hex);
+BlsctOutPointHexResult serialize_out_point(const BlsctOutPoint* blsct_out_point);
+BlsctOutPointResult deserialize_out_point(const char* hex);
 
 // point
 int are_point_equal(const BlsctPoint* a, const BlsctPoint* b);
-BlsctRetVal* gen_base_point();
-BlsctRetVal* gen_random_point();
-BlsctPoint* scalar_muliply_point(
+BlsctPointResult gen_base_point();
+BlsctPointResult gen_random_point();
+BlsctPointResult scalar_muliply_point(
     const BlsctPoint* blsct_point,
-    const BlsctScalar* blsct_scalar
-);
-const char* point_to_str(const BlsctPoint* blsct_point);
-BlsctPoint* point_from_scalar(const BlsctScalar* blsct_scalar);
+    const BlsctScalar* blsct_scalar);
+BlsctSizeTResult point_to_str(const BlsctPoint* blsct_point, char* buf, size_t buf_size);
+BlsctPointResult point_from_scalar(const BlsctScalar* blsct_scalar);
 bool is_valid_point(const BlsctPoint* blsct_point);
 
-const char* serialize_point(const BlsctPoint* blsct_point);
-BlsctRetVal* deserialize_point(const char* hex);
+BlsctPointHexResult serialize_point(const BlsctPoint* blsct_point);
+BlsctPointResult deserialize_point(const char* hex);
 
 // public key
-BlsctRetVal* gen_random_public_key();
-BlsctPoint* get_public_key_point(const BlsctPubKey* blsct_pub_key);
-BlsctPubKey* point_to_public_key(const BlsctPoint* blsct_point);
-const char* serialize_public_key(const BlsctPoint* blsct_point);
-BlsctRetVal* deserialize_public_key(const char* hex);
+BlsctPubKeyResult gen_random_public_key();
+BlsctPointResult get_public_key_point(const BlsctPubKey* blsct_pub_key);
+BlsctPubKeyResult point_to_public_key(const BlsctPoint* blsct_point);
+BlsctPointHexResult serialize_public_key(const BlsctPoint* blsct_point);
+BlsctPubKeyResult deserialize_public_key(const char* hex);
 
 // range proof
-BlsctRetVal* build_range_proof(
-    const void* vp_uint64_vec,
+BLSCT_RESULT build_range_proof(
+    const uint64_t* amounts,
+    size_t amounts_len,
     const BlsctPoint* blsct_nonce,
     const char* blsct_msg,
-    const BlsctTokenId* blsct_token_id);
+    const BlsctTokenId* blsct_token_id,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-BlsctBoolRetVal* verify_range_proofs(
-    const void* vp_range_proofs);
+BlsctBoolResult verify_range_proofs(
+    const BlsctRangeProof* const* proofs,
+    const size_t* proof_sizes,
+    size_t proof_count);
 
-BlsctPoint* get_range_proof_A(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctPoint* get_range_proof_A_wip(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctPoint* get_range_proof_B(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
+BlsctPointResult get_range_proof_A(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctPointResult get_range_proof_A_wip(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctPointResult get_range_proof_B(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
 
-BlsctScalar* get_range_proof_r_prime(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctScalar* get_range_proof_s_prime(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctScalar* get_range_proof_delta_prime(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctScalar* get_range_proof_alpha_hat(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
-BlsctScalar* get_range_proof_tau_x(const BlsctRangeProof* blsct_range_proof, size_t range_proof_size);
+BlsctScalarResult get_range_proof_r_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_s_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_delta_prime(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_alpha_hat(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
+BlsctScalarResult get_range_proof_tau_x(const BlsctRangeProof* blsct_range_proof, const size_t range_proof_size);
 
-void* create_range_proof_vec();
-void add_to_range_proof_vec(
-    void* vp_range_proofs,
+
+BlsctSizeTResult serialize_range_proof(
     const BlsctRangeProof* blsct_range_proof,
-    size_t blsct_range_proof_size);
-void delete_range_proof_vec(const void* vp_range_proofs);
-
-const char* serialize_range_proof(
-    const BlsctRangeProof* blsct_range_proof,
-    size_t obj_size);
-BlsctRetVal* deserialize_range_proof(
+    size_t range_proof_size,
+    char* buf,
+    size_t buf_size);
+BLSCT_RESULT deserialize_range_proof(
     const char* hex,
-    size_t obj_size);
+    const size_t range_proof_size,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
 
 // scalar
 int are_scalar_equal(const BlsctScalar* a, const BlsctScalar* b);
-BlsctRetVal* gen_random_scalar();
-BlsctRetVal* gen_scalar(uint64_t n);
-uint64_t scalar_to_uint64(const BlsctScalar* blsct_scalar);
+BlsctScalarResult gen_random_scalar();
+BlsctScalarResult gen_scalar(const uint64_t n);
+BlsctUint64Result scalar_to_uint64(const BlsctScalar* blsct_scalar);
 
-const char* scalar_to_str(const BlsctScalar* blsct_scalar);
-BlsctPubKey* scalar_to_pub_key(const BlsctScalar* blsct_scalar);
+BlsctSizeTResult scalar_to_str(const BlsctScalar* blsct_scalar, char* buf, size_t buf_size);
+BlsctPubKeyResult scalar_to_pub_key(const BlsctScalar* blsct_scalar);
 
-const char* serialize_scalar(const BlsctScalar* blsct_scalar);
-BlsctRetVal* deserialize_scalar(const char* hex);
+BlsctScalarHexResult serialize_scalar(const BlsctScalar* blsct_scalar);
+BlsctScalarResult deserialize_scalar(const char* hex);
 
 // script
-const char* serialize_script(const BlsctScript* blsct_script);
-BlsctRetVal* deserialize_script(const char* hex);
+BlsctScriptHexResult serialize_script(const BlsctScript* blsct_script);
+BlsctScriptResult deserialize_script(const char* hex);
 
 // signature
-const BlsctSignature* sign_message(
+BlsctSignatureResult sign_message(
     const BlsctScalar* blsct_priv_key,
     const char* blsct_msg);
 
@@ -538,86 +615,81 @@ bool verify_msg_sig(
     const char* blsct_msg,
     const BlsctSignature* blsct_signature);
 
-const char* serialize_signature(const BlsctSignature* blsct_signature);
-BlsctRetVal* deserialize_signature(const char* hex);
+BlsctSignatureHexResult serialize_signature(const BlsctSignature* blsct_signature);
+BlsctSignatureResult deserialize_signature(const char* hex);
 
 // sub addr
-BlsctSubAddr* derive_sub_address(
+BlsctSubAddrResult derive_sub_address(
     const BlsctScalar* blsct_view_key,
     const BlsctPubKey* blsct_spending_pub_key,
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-BlsctDoublePubKey* sub_addr_to_dpk(
-    const BlsctSubAddr* blsct_sub_addr
-);
+BlsctDoublePubKeyResult sub_addr_to_dpk(
+    const BlsctSubAddr* blsct_sub_addr);
 
-const char* serialize_sub_addr(const BlsctSignature* blsct_sub_addr);
-BlsctRetVal* deserialize_sub_addr(const char* hex);
+BlsctSubAddrHexResult serialize_sub_addr(const BlsctSubAddr* blsct_sub_addr);
+BlsctSubAddrResult deserialize_sub_addr(const char* hex);
 
 // sub addr id
-BlsctSubAddrId* gen_sub_addr_id(
-    int64_t account,
-    uint64_t address);
+BlsctSubAddrIdResult gen_sub_addr_id(
+    const int64_t account,
+    const uint64_t address);
 
-int64_t get_sub_addr_id_account(
+BlsctInt64Result get_sub_addr_id_account(
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-uint64_t get_sub_addr_id_address(
+BlsctUint64Result get_sub_addr_id_address(
     const BlsctSubAddrId* blsct_sub_addr_id);
 
-const char* serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id);
-BlsctRetVal* deserialize_sub_addr_id(const char* hex);
+BlsctSubAddrIdHexResult serialize_sub_addr_id(const BlsctSubAddrId* blsct_sub_addr_id);
+BlsctSubAddrIdResult deserialize_sub_addr_id(const char* hex);
 
 // token id
-BlsctRetVal* gen_token_id_with_token_and_subid(
-    uint64_t token,
-    uint64_t subid);
+BlsctTokenIdResult gen_token_id_with_token_and_subid(
+    const uint64_t token,
+    const uint64_t subid);
 
-BlsctRetVal* gen_token_id(
-    uint64_t token);
+BlsctTokenIdResult gen_token_id(
+    const uint64_t token);
 
-BlsctRetVal* gen_default_token_id();
-uint64_t get_token_id_token(const BlsctTokenId* blsct_token_id);
-uint64_t get_token_id_subid(const BlsctTokenId* blsct_token_id);
-const char* serialize_token_id(const BlsctTokenId* blsct_token_id);
-BlsctRetVal* deserialize_token_id(const char* hex);
-
-// generic string map helpers
-void* create_string_map();
-void add_to_string_map(void* vp_string_map, const char* key, const char* value);
-void delete_string_map(const void* vp_string_map);
-size_t get_string_map_size(const void* vp_string_map);
-const char* get_string_map_key_at(const void* vp_string_map, size_t idx);
-const char* get_string_map_value_at(const void* vp_string_map, size_t idx);
+BlsctTokenIdResult gen_default_token_id();
+BlsctUint64Result get_token_id_token(const BlsctTokenId* blsct_token_id);
+BlsctUint64Result get_token_id_subid(const BlsctTokenId* blsct_token_id);
+BlsctTokenIdHexResult serialize_token_id(const BlsctTokenId* blsct_token_id);
+BlsctTokenIdResult deserialize_token_id(const char* hex);
 
 // token info helpers
-BlsctRetVal* build_token_info(
+BLSCT_RESULT build_token_info(
     enum BlsctTokenType type,
     const BlsctPubKey* blsct_public_key,
-    const void* vp_metadata,
-    uint64_t total_supply);
-void delete_token_info(void* vp_token_info);
-const char* serialize_token_info(const void* vp_token_info);
-BlsctRetVal* deserialize_token_info(const char* hex);
-enum BlsctTokenType get_token_info_type(const void* vp_token_info);
-const BlsctPubKey* get_token_info_public_key(const void* vp_token_info);
-uint64_t get_token_info_total_supply(const void* vp_token_info);
-void* get_token_info_metadata(const void* vp_token_info);
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    const uint64_t total_supply,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctTokenTypeResult get_token_info_type(const char* hex);
+BlsctPubKeyResult get_token_info_public_key(const char* hex);
+BlsctUint64Result get_token_info_total_supply(const char* hex);
+void get_token_info_metadata(const char* hex, BlsctStringMapCallback cb, void* user_data);
 
 // collection token hash and token key derivation
-BlsctRetVal* calc_collection_token_hash(
-    const void* vp_metadata,
-    uint64_t total_supply);
-BlsctRetVal* derive_collection_token_key(
+BlsctUint256Result calc_collection_token_hash(
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    const uint64_t total_supply);
+BlsctScalarResult derive_collection_token_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash);
-const BlsctPubKey* derive_collection_token_public_key(
+BlsctPubKeyResult derive_collection_token_public_key(
     const BlsctScalar* blsct_master_token_key,
     const BlsctUint256* blsct_collection_token_hash);
 
 // tx in
-BlsctRetVal* build_tx_in(
-    uint64_t amount,
+BlsctTxInResult build_tx_in(
+    const uint64_t amount,
     const BlsctScalar* gamma,
     const BlsctScalar* spending_key,
     const BlsctTokenId* token_id,
@@ -625,115 +697,138 @@ BlsctRetVal* build_tx_in(
     bool staked_commitment,
     bool rbf);
 
-uint64_t get_tx_in_amount(const BlsctTxIn* tx_in);
-const BlsctScalar* get_tx_in_gamma(const BlsctTxIn* tx_in);
-const BlsctScalar* get_tx_in_spending_key(const BlsctTxIn* tx_in);
-const BlsctTokenId* get_tx_in_token_id(const BlsctTxIn* tx_in);
-const BlsctOutPoint* get_tx_in_out_point(const BlsctTxIn* tx_in);
-bool get_tx_in_staked_commitment(const BlsctTxIn* tx_in);
-bool get_tx_in_rbf(const BlsctTxIn* tx_in);
+BlsctUint64Result get_tx_in_amount(const BlsctTxInData* tx_in);
+BlsctScalarResult get_tx_in_gamma(const BlsctTxInData* tx_in);
+BlsctScalarResult get_tx_in_spending_key(const BlsctTxInData* tx_in);
+BlsctTokenIdResult get_tx_in_token_id(const BlsctTxInData* tx_in);
+BlsctOutPointResult get_tx_in_out_point(const BlsctTxInData* tx_in);
+BlsctBoolResult get_tx_in_staked_commitment(const BlsctTxInData* tx_in);
+BlsctBoolResult get_tx_in_rbf(const BlsctTxInData* tx_in);
 
 // tx out
-BlsctRetVal* build_tx_out(
+BlsctTxOutResult build_tx_out(
     const BlsctSubAddr* blsct_dest,
     uint64_t amount,
     const char* memo_c_str,
     const BlsctTokenId* blsct_token_id,
-    TxOutputType output_type,
-    uint64_t min_stake,
-    bool subtract_fee_from_amount,
-    const BlsctScalar* blsct_blinding_key
-);
+    const TxOutputType output_type,
+    const uint64_t min_stake,
+    const bool subtract_fee_from_amount,
+    const BlsctScalar* blsct_blinding_key);
 
-const BlsctSubAddr* get_tx_out_destination(const BlsctTxOut* tx_out);
-uint64_t get_tx_out_amount(const BlsctTxOut* tx_out);
-const char* get_tx_out_memo(const BlsctTxOut* tx_out);
-const BlsctTokenId* get_tx_out_token_id(const BlsctTxOut* tx_out);
-TxOutputType get_tx_out_output_type(const BlsctTxOut* tx_out);
-uint64_t get_tx_out_min_stake(const BlsctTxOut* tx_out);
-bool get_tx_out_subtract_fee_from_amount(const BlsctTxOut* tx_out);
-const BlsctScalar* get_tx_out_blinding_key(const BlsctTxOut* tx_out);
+BlsctSubAddrResult get_tx_out_destination(const BlsctTxOutData* tx_out);
+BlsctUint64Result get_tx_out_amount(const BlsctTxOutData* tx_out);
+BlsctStrResult get_tx_out_memo(const BlsctTxOutData* tx_out);
+BlsctTokenIdResult get_tx_out_token_id(const BlsctTxOutData* tx_out);
+BlsctTxOutputTypeResult get_tx_out_output_type(const BlsctTxOutData* tx_out);
+BlsctUint64Result get_tx_out_min_stake(const BlsctTxOutData* tx_out);
+BlsctBoolResult get_tx_out_subtract_fee_from_amount(const BlsctTxOutData* tx_out);
+BlsctScalarResult get_tx_out_blinding_key(const BlsctTxOutData* tx_out);
 
 // vector predicate
 int are_vector_predicate_equal(
     const BlsctVectorPredicate* a,
     size_t a_size,
     const BlsctVectorPredicate* b,
-    size_t b_size);
-const char* serialize_vector_predicate(
+    const size_t b_size);
+BlsctSizeTResult serialize_vector_predicate(
+    const BlsctVectorPredicate* blsct_vector_predicate,
+    size_t obj_size,
+    char* buf,
+    size_t buf_size);
+BLSCT_RESULT deserialize_vector_predicate(
+    const char* hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctPredicateTypeResult get_vector_predicate_type(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-BlsctRetVal* deserialize_vector_predicate(
-    const char* hex);
-enum BlsctPredicateType get_vector_predicate_type(
-    const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
-BlsctRetVal* build_create_token_predicate(
-    const void* vp_token_info);
-BlsctRetVal* build_mint_token_predicate(
+BLSCT_RESULT build_create_token_predicate(
+    const char* token_info_hex,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_mint_token_predicate(
     const BlsctPubKey* blsct_token_public_key,
-    uint64_t amount);
-BlsctRetVal* build_mint_nft_predicate(
+    const uint64_t amount,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_mint_nft_predicate(
     const BlsctPubKey* blsct_token_public_key,
-    uint64_t nft_id,
-    const void* vp_metadata);
-BlsctRetVal* get_create_token_predicate_token_info(
+    const uint64_t nft_id,
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    uint8_t* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT get_create_token_predicate_token_info(
+    const BlsctVectorPredicate* blsct_vector_predicate,
+    size_t obj_size,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BlsctPubKeyResult get_mint_token_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-const BlsctPubKey* get_mint_token_predicate_public_key(
+BlsctUint64Result get_mint_token_predicate_amount(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-uint64_t get_mint_token_predicate_amount(
+BlsctPubKeyResult get_mint_nft_predicate_public_key(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-const BlsctPubKey* get_mint_nft_predicate_public_key(
+BlsctUint64Result get_mint_nft_predicate_nft_id(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size);
-uint64_t get_mint_nft_predicate_nft_id(
+void get_mint_nft_predicate_metadata(
     const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
-void* get_mint_nft_predicate_metadata(
-    const BlsctVectorPredicate* blsct_vector_predicate,
-    size_t obj_size);
+    size_t obj_size,
+    BlsctStringMapCallback cb,
+    void* user_data);
 
 // unsigned input/output/transaction helpers
-BlsctRetVal* build_unsigned_input(const BlsctTxIn* tx_in);
-void delete_unsigned_input(void* vp_unsigned_input);
-const char* serialize_unsigned_input(const void* vp_unsigned_input);
-BlsctRetVal* deserialize_unsigned_input(const char* hex);
+BLSCT_RESULT build_unsigned_input(const BlsctTxInData* tx_in, char* buf, size_t buf_size, size_t* out_len);
 
-BlsctRetVal* build_unsigned_output(const BlsctTxOut* tx_out);
-BlsctRetVal* build_unsigned_create_token_output(
+BLSCT_RESULT build_unsigned_output(const BlsctTxOutData* tx_out, char* buf, size_t buf_size, size_t* out_len);
+BLSCT_RESULT build_unsigned_create_token_output(
     const BlsctScalar* blsct_token_key,
-    const void* vp_token_info);
-BlsctRetVal* build_unsigned_mint_token_output(
+    const char* token_info_hex,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_unsigned_mint_token_output(
     const BlsctSubAddr* blsct_dest,
     uint64_t amount,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
-    const BlsctPubKey* blsct_token_public_key);
-BlsctRetVal* build_unsigned_mint_nft_output(
+    const BlsctPubKey* blsct_token_public_key,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
+BLSCT_RESULT build_unsigned_mint_nft_output(
     const BlsctSubAddr* blsct_dest,
     const BlsctScalar* blsct_blinding_key,
     const BlsctScalar* blsct_token_key,
     const BlsctPubKey* blsct_token_public_key,
-    uint64_t nft_id,
-    const void* vp_metadata);
-void delete_unsigned_output(void* vp_unsigned_output);
-const char* serialize_unsigned_output(const void* vp_unsigned_output);
-BlsctRetVal* deserialize_unsigned_output(const char* hex);
+    const uint64_t nft_id,
+    const char* const* metadata_keys,
+    const char* const* metadata_values,
+    size_t metadata_count,
+    char* buf,
+    size_t buf_size,
+    size_t* out_len);
 
-void* create_unsigned_transaction();
-void add_unsigned_transaction_input(void* vp_unsigned_transaction, const void* vp_unsigned_input);
-void add_unsigned_transaction_output(void* vp_unsigned_transaction, const void* vp_unsigned_output);
-void set_unsigned_transaction_fee(void* vp_unsigned_transaction, uint64_t fee);
-uint64_t get_unsigned_transaction_fee(const void* vp_unsigned_transaction);
-size_t get_unsigned_transaction_inputs_size(const void* vp_unsigned_transaction);
-size_t get_unsigned_transaction_outputs_size(const void* vp_unsigned_transaction);
-void delete_unsigned_transaction(void* vp_unsigned_transaction);
-const char* serialize_unsigned_transaction(const void* vp_unsigned_transaction);
-BlsctRetVal* deserialize_unsigned_transaction(const char* hex);
-BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction);
+// Build and sign a transaction from caller-supplied hex arrays.
+// input_hexes: array of n_inputs serialized UnsignedInput hex strings
+// output_hexes: array of n_outputs serialized UnsignedOutput hex strings
+// fee: transaction fee in satoshis
+BLSCT_RESULT sign_unsigned_transaction(
+    const char* const* input_hexes, size_t n_inputs,
+    const char* const* output_hexes, size_t n_outputs,
+    uint64_t fee,
+    char* buf, size_t buf_size, size_t* out_len);
 
 // key derivation functions
 
@@ -746,28 +841,28 @@ BlsctRetVal* sign_unsigned_transaction(const void* vp_unsigned_transaction);
 //                     +----> spending key (scalar)
 
 // from seed
-BlsctScalar* from_seed_to_child_key(
+BlsctScalarResult from_seed_to_child_key(
     const BlsctScalar* blsct_seed);
 
 // from child_key
-BlsctScalar* from_child_key_to_blinding_key(
+BlsctScalarResult from_child_key_to_blinding_key(
     const BlsctScalar* blsct_child_key);
 
-BlsctScalar* from_child_key_to_token_key(
+BlsctScalarResult from_child_key_to_token_key(
     const BlsctScalar* blsct_child_key);
 
-BlsctScalar* from_child_key_to_tx_key(
+BlsctScalarResult from_child_key_to_tx_key(
     const BlsctScalar* blsct_child_key);
 
 // from tx key
-BlsctScalar* from_tx_key_to_view_key(
+BlsctScalarResult from_tx_key_to_view_key(
     const BlsctScalar* blsct_tx_key);
 
-BlsctScalar* from_tx_key_to_spending_key(
+BlsctScalarResult from_tx_key_to_spending_key(
     const BlsctScalar* blsct_tx_key);
 
 // from multiple keys and other info
-BlsctScalar* calc_priv_spending_key(
+BlsctScalarResult calc_priv_spending_key(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* blsct_view_key,
     const BlsctScalar* blsct_spending_key,
@@ -775,11 +870,11 @@ BlsctScalar* calc_priv_spending_key(
     uint64_t address);
 
 // blsct/wallet/helpers delegators
-uint64_t calc_view_tag(
+BlsctUint64Result calc_view_tag(
     const BlsctPubKey* blinding_pub_key,
     const BlsctScalar* view_key);
 
-BlsctPoint* calc_nonce(
+BlsctPointResult calc_nonce(
     const BlsctPubKey* blsct_blinding_pub_key,
     const BlsctScalar* view_key);
 
@@ -801,14 +896,9 @@ BlsctPoint* calc_nonce(
         return;                          \
     }
 
-BlsctRetVal* deserialize_hex(const char* hex);
-uint8_t* hex_to_malloced_buf(const char* hex);
-const char* buf_to_malloced_hex_c_str(const uint8_t* buf, size_t size);
+size_t buf_to_hex(const uint8_t* buf, size_t size, char* out, size_t out_size);
 
 // uint64 vector
-void* create_uint64_vec();
-void add_to_uint64_vec(void* vp_uint64_vec, uint64_t n);
-void delete_uint64_vec(const void* vp_vec);
 
 } // extern "C"
 

--- a/src/blsct/external_api/blsct.h
+++ b/src/blsct/external_api/blsct.h
@@ -730,7 +730,7 @@ int are_vector_predicate_equal(
     const BlsctVectorPredicate* a,
     size_t a_size,
     const BlsctVectorPredicate* b,
-    const size_t b_size);
+    size_t b_size);
 BlsctSizeTResult serialize_vector_predicate(
     const BlsctVectorPredicate* blsct_vector_predicate,
     size_t obj_size,

--- a/src/test/blsct/external_api/external_api_tests.cpp
+++ b/src/test/blsct/external_api/external_api_tests.cpp
@@ -2,29 +2,29 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <blsct/eip_2333/bls12_381_keygen.h>
 #include <blsct/external_api/blsct.h>
 #include <blsct/range_proof/bulletproofs_plus/range_proof_logic.h>
-#include <util/strencodings.h>
-#include <blsct/eip_2333/bls12_381_keygen.h>
 #include <blsct/tokens/predicate_parser.h>
+#include <blsct/wallet/txfactory.h>
 #include <blsct/wallet/unsigned_transaction.h>
+#include <blsct/wallet/verification.h>
 #include <core_io.h>
 #include <hash.h>
-#include <blsct/wallet/txfactory.h>
-#include <blsct/wallet/verification.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <txdb.h>
+#include <util/strencodings.h>
 #include <wallet/receive.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-#include <iostream>
 
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(external_api_tests, BasicTestingSetup)
 
-uint8_t hex_to_uint(char c) {
+uint8_t hex_to_uint(char c)
+{
     if (c >= '0' && c <= '9') {
         return c - '0';
     } else if (c >= 'a' && c <= 'f') {
@@ -34,29 +34,24 @@ uint8_t hex_to_uint(char c) {
     }
 }
 
-template <typename T>
-T& RequireSuccess(BlsctRetVal* rv)
+static std::map<std::string, std::string> g_collected_map;
+static void CollectMapEntry(const char* key, const char* value, void* /*user_data*/)
 {
-    BOOST_REQUIRE(rv != nullptr);
-    BOOST_REQUIRE_EQUAL(rv->result, BLSCT_SUCCESS);
-    BOOST_REQUIRE(rv->value != nullptr);
-    return *static_cast<T*>(rv->value);
+    g_collected_map[key] = value;
 }
 
-static std::map<std::string, std::string> ReadStringMap(const void* vp_string_map)
+static std::map<std::string, std::string> ReadTokenInfoMetadata(const char* hex)
 {
-    std::map<std::string, std::string> out;
-    const size_t size = get_string_map_size(vp_string_map);
-    for (size_t i = 0; i < size; ++i) {
-        const char* key = get_string_map_key_at(vp_string_map, i);
-        const char* value = get_string_map_value_at(vp_string_map, i);
-        BOOST_REQUIRE(key != nullptr);
-        BOOST_REQUIRE(value != nullptr);
-        out[key] = value;
-        free_obj((void*)key);
-        free_obj((void*)value);
-    }
-    return out;
+    g_collected_map.clear();
+    get_token_info_metadata(hex, CollectMapEntry, nullptr);
+    return g_collected_map;
+}
+
+static std::map<std::string, std::string> ReadMintNftMetadata(const uint8_t* pred, size_t len)
+{
+    g_collected_map.clear();
+    get_mint_nft_predicate_metadata(pred, len, CollectMapEntry, nullptr);
+    return g_collected_map;
 }
 
 // This test checks if there is any structural change in
@@ -68,14 +63,14 @@ BOOST_AUTO_TEST_CASE(test_cmutable_transaction_sizes)
     std::string tx_hex = "200000000100000000000000000000000000000000000000000000000000000000000000000503615d0200ffffffff02ffffffffffffff7f0100000000000000015101855f4e35c5fbe93bf5b8a7a2dc55420144388fd0736ce7d9c8289e793da409d89f2bf2f4f4ac9364d81922d9255c33880683ed1c387aa2555b28af1c6d2b4a2725af9551263c00962daeec3736de0724167d18579973ff9cfcaeedc9ed59036aaaa2ad79cef575dc618d14729169a88c87edb5d3303efab1109572ca4a98800d61c45d8ca9074a7beb9c5c4123e7af8054b4bce1a360c663b86e8af1f06dea120fce8d7529b90ff383fd69c7dd9a50215881df91544949b95eaeac780c133699bdb030b321c32c0efbafa29fe840fe93b01bffc47e096a4577f5ba7d6745506f5e658cbd21c0c7f4c5fc28fdb28dd1c27a8027da5ca650a48ced1c52725abc54a1bd54e9823341753de270ea7882fd54b5b7513d9184635b9dbf0812ccf769df4cb50985bfa52fa515fa7034a317b2da1453d2d919797a22e6889c8aada6fe25e2dfda8f57f57de8fc2a9fa957d264240d06b8548ad7eec8b644df2e89b9a5a1d83ecce4ca94005b7d61782743e74ed011f7cc96c634327b67cfbc954de4effa0d7884f88d27ac1c1686bad02f527975ed9f3e7b2570120dc68ad88ddd350119d00c6df24916d5fc361f20f4f4d4482711b5850b3f91c9315beb1af544d63ed7049b6a1af783e0171526ba9c31466de735527d2d1bfeaf292a73ecf0312e6e784ae18dc6949e4a452fadc0734bff7bdf56074434f7a311290ba2ec6cbe960e29829d2b8ad6fb7946e356580b5a40f9676274a8336c5eecc36a9ddb58bb81cd8d08dfda7714aa9634941a94076cbc3ed74561d9043146dc81f1ccafd4e06f98faae3da017fe07af9ac407d0b81e6e1e634e5b53f5f98728850298673e355093844d0443466fad33d233ed7c40c1788a43d4d48d63778e8cf80e9cd5d01e789637b0cae99a372dd0bc8b5dbf2bc2df9fea229d71eaebab6a9277bb3bb3ba07c14edef6a7fcdcf02e8c1e927872003b9683d3b3ff1e740d5ec8a8145361166b33da8dcda6edf5d7bf32f63d27a5b72e515e6641b672275eee06f3bd5abd6790eded07d49b9e55e5c29e136eb5ad4857f9f55b6e7be10d2002ed91244243ea0fe7b6dea43ea70eb0d3d438ae2a335ced8e1620392562a2c503d2c4b53bed0d39c3749cb032741cacd0ca73bc6d72d350184cc82a45ad8df2e3443599ba51dfd5dce328362f9032cb350f579234f36c282d4b0acdf27d6a8d66f62713adf6481c8c9f240f59a15c6e064a5c05b56e6c068801f639ee1e83003a6a8dd97d5c24b5236c30d43efa0d75709fcaba4ca72077232f537900b2697973d2a08ee405d4298d4a8afeb24f6066b9648b3265e10931756678606fc173b92525567648af5408ff6af65eece8bbe70c671f9f8b94f012dd97eb3f8efcbeae6b34fc2fa3932ffac63b68c7167eeea1b7798872c92e40c057663cd1bdd07ce887a175b0feb74c394f9232dbaf3c8bd84e5624c2b6ca3605cfe3a1acfd1c5871a54d5a5b497588916840d422eeabc75d528275e0f7db46d95654ec9453c20000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9000000008a8c3b2f2bafb7b71f9192b2b8e02df5caf27c04b535ef577c0703f820a110155984f294bc01fccaf6957b622156a97712e57526ce7ef914af67e7aea2fd3daf8a4176660300ea64be6ab6c87b1a597cb96f7d5ac0ab59fe115190bc33946ba3";
 
     DataStream st{ParseHex(tx_hex)};
-    TransactionSerParams params { .allow_witness = true };
-    ParamsStream ps {params, st};
+    TransactionSerParams params{.allow_witness = true};
+    ParamsStream ps{params, st};
 
     CMutableTransaction tx;
 
     try {
         tx.Unserialize(ps); // should not throw an exception
-    } catch(...) {
+    } catch (...) {
         BOOST_CHECK(false);
     }
 }
@@ -86,26 +81,26 @@ BOOST_AUTO_TEST_CASE(test_build_tx_in_gamma_is_blsct_scalar)
 
     // create a random scalar to use as gamma
     auto gamma_rv = gen_random_scalar();
-    BOOST_REQUIRE(gamma_rv->result == BLSCT_SUCCESS);
-    auto* gamma = static_cast<BlsctScalar*>(gamma_rv->value);
+    BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+    auto* gamma = &gamma_rv.value;
 
     // create a spending key
     auto sk_rv = gen_random_scalar();
-    BOOST_REQUIRE(sk_rv->result == BLSCT_SUCCESS);
-    auto* spending_key = static_cast<BlsctScalar*>(sk_rv->value);
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+    auto* spending_key = &sk_rv.value;
 
     // create a token id
     auto tid_rv = gen_default_token_id();
-    BOOST_REQUIRE(tid_rv->result == BLSCT_SUCCESS);
-    auto* token_id = static_cast<BlsctTokenId*>(tid_rv->value);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    auto* token_id = &tid_rv.value;
 
     // create an out point
     std::string txid_hex(64, '0');
     auto op_rv = gen_out_point(txid_hex.c_str());
-    BOOST_REQUIRE(op_rv->result == BLSCT_SUCCESS);
-    auto* out_point = static_cast<BlsctOutPoint*>(op_rv->value);
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+    auto* out_point = &op_rv.value;
 
-    auto* tx_in_rv = build_tx_in(
+    auto tx_in_rv = build_tx_in(
         1000,
         gamma,
         spending_key,
@@ -113,22 +108,18 @@ BOOST_AUTO_TEST_CASE(test_build_tx_in_gamma_is_blsct_scalar)
         out_point,
         false,
         false);
-    BOOST_REQUIRE(tx_in_rv->result == BLSCT_SUCCESS);
-    auto* tx_in = static_cast<BlsctTxIn*>(tx_in_rv->value);
+    BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
+    auto* tx_in = &tx_in_rv.value;
 
     // verify the amount round-trips
-    BOOST_CHECK_EQUAL(get_tx_in_amount(tx_in), 1000ULL);
+    auto amt_rv = get_tx_in_amount(tx_in);
+    BOOST_REQUIRE_EQUAL(amt_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(amt_rv.value, 1000ULL);
 
     // verify the gamma round-trips as a full 32-byte scalar
-    const BlsctScalar* retrieved_gamma = get_tx_in_gamma(tx_in);
-    BOOST_REQUIRE(retrieved_gamma != nullptr);
-    BOOST_CHECK(are_scalar_equal(gamma, retrieved_gamma) == 1);
-
-    free_obj(gamma_rv);
-    free_obj(sk_rv);
-    free_obj(tid_rv);
-    free_obj(op_rv);
-    free_obj(tx_in_rv);
+    BlsctScalarResult retrieved_gamma_rv = get_tx_in_gamma(tx_in);
+    BOOST_REQUIRE_EQUAL(retrieved_gamma_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(are_scalar_equal(gamma, &retrieved_gamma_rv.value) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_amount_recovery_returns_gamma)
@@ -140,8 +131,8 @@ BOOST_AUTO_TEST_CASE(test_amount_recovery_returns_gamma)
     std::vector<uint8_t> msg_vec(msg.begin(), msg.end());
 
     auto tid_rv = gen_default_token_id();
-    BOOST_REQUIRE(tid_rv->result == BLSCT_SUCCESS);
-    auto* blsct_token_id = static_cast<BlsctTokenId*>(tid_rv->value);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    auto* blsct_token_id = &tid_rv.value;
 
     TokenId token_id;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id, TOKEN_ID_SIZE, token_id);
@@ -171,31 +162,23 @@ BOOST_AUTO_TEST_CASE(test_amount_recovery_returns_gamma)
     BlsctPoint blsct_nonce;
     SERIALIZE_AND_COPY(nonce, blsct_nonce);
 
-    auto* req = gen_amount_recovery_req(rp_buf, rp_size, &blsct_nonce, nullptr);
-    BOOST_REQUIRE(req != nullptr);
+    BlsctAmountRecoveryReq req{};
+    req.range_proof = rp_buf;
+    req.range_proof_size = rp_size;
+    std::memcpy(req.nonce, blsct_nonce, POINT_SIZE);
+    std::memcpy(req.token_id, tid_rv.value, TOKEN_ID_SIZE);
 
-    void* req_vec = create_amount_recovery_req_vec();
-    add_to_amount_recovery_req_vec(req_vec, req);
-
-    auto* amounts_rv = recover_amount(req_vec);
-    BOOST_REQUIRE(amounts_rv->result == BLSCT_SUCCESS);
-
-    BOOST_CHECK(get_amount_recovery_result_is_succ(amounts_rv->value, 0));
-    BOOST_CHECK_EQUAL(get_amount_recovery_result_amount(amounts_rv->value, 0), amount);
+    BlsctAmountRecoveryResult result{};
+    BOOST_REQUIRE_EQUAL(recover_amount(&req, 1, &result), BLSCT_SUCCESS);
+    BOOST_CHECK(result.is_succ);
+    BOOST_CHECK_EQUAL(result.amount, amount);
 
     // verify the gamma matches the expected value from the C++ recovery
-    const BlsctScalar* recovered_gamma = get_amount_recovery_result_gamma(amounts_rv->value, 0);
-    BOOST_REQUIRE(recovered_gamma != nullptr);
-
     BlsctScalar expected_gamma_bytes;
     SERIALIZE_AND_COPY(expected_gamma, expected_gamma_bytes);
-    BOOST_CHECK(are_scalar_equal(recovered_gamma, &expected_gamma_bytes) == 1);
+    BOOST_CHECK(are_scalar_equal(&result.gamma, &expected_gamma_bytes) == 1);
 
     free(rp_buf);
-    delete req;
-    delete_amount_recovery_req_vec(req_vec);
-    free_amounts_ret_val(amounts_rv);
-    free_obj(tid_rv);
 }
 
 BOOST_AUTO_TEST_CASE(test_recovered_gamma_round_trips_through_tx_in)
@@ -207,8 +190,8 @@ BOOST_AUTO_TEST_CASE(test_recovered_gamma_round_trips_through_tx_in)
     std::vector<uint8_t> msg_vec(msg.begin(), msg.end());
 
     auto tid_rv = gen_default_token_id();
-    BOOST_REQUIRE(tid_rv->result == BLSCT_SUCCESS);
-    auto* blsct_token_id = static_cast<BlsctTokenId*>(tid_rv->value);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    auto* blsct_token_id = &tid_rv.value;
 
     TokenId token_id;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(blsct_token_id, TOKEN_ID_SIZE, token_id);
@@ -228,169 +211,158 @@ BOOST_AUTO_TEST_CASE(test_recovered_gamma_round_trips_through_tx_in)
     BlsctPoint blsct_nonce;
     SERIALIZE_AND_COPY(nonce, blsct_nonce);
 
-    auto* req = gen_amount_recovery_req(rp_buf, rp_st.size(), &blsct_nonce, nullptr);
-    void* req_vec = create_amount_recovery_req_vec();
-    add_to_amount_recovery_req_vec(req_vec, req);
+    BlsctAmountRecoveryReq req{};
+    req.range_proof = rp_buf;
+    req.range_proof_size = rp_st.size();
+    std::memcpy(req.nonce, blsct_nonce, POINT_SIZE);
+    std::memcpy(req.token_id, tid_rv.value, TOKEN_ID_SIZE);
 
-    auto* amounts_rv = recover_amount(req_vec);
-    BOOST_REQUIRE(amounts_rv->result == BLSCT_SUCCESS);
-    BOOST_REQUIRE(get_amount_recovery_result_is_succ(amounts_rv->value, 0));
-
-    const BlsctScalar* recovered_gamma = get_amount_recovery_result_gamma(amounts_rv->value, 0);
+    BlsctAmountRecoveryResult result{};
+    BOOST_REQUIRE_EQUAL(recover_amount(&req, 1, &result), BLSCT_SUCCESS);
+    BOOST_REQUIRE(result.is_succ);
 
     // feed the recovered gamma directly into build_tx_in
     auto sk_rv = gen_random_scalar();
-    BOOST_REQUIRE(sk_rv->result == BLSCT_SUCCESS);
-    auto* spending_key = static_cast<BlsctScalar*>(sk_rv->value);
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+    auto* spending_key = &sk_rv.value;
 
     std::string txid_hex(64, '0');
     auto op_rv = gen_out_point(txid_hex.c_str());
-    BOOST_REQUIRE(op_rv->result == BLSCT_SUCCESS);
-    auto* out_point = static_cast<BlsctOutPoint*>(op_rv->value);
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+    auto* out_point = &op_rv.value;
 
-    auto* tx_in_rv = build_tx_in(
+    auto tx_in_rv = build_tx_in(
         amount,
-        recovered_gamma,
+        &result.gamma,
         spending_key,
         blsct_token_id,
         out_point,
         false,
         false);
-    BOOST_REQUIRE(tx_in_rv->result == BLSCT_SUCCESS);
-    auto* tx_in = static_cast<BlsctTxIn*>(tx_in_rv->value);
+    BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
+    auto* tx_in = &tx_in_rv.value;
 
     // the gamma stored in the tx_in must equal the recovered gamma
-    const BlsctScalar* tx_in_gamma = get_tx_in_gamma(tx_in);
-    BOOST_CHECK(are_scalar_equal(recovered_gamma, tx_in_gamma) == 1);
+    BlsctScalarResult tx_in_gamma_rv = get_tx_in_gamma(tx_in);
+    BOOST_CHECK(are_scalar_equal(&result.gamma, &tx_in_gamma_rv.value) == 1);
 
     free(rp_buf);
-    delete req;
-    delete_amount_recovery_req_vec(req_vec);
-    free_amounts_ret_val(amounts_rv);
-    free_obj(sk_rv);
-    free_obj(op_rv);
-    free_obj(tx_in_rv);
-    free_obj(tid_rv);
 }
 
 BOOST_AUTO_TEST_CASE(test_token_info_predicates_and_unsigned_outputs)
 {
     init();
 
-    auto* metadata = create_string_map();
-    BOOST_REQUIRE(metadata != nullptr);
-    add_to_string_map(metadata, "name", "Collection");
-    add_to_string_map(metadata, "symbol", "COLL");
+    const char* meta_keys[] = {"name", "symbol"};
+    const char* meta_vals[] = {"Collection", "COLL"};
 
-    auto* collection_hash_rv = calc_collection_token_hash(metadata, 1000);
-    BOOST_REQUIRE(collection_hash_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(collection_hash_rv->result, BLSCT_SUCCESS);
-    auto* collection_hash = static_cast<BlsctUint256*>(collection_hash_rv->value);
+    auto collection_hash_rv = calc_collection_token_hash(meta_keys, meta_vals, 2, 1000);
+    BOOST_REQUIRE_EQUAL(collection_hash_rv.result, BLSCT_SUCCESS);
+    auto* collection_hash = &collection_hash_rv.value;
 
     const std::map<std::string, std::string> expected_metadata{{"name", "Collection"}, {"symbol", "COLL"}};
     const uint256 expected_collection_hash = (HashWriter{} << expected_metadata << CAmount{1000}).GetHash();
     BOOST_CHECK(std::memcmp(collection_hash, expected_collection_hash.begin(), UINT256_SIZE) == 0);
 
-    auto* master_token_key_rv = gen_scalar(42);
-    BOOST_REQUIRE(master_token_key_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(master_token_key_rv->result, BLSCT_SUCCESS);
-    auto* master_token_key = static_cast<BlsctScalar*>(master_token_key_rv->value);
+    auto master_token_key_rv = gen_scalar(42);
+    BOOST_REQUIRE_EQUAL(master_token_key_rv.result, BLSCT_SUCCESS);
+    auto* master_token_key = &master_token_key_rv.value;
 
-    auto* token_key_rv = derive_collection_token_key(master_token_key, collection_hash);
-    BOOST_REQUIRE(token_key_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(token_key_rv->result, BLSCT_SUCCESS);
-    auto* token_key = static_cast<BlsctScalar*>(token_key_rv->value);
+    auto token_key_rv = derive_collection_token_key(master_token_key, collection_hash);
+    BOOST_REQUIRE_EQUAL(token_key_rv.result, BLSCT_SUCCESS);
+    auto* token_key = &token_key_rv.value;
 
     MclScalar expected_token_key = BLS12_381_KeyGen::derive_child_SK_hash(MclScalar(uint64_t{42}), expected_collection_hash);
     MclScalar token_key_native;
     UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(token_key, SCALAR_SIZE, token_key_native);
     BOOST_CHECK(token_key_native == expected_token_key);
 
-    const BlsctPubKey* token_public_key = derive_collection_token_public_key(master_token_key, collection_hash);
-    BOOST_REQUIRE(token_public_key != nullptr);
+    BlsctPubKeyResult token_public_key_rv = derive_collection_token_public_key(master_token_key, collection_hash);
+    BOOST_REQUIRE_EQUAL(token_public_key_rv.result, BLSCT_SUCCESS);
+    auto* token_public_key = &token_public_key_rv.value;
 
-    auto* token_info_rv = build_token_info(BlsctToken, token_public_key, metadata, 1000);
-    auto& token_info = RequireSuccess<blsct::TokenInfo>(token_info_rv);
-    BOOST_CHECK_EQUAL(get_token_info_type(&token_info), BlsctToken);
-    BOOST_CHECK_EQUAL(get_token_info_total_supply(&token_info), 1000U);
+    size_t token_info_len = 0;
+    BOOST_REQUIRE_EQUAL(build_token_info(BlsctToken, token_public_key, meta_keys, meta_vals, 2, 1000, nullptr, 0, &token_info_len), BLSCT_SUCCESS);
+    std::vector<char> token_info_hex(token_info_len + 1);
+    BOOST_REQUIRE_EQUAL(build_token_info(BlsctToken, token_public_key, meta_keys, meta_vals, 2, 1000, token_info_hex.data(), token_info_hex.size(), &token_info_len), BLSCT_SUCCESS);
+    auto type_rv = get_token_info_type(token_info_hex.data());
+    BOOST_REQUIRE_EQUAL(type_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(type_rv.value, BlsctToken);
+    BOOST_CHECK_EQUAL(get_token_info_total_supply(token_info_hex.data()).value, 1000U);
 
-    void* token_info_metadata = get_token_info_metadata(&token_info);
-    BOOST_REQUIRE(token_info_metadata != nullptr);
-    BOOST_CHECK(ReadStringMap(token_info_metadata) == expected_metadata);
-    delete_string_map(token_info_metadata);
+    BOOST_CHECK(ReadTokenInfoMetadata(token_info_hex.data()) == expected_metadata);
 
-    const char* token_info_hex = serialize_token_info(&token_info);
-    BOOST_REQUIRE(token_info_hex != nullptr);
-    auto* token_info_roundtrip_rv = deserialize_token_info(token_info_hex);
-    auto& token_info_roundtrip = RequireSuccess<blsct::TokenInfo>(token_info_roundtrip_rv);
-    BOOST_CHECK_EQUAL(token_info_roundtrip.nTotalSupply, token_info.nTotalSupply);
-    BOOST_CHECK(token_info_roundtrip.publicKey == token_info.publicKey);
-    BOOST_CHECK(token_info_roundtrip.mapMetadata == token_info.mapMetadata);
+    size_t create_pred_len = 0;
+    BOOST_REQUIRE_EQUAL(build_create_token_predicate(token_info_hex.data(), nullptr, 0, &create_pred_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> create_pred_buf(create_pred_len);
+    BOOST_REQUIRE_EQUAL(build_create_token_predicate(token_info_hex.data(), create_pred_buf.data(), create_pred_buf.size(), &create_pred_len), BLSCT_SUCCESS);
+    auto* create_pred = create_pred_buf.data();
+    auto create_pred_type_rv = get_vector_predicate_type(create_pred, create_pred_len);
+    BOOST_REQUIRE_EQUAL(create_pred_type_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(create_pred_type_rv.value, BlsctCreateTokenPredicateType);
 
-    auto* create_pred_rv = build_create_token_predicate(&token_info);
-    BOOST_REQUIRE(create_pred_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(create_pred_rv->result, BLSCT_SUCCESS);
-    auto* create_pred = static_cast<BlsctVectorPredicate*>(create_pred_rv->value);
-    BOOST_CHECK_EQUAL(get_vector_predicate_type(create_pred, create_pred_rv->value_size), BlsctCreateTokenPredicateType);
+    size_t parsed_token_info_len = 0;
+    BOOST_REQUIRE_EQUAL(get_create_token_predicate_token_info(create_pred, create_pred_len, nullptr, 0, &parsed_token_info_len), BLSCT_SUCCESS);
+    std::vector<char> parsed_token_info_hex(parsed_token_info_len + 1);
+    BOOST_REQUIRE_EQUAL(get_create_token_predicate_token_info(create_pred, create_pred_len, parsed_token_info_hex.data(), parsed_token_info_hex.size(), &parsed_token_info_len), BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(parsed_token_info_hex.data()), std::string(token_info_hex.data()));
 
-    auto* parsed_token_info_rv = get_create_token_predicate_token_info(create_pred, create_pred_rv->value_size);
-    auto& parsed_token_info = RequireSuccess<blsct::TokenInfo>(parsed_token_info_rv);
-    BOOST_CHECK(parsed_token_info.publicKey == token_info.publicKey);
-    BOOST_CHECK_EQUAL(parsed_token_info.nTotalSupply, token_info.nTotalSupply);
-    BOOST_CHECK(parsed_token_info.mapMetadata == token_info.mapMetadata);
+    size_t mint_pred_len = 0;
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(token_public_key, 25, nullptr, 0, &mint_pred_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> mint_pred_buf(mint_pred_len);
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(token_public_key, 25, mint_pred_buf.data(), mint_pred_buf.size(), &mint_pred_len), BLSCT_SUCCESS);
+    auto* mint_pred = mint_pred_buf.data();
+    auto mint_pred_type_rv = get_vector_predicate_type(mint_pred, mint_pred_len);
+    BOOST_REQUIRE_EQUAL(mint_pred_type_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(mint_pred_type_rv.value, BlsctMintTokenPredicateType);
+    BOOST_CHECK_EQUAL(get_mint_token_predicate_amount(mint_pred, mint_pred_len).value, 25U);
 
-    auto* mint_pred_rv = build_mint_token_predicate(token_public_key, 25);
-    BOOST_REQUIRE(mint_pred_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(mint_pred_rv->result, BLSCT_SUCCESS);
-    auto* mint_pred = static_cast<BlsctVectorPredicate*>(mint_pred_rv->value);
-    BOOST_CHECK_EQUAL(get_vector_predicate_type(mint_pred, mint_pred_rv->value_size), BlsctMintTokenPredicateType);
-    BOOST_CHECK_EQUAL(get_mint_token_predicate_amount(mint_pred, mint_pred_rv->value_size), 25U);
+    BlsctPubKeyResult mint_pred_pub_key_rv = get_mint_token_predicate_public_key(mint_pred, mint_pred_len);
+    BOOST_REQUIRE_EQUAL(mint_pred_pub_key_rv.result, BLSCT_SUCCESS);
+    BlsctPointHexResult token_pub_hex_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(token_public_key));
+    BlsctPointHexResult mint_pub_hex_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&mint_pred_pub_key_rv.value));
+    BOOST_REQUIRE_EQUAL(token_pub_hex_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(mint_pub_hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(token_pub_hex_rv.value), std::string(mint_pub_hex_rv.value));
 
-    const BlsctPubKey* mint_pred_pub_key = get_mint_token_predicate_public_key(mint_pred, mint_pred_rv->value_size);
-    BOOST_REQUIRE(mint_pred_pub_key != nullptr);
-    const char* token_pub_hex = serialize_public_key(reinterpret_cast<const BlsctPoint*>(token_public_key));
-    const char* mint_pub_hex = serialize_public_key(reinterpret_cast<const BlsctPoint*>(mint_pred_pub_key));
-    BOOST_REQUIRE(token_pub_hex != nullptr);
-    BOOST_REQUIRE(mint_pub_hex != nullptr);
-    BOOST_CHECK_EQUAL(std::string(token_pub_hex), std::string(mint_pub_hex));
+    const char* nft_keys[] = {"rarity"};
+    const char* nft_vals[] = {"legendary"};
 
-    auto* nft_metadata = create_string_map();
-    BOOST_REQUIRE(nft_metadata != nullptr);
-    add_to_string_map(nft_metadata, "rarity", "legendary");
+    size_t mint_nft_pred_len = 0;
+    BOOST_REQUIRE_EQUAL(build_mint_nft_predicate(token_public_key, 7, nft_keys, nft_vals, 1, nullptr, 0, &mint_nft_pred_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> mint_nft_pred_buf(mint_nft_pred_len);
+    BOOST_REQUIRE_EQUAL(build_mint_nft_predicate(token_public_key, 7, nft_keys, nft_vals, 1, mint_nft_pred_buf.data(), mint_nft_pred_buf.size(), &mint_nft_pred_len), BLSCT_SUCCESS);
+    auto* mint_nft_pred = mint_nft_pred_buf.data();
+    auto mint_nft_pred_type_rv = get_vector_predicate_type(mint_nft_pred, mint_nft_pred_len);
+    BOOST_REQUIRE_EQUAL(mint_nft_pred_type_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(mint_nft_pred_type_rv.value, BlsctMintNftPredicateType);
+    BOOST_CHECK_EQUAL(get_mint_nft_predicate_nft_id(mint_nft_pred, mint_nft_pred_len).value, 7U);
 
-    auto* mint_nft_pred_rv = build_mint_nft_predicate(token_public_key, 7, nft_metadata);
-    BOOST_REQUIRE(mint_nft_pred_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(mint_nft_pred_rv->result, BLSCT_SUCCESS);
-    auto* mint_nft_pred = static_cast<BlsctVectorPredicate*>(mint_nft_pred_rv->value);
-    BOOST_CHECK_EQUAL(get_vector_predicate_type(mint_nft_pred, mint_nft_pred_rv->value_size), BlsctMintNftPredicateType);
-    BOOST_CHECK_EQUAL(get_mint_nft_predicate_nft_id(mint_nft_pred, mint_nft_pred_rv->value_size), 7U);
-
-    void* parsed_nft_metadata = get_mint_nft_predicate_metadata(mint_nft_pred, mint_nft_pred_rv->value_size);
-    BOOST_REQUIRE(parsed_nft_metadata != nullptr);
     const std::map<std::string, std::string> expected_nft_metadata{{"rarity", "legendary"}};
-    BOOST_CHECK(ReadStringMap(parsed_nft_metadata) == expected_nft_metadata);
-    delete_string_map(parsed_nft_metadata);
+    BOOST_CHECK(ReadMintNftMetadata(mint_nft_pred, mint_nft_pred_len) == expected_nft_metadata);
 
-    auto* view_key_rv = gen_scalar(11);
-    auto* spend_key_rv = gen_scalar(12);
-    BOOST_REQUIRE(view_key_rv != nullptr);
-    BOOST_REQUIRE(spend_key_rv != nullptr);
-    const BlsctPubKey* spend_pub_key = scalar_to_pub_key(static_cast<const BlsctScalar*>(spend_key_rv->value));
-    BOOST_REQUIRE(spend_pub_key != nullptr);
-    auto* sub_addr_id = gen_sub_addr_id(0, 1);
-    BOOST_REQUIRE(sub_addr_id != nullptr);
-    auto* dest = derive_sub_address(static_cast<const BlsctScalar*>(view_key_rv->value), spend_pub_key, sub_addr_id);
-    BOOST_REQUIRE(dest != nullptr);
-    auto* blinding_key_rv = gen_scalar(99);
-    BOOST_REQUIRE(blinding_key_rv != nullptr);
+    auto view_key_rv = gen_scalar(11);
+    auto spend_key_rv = gen_scalar(12);
+    BOOST_REQUIRE_EQUAL(view_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_key_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult spend_pub_key_rv = scalar_to_pub_key(&spend_key_rv.value);
+    BOOST_REQUIRE_EQUAL(spend_pub_key_rv.result, BLSCT_SUCCESS);
+    auto* spend_pub_key = &spend_pub_key_rv.value;
+    BlsctSubAddrIdResult sub_addr_id_rv = gen_sub_addr_id(0, 1);
+    BOOST_REQUIRE_EQUAL(sub_addr_id_rv.result, BLSCT_SUCCESS);
+    auto* sub_addr_id = &sub_addr_id_rv.value;
+    BlsctSubAddrResult dest_rv = derive_sub_address(&view_key_rv.value, spend_pub_key, sub_addr_id);
+    BOOST_REQUIRE_EQUAL(dest_rv.result, BLSCT_SUCCESS);
+    auto* dest = &dest_rv.value;
+    auto blinding_key_rv = gen_scalar(99);
+    BOOST_REQUIRE_EQUAL(blinding_key_rv.result, BLSCT_SUCCESS);
 
-    auto* create_output_rv = build_unsigned_create_token_output(token_key, &token_info);
-    BOOST_REQUIRE(create_output_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(create_output_rv->result, BLSCT_SUCCESS);
-    const char* create_output_hex = serialize_unsigned_output(create_output_rv->value);
-    BOOST_REQUIRE(create_output_hex != nullptr);
+    size_t create_output_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_create_token_output(token_key, token_info_hex.data(), nullptr, 0, &create_output_len), BLSCT_SUCCESS);
+    std::vector<char> create_output_hex(create_output_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_create_token_output(token_key, token_info_hex.data(), create_output_hex.data(), create_output_hex.size(), &create_output_len), BLSCT_SUCCESS);
     {
-        DataStream st{ParseHex(create_output_hex)};
+        DataStream st{ParseHex(create_output_hex.data())};
         blsct::UnsignedOutput output;
         st >> output;
         auto parsed = blsct::ParsePredicate(output.out.predicate);
@@ -398,13 +370,12 @@ BOOST_AUTO_TEST_CASE(test_token_info_predicates_and_unsigned_outputs)
         BOOST_CHECK_EQUAL(parsed.GetTokenInfo().nTotalSupply, 1000);
     }
 
-    auto* mint_output_rv = build_unsigned_mint_token_output(dest, 25, static_cast<const BlsctScalar*>(blinding_key_rv->value), token_key, token_public_key);
-    BOOST_REQUIRE(mint_output_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(mint_output_rv->result, BLSCT_SUCCESS);
-    const char* mint_output_hex = serialize_unsigned_output(mint_output_rv->value);
-    BOOST_REQUIRE(mint_output_hex != nullptr);
+    size_t mint_output_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_mint_token_output(dest, 25, &blinding_key_rv.value, token_key, token_public_key, nullptr, 0, &mint_output_len), BLSCT_SUCCESS);
+    std::vector<char> mint_output_hex(mint_output_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_mint_token_output(dest, 25, &blinding_key_rv.value, token_key, token_public_key, mint_output_hex.data(), mint_output_hex.size(), &mint_output_len), BLSCT_SUCCESS);
     {
-        DataStream st{ParseHex(mint_output_hex)};
+        DataStream st{ParseHex(mint_output_hex.data())};
         blsct::UnsignedOutput output;
         st >> output;
         auto parsed = blsct::ParsePredicate(output.out.predicate);
@@ -412,13 +383,12 @@ BOOST_AUTO_TEST_CASE(test_token_info_predicates_and_unsigned_outputs)
         BOOST_CHECK_EQUAL(parsed.GetAmount(), 25);
     }
 
-    auto* mint_nft_output_rv = build_unsigned_mint_nft_output(dest, static_cast<const BlsctScalar*>(blinding_key_rv->value), token_key, token_public_key, 7, nft_metadata);
-    BOOST_REQUIRE(mint_nft_output_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(mint_nft_output_rv->result, BLSCT_SUCCESS);
-    const char* mint_nft_output_hex = serialize_unsigned_output(mint_nft_output_rv->value);
-    BOOST_REQUIRE(mint_nft_output_hex != nullptr);
+    size_t mint_nft_output_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_mint_nft_output(dest, &blinding_key_rv.value, token_key, token_public_key, 7, nft_keys, nft_vals, 1, nullptr, 0, &mint_nft_output_len), BLSCT_SUCCESS);
+    std::vector<char> mint_nft_output_hex(mint_nft_output_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_mint_nft_output(dest, &blinding_key_rv.value, token_key, token_public_key, 7, nft_keys, nft_vals, 1, mint_nft_output_hex.data(), mint_nft_output_hex.size(), &mint_nft_output_len), BLSCT_SUCCESS);
     {
-        DataStream st{ParseHex(mint_nft_output_hex)};
+        DataStream st{ParseHex(mint_nft_output_hex.data())};
         blsct::UnsignedOutput output;
         st >> output;
         auto parsed = blsct::ParsePredicate(output.out.predicate);
@@ -426,137 +396,78 @@ BOOST_AUTO_TEST_CASE(test_token_info_predicates_and_unsigned_outputs)
         BOOST_CHECK_EQUAL(parsed.GetNftId(), 7U);
         BOOST_CHECK(parsed.GetNftMetaData() == expected_nft_metadata);
     }
-
-    delete_string_map(metadata);
-    delete_string_map(nft_metadata);
-    delete_token_info(token_info_roundtrip_rv->value);
-    free(token_info_roundtrip_rv);
-    delete_token_info(parsed_token_info_rv->value);
-    free(parsed_token_info_rv);
-    delete_token_info(token_info_rv->value);
-    free(token_info_rv);
-    free_obj((void*)token_public_key);
-    free_obj((void*)mint_pred_pub_key);
-    free_obj((void*)token_pub_hex);
-    free_obj((void*)mint_pub_hex);
-    free_obj((void*)spend_pub_key);
-    free_obj((void*)sub_addr_id);
-    free_obj((void*)dest);
-    free_obj((void*)create_output_hex);
-    free_obj((void*)mint_output_hex);
-    free_obj((void*)mint_nft_output_hex);
-    delete_unsigned_output(create_output_rv->value);
-    free(create_output_rv);
-    delete_unsigned_output(mint_output_rv->value);
-    free(mint_output_rv);
-    delete_unsigned_output(mint_nft_output_rv->value);
-    free(mint_nft_output_rv);
-    free_obj(master_token_key_rv->value);
-    free(master_token_key_rv);
-    free_obj(token_key_rv->value);
-    free(token_key_rv);
-    free_obj(collection_hash_rv->value);
-    free(collection_hash_rv);
-    free_obj((void*)token_info_hex);
-    free_obj(create_pred_rv->value);
-    free(create_pred_rv);
-    free_obj(mint_pred_rv->value);
-    free(mint_pred_rv);
-    free_obj(mint_nft_pred_rv->value);
-    free(mint_nft_pred_rv);
-    free_obj(view_key_rv->value);
-    free(view_key_rv);
-    free_obj(spend_key_rv->value);
-    free(spend_key_rv);
-    free_obj(blinding_key_rv->value);
-    free(blinding_key_rv);
 }
 
 BOOST_AUTO_TEST_CASE(test_unsigned_transaction_sign)
 {
     init();
 
-    auto* view_key_rv = gen_scalar(21);
-    auto* spend_key_rv = gen_scalar(22);
-    auto* input_spending_key_rv = gen_scalar(23);
-    auto* gamma_rv = gen_scalar(24);
-    auto* blinding_key_rv = gen_scalar(25);
-    auto* default_token_id_rv = gen_default_token_id();
-    BOOST_REQUIRE(view_key_rv != nullptr);
-    BOOST_REQUIRE(spend_key_rv != nullptr);
-    BOOST_REQUIRE(input_spending_key_rv != nullptr);
-    BOOST_REQUIRE(gamma_rv != nullptr);
-    BOOST_REQUIRE(blinding_key_rv != nullptr);
-    BOOST_REQUIRE(default_token_id_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(default_token_id_rv->result, BLSCT_SUCCESS);
+    auto view_key_rv = gen_scalar(21);
+    auto spend_key_rv = gen_scalar(22);
+    auto input_spending_key_rv = gen_scalar(23);
+    auto gamma_rv = gen_scalar(24);
+    auto blinding_key_rv = gen_scalar(25);
+    auto default_token_id_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(view_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(input_spending_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(blinding_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(default_token_id_rv.result, BLSCT_SUCCESS);
 
-    const BlsctPubKey* spend_pub_key = scalar_to_pub_key(static_cast<const BlsctScalar*>(spend_key_rv->value));
-    BOOST_REQUIRE(spend_pub_key != nullptr);
-    auto* sub_addr_id = gen_sub_addr_id(0, 2);
-    BOOST_REQUIRE(sub_addr_id != nullptr);
-    auto* dest = derive_sub_address(static_cast<const BlsctScalar*>(view_key_rv->value), spend_pub_key, sub_addr_id);
-    BOOST_REQUIRE(dest != nullptr);
+    BlsctPubKeyResult spend_pub_key_rv = scalar_to_pub_key(&spend_key_rv.value);
+    BOOST_REQUIRE_EQUAL(spend_pub_key_rv.result, BLSCT_SUCCESS);
+    auto* spend_pub_key = &spend_pub_key_rv.value;
+    BlsctSubAddrIdResult sub_addr_id_rv = gen_sub_addr_id(0, 2);
+    BOOST_REQUIRE_EQUAL(sub_addr_id_rv.result, BLSCT_SUCCESS);
+    auto* sub_addr_id = &sub_addr_id_rv.value;
+    BlsctSubAddrResult dest_rv = derive_sub_address(&view_key_rv.value, spend_pub_key, sub_addr_id);
+    BOOST_REQUIRE_EQUAL(dest_rv.result, BLSCT_SUCCESS);
+    auto* dest = &dest_rv.value;
 
-    auto* out_point_rv = gen_out_point("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
-    BOOST_REQUIRE(out_point_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(out_point_rv->result, BLSCT_SUCCESS);
+    auto out_point_rv = gen_out_point("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+    BOOST_REQUIRE_EQUAL(out_point_rv.result, BLSCT_SUCCESS);
 
-    auto* tx_in_rv = build_tx_in(
+    auto tx_in_rv = build_tx_in(
         1000,
-        static_cast<const BlsctScalar*>(gamma_rv->value),
-        static_cast<const BlsctScalar*>(input_spending_key_rv->value),
-        static_cast<const BlsctTokenId*>(default_token_id_rv->value),
-        static_cast<const BlsctOutPoint*>(out_point_rv->value),
+        &gamma_rv.value,
+        &input_spending_key_rv.value,
+        &default_token_id_rv.value,
+        &out_point_rv.value,
         false,
         false);
-    BOOST_REQUIRE(tx_in_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(tx_in_rv->result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
 
-    auto* unsigned_input_rv = build_unsigned_input(static_cast<const BlsctTxIn*>(tx_in_rv->value));
-    BOOST_REQUIRE(unsigned_input_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(unsigned_input_rv->result, BLSCT_SUCCESS);
+    size_t unsigned_input_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, nullptr, 0, &unsigned_input_len), BLSCT_SUCCESS);
+    std::vector<char> unsigned_input_hex(unsigned_input_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, unsigned_input_hex.data(), unsigned_input_hex.size(), &unsigned_input_len), BLSCT_SUCCESS);
 
-    auto* tx_out_rv = build_tx_out(
+    auto tx_out_rv = build_tx_out(
         dest,
         500,
         "memo",
-        static_cast<const BlsctTokenId*>(default_token_id_rv->value),
+        &default_token_id_rv.value,
         TxOutputType::Normal,
         0,
         false,
-        static_cast<const BlsctScalar*>(blinding_key_rv->value));
-    BOOST_REQUIRE(tx_out_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(tx_out_rv->result, BLSCT_SUCCESS);
+        &blinding_key_rv.value);
+    BOOST_REQUIRE_EQUAL(tx_out_rv.result, BLSCT_SUCCESS);
 
-    auto* unsigned_output_rv = build_unsigned_output(static_cast<const BlsctTxOut*>(tx_out_rv->value));
-    BOOST_REQUIRE(unsigned_output_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(unsigned_output_rv->result, BLSCT_SUCCESS);
+    size_t unsigned_output_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&tx_out_rv.value, nullptr, 0, &unsigned_output_len), BLSCT_SUCCESS);
+    std::vector<char> unsigned_output_hex(unsigned_output_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&tx_out_rv.value, unsigned_output_hex.data(), unsigned_output_hex.size(), &unsigned_output_len), BLSCT_SUCCESS);
 
-    void* unsigned_tx = create_unsigned_transaction();
-    BOOST_REQUIRE(unsigned_tx != nullptr);
-    add_unsigned_transaction_input(unsigned_tx, unsigned_input_rv->value);
-    add_unsigned_transaction_output(unsigned_tx, unsigned_output_rv->value);
-    set_unsigned_transaction_fee(unsigned_tx, 125);
+    const char* input_hexes[] = {unsigned_input_hex.data()};
+    const char* output_hexes[] = {unsigned_output_hex.data()};
 
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_inputs_size(unsigned_tx), 1U);
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_outputs_size(unsigned_tx), 1U);
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_fee(unsigned_tx), 125U);
-
-    const char* unsigned_tx_hex = serialize_unsigned_transaction(unsigned_tx);
-    BOOST_REQUIRE(unsigned_tx_hex != nullptr);
-    auto* unsigned_tx_roundtrip_rv = deserialize_unsigned_transaction(unsigned_tx_hex);
-    BOOST_REQUIRE(unsigned_tx_roundtrip_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(unsigned_tx_roundtrip_rv->result, BLSCT_SUCCESS);
-
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_inputs_size(unsigned_tx_roundtrip_rv->value), 1U);
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_outputs_size(unsigned_tx_roundtrip_rv->value), 1U);
-    BOOST_CHECK_EQUAL(get_unsigned_transaction_fee(unsigned_tx_roundtrip_rv->value), 125U);
-
-    auto* signed_tx_rv = sign_unsigned_transaction(unsigned_tx_roundtrip_rv->value);
-    BOOST_REQUIRE(signed_tx_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(signed_tx_rv->result, BLSCT_SUCCESS);
-    const char* signed_tx_hex = static_cast<const char*>(signed_tx_rv->value);
-    BOOST_REQUIRE(signed_tx_hex != nullptr);
+    size_t signed_tx_len;
+    BLSCT_RESULT signed_tx_r = sign_unsigned_transaction(input_hexes, 1, output_hexes, 1, 125, nullptr, 0, &signed_tx_len);
+    BOOST_REQUIRE_EQUAL(signed_tx_r, BLSCT_SUCCESS);
+    std::vector<char> signed_tx_hex_buf(signed_tx_len + 1);
+    sign_unsigned_transaction(input_hexes, 1, output_hexes, 1, 125, signed_tx_hex_buf.data(), signed_tx_hex_buf.size(), nullptr);
+    const char* signed_tx_hex = signed_tx_hex_buf.data();
 
     CMutableTransaction decoded;
     BOOST_REQUIRE(DecodeHexTx(decoded, signed_tx_hex));
@@ -567,38 +478,6 @@ BOOST_AUTO_TEST_CASE(test_unsigned_transaction_sign)
     BOOST_CHECK_EQUAL(signed_tx.vout.back().nValue, 125);
     auto fee_predicate = blsct::ParsePredicate(signed_tx.vout.back().predicate);
     BOOST_CHECK(fee_predicate.IsPayFeePredicate());
-
-    free_obj(view_key_rv->value);
-    free(view_key_rv);
-    free_obj(spend_key_rv->value);
-    free(spend_key_rv);
-    free_obj(input_spending_key_rv->value);
-    free(input_spending_key_rv);
-    free_obj(gamma_rv->value);
-    free(gamma_rv);
-    free_obj(blinding_key_rv->value);
-    free(blinding_key_rv);
-    free_obj(default_token_id_rv->value);
-    free(default_token_id_rv);
-    free_obj((void*)spend_pub_key);
-    free_obj((void*)sub_addr_id);
-    free_obj((void*)dest);
-    free_obj(out_point_rv->value);
-    free(out_point_rv);
-    free_obj(tx_in_rv->value);
-    free(tx_in_rv);
-    delete_unsigned_input(unsigned_input_rv->value);
-    free(unsigned_input_rv);
-    free_obj(tx_out_rv->value);
-    free(tx_out_rv);
-    delete_unsigned_output(unsigned_output_rv->value);
-    free(unsigned_output_rv);
-    free_obj((void*)unsigned_tx_hex);
-    delete_unsigned_transaction(unsigned_tx);
-    delete_unsigned_transaction(unsigned_tx_roundtrip_rv->value);
-    free(unsigned_tx_roundtrip_rv);
-    free_obj(signed_tx_rv->value);
-    free(signed_tx_rv);
 }
 
 BOOST_AUTO_TEST_CASE(test_are_ctx_in_equal)
@@ -625,103 +504,74 @@ BOOST_AUTO_TEST_CASE(test_aggregate_transactions)
     init();
 
     const auto build_signed_tx = [](const uint64_t seed_base, const char* out_point_hex, const uint64_t output_amount, const uint64_t fee) {
-        auto* view_key_rv = gen_scalar(seed_base + 1);
-        auto* spend_key_rv = gen_scalar(seed_base + 2);
-        auto* input_spending_key_rv = gen_scalar(seed_base + 3);
-        auto* gamma_rv = gen_scalar(seed_base + 4);
-        auto* blinding_key_rv = gen_scalar(seed_base + 5);
-        auto* default_token_id_rv = gen_default_token_id();
+        auto view_key_rv = gen_scalar(seed_base + 1);
+        auto spend_key_rv = gen_scalar(seed_base + 2);
+        auto input_spending_key_rv = gen_scalar(seed_base + 3);
+        auto gamma_rv = gen_scalar(seed_base + 4);
+        auto blinding_key_rv = gen_scalar(seed_base + 5);
+        auto default_token_id_rv = gen_default_token_id();
 
-        BOOST_REQUIRE(view_key_rv != nullptr);
-        BOOST_REQUIRE(spend_key_rv != nullptr);
-        BOOST_REQUIRE(input_spending_key_rv != nullptr);
-        BOOST_REQUIRE(gamma_rv != nullptr);
-        BOOST_REQUIRE(blinding_key_rv != nullptr);
-        BOOST_REQUIRE(default_token_id_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(default_token_id_rv->result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(view_key_rv.result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(spend_key_rv.result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(input_spending_key_rv.result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(blinding_key_rv.result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(default_token_id_rv.result, BLSCT_SUCCESS);
 
-        const BlsctPubKey* spend_pub_key = scalar_to_pub_key(static_cast<const BlsctScalar*>(spend_key_rv->value));
-        BOOST_REQUIRE(spend_pub_key != nullptr);
+        BlsctPubKeyResult spend_pub_key_rv = scalar_to_pub_key(&spend_key_rv.value);
+        BOOST_REQUIRE_EQUAL(spend_pub_key_rv.result, BLSCT_SUCCESS);
+        auto* spend_pub_key = &spend_pub_key_rv.value;
 
-        auto* sub_addr_id = gen_sub_addr_id(0, seed_base);
-        BOOST_REQUIRE(sub_addr_id != nullptr);
-        auto* dest = derive_sub_address(static_cast<const BlsctScalar*>(view_key_rv->value), spend_pub_key, sub_addr_id);
-        BOOST_REQUIRE(dest != nullptr);
+        BlsctSubAddrIdResult sub_addr_id_rv = gen_sub_addr_id(0, seed_base);
+        BOOST_REQUIRE_EQUAL(sub_addr_id_rv.result, BLSCT_SUCCESS);
+        auto* sub_addr_id = &sub_addr_id_rv.value;
+        BlsctSubAddrResult dest_rv = derive_sub_address(&view_key_rv.value, spend_pub_key, sub_addr_id);
+        BOOST_REQUIRE_EQUAL(dest_rv.result, BLSCT_SUCCESS);
+        auto* dest = &dest_rv.value;
 
-        auto* out_point_rv = gen_out_point(out_point_hex);
-        BOOST_REQUIRE(out_point_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(out_point_rv->result, BLSCT_SUCCESS);
+        auto out_point_rv = gen_out_point(out_point_hex);
+        BOOST_REQUIRE_EQUAL(out_point_rv.result, BLSCT_SUCCESS);
 
-        auto* tx_in_rv = build_tx_in(
+        auto tx_in_rv = build_tx_in(
             1000,
-            static_cast<const BlsctScalar*>(gamma_rv->value),
-            static_cast<const BlsctScalar*>(input_spending_key_rv->value),
-            static_cast<const BlsctTokenId*>(default_token_id_rv->value),
-            static_cast<const BlsctOutPoint*>(out_point_rv->value),
+            &gamma_rv.value,
+            &input_spending_key_rv.value,
+            &default_token_id_rv.value,
+            &out_point_rv.value,
             false,
             false);
-        BOOST_REQUIRE(tx_in_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(tx_in_rv->result, BLSCT_SUCCESS);
+        BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
 
-        auto* unsigned_input_rv = build_unsigned_input(static_cast<const BlsctTxIn*>(tx_in_rv->value));
-        BOOST_REQUIRE(unsigned_input_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(unsigned_input_rv->result, BLSCT_SUCCESS);
+        size_t unsigned_input_len = 0;
+        BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, nullptr, 0, &unsigned_input_len), BLSCT_SUCCESS);
+        std::vector<char> unsigned_input_hex(unsigned_input_len + 1);
+        BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, unsigned_input_hex.data(), unsigned_input_hex.size(), &unsigned_input_len), BLSCT_SUCCESS);
 
-        auto* tx_out_rv = build_tx_out(
+        auto tx_out_rv = build_tx_out(
             dest,
             output_amount,
             "aggregate",
-            static_cast<const BlsctTokenId*>(default_token_id_rv->value),
+            &default_token_id_rv.value,
             TxOutputType::Normal,
             0,
             false,
-            static_cast<const BlsctScalar*>(blinding_key_rv->value));
-        BOOST_REQUIRE(tx_out_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(tx_out_rv->result, BLSCT_SUCCESS);
+            &blinding_key_rv.value);
+        BOOST_REQUIRE_EQUAL(tx_out_rv.result, BLSCT_SUCCESS);
 
-        auto* unsigned_output_rv = build_unsigned_output(static_cast<const BlsctTxOut*>(tx_out_rv->value));
-        BOOST_REQUIRE(unsigned_output_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(unsigned_output_rv->result, BLSCT_SUCCESS);
+        size_t unsigned_output_len = 0;
+        BOOST_REQUIRE_EQUAL(build_unsigned_output(&tx_out_rv.value, nullptr, 0, &unsigned_output_len), BLSCT_SUCCESS);
+        std::vector<char> unsigned_output_hex(unsigned_output_len + 1);
+        BOOST_REQUIRE_EQUAL(build_unsigned_output(&tx_out_rv.value, unsigned_output_hex.data(), unsigned_output_hex.size(), &unsigned_output_len), BLSCT_SUCCESS);
 
-        void* unsigned_tx = create_unsigned_transaction();
-        BOOST_REQUIRE(unsigned_tx != nullptr);
-        add_unsigned_transaction_input(unsigned_tx, unsigned_input_rv->value);
-        add_unsigned_transaction_output(unsigned_tx, unsigned_output_rv->value);
-        set_unsigned_transaction_fee(unsigned_tx, fee);
+        const char* in_hexes[] = {unsigned_input_hex.data()};
+        const char* out_hexes[] = {unsigned_output_hex.data()};
 
-        auto* signed_tx_rv = sign_unsigned_transaction(unsigned_tx);
-        BOOST_REQUIRE(signed_tx_rv != nullptr);
-        BOOST_REQUIRE_EQUAL(signed_tx_rv->result, BLSCT_SUCCESS);
-        const std::string signed_tx_hex(static_cast<const char*>(signed_tx_rv->value));
-
-        free_obj(view_key_rv->value);
-        free(view_key_rv);
-        free_obj(spend_key_rv->value);
-        free(spend_key_rv);
-        free_obj(input_spending_key_rv->value);
-        free(input_spending_key_rv);
-        free_obj(gamma_rv->value);
-        free(gamma_rv);
-        free_obj(blinding_key_rv->value);
-        free(blinding_key_rv);
-        free_obj(default_token_id_rv->value);
-        free(default_token_id_rv);
-        free_obj((void*)spend_pub_key);
-        free_obj((void*)sub_addr_id);
-        free_obj((void*)dest);
-        free_obj(out_point_rv->value);
-        free(out_point_rv);
-        free_obj(tx_in_rv->value);
-        free(tx_in_rv);
-        delete_unsigned_input(unsigned_input_rv->value);
-        free(unsigned_input_rv);
-        free_obj(tx_out_rv->value);
-        free(tx_out_rv);
-        delete_unsigned_output(unsigned_output_rv->value);
-        free(unsigned_output_rv);
-        delete_unsigned_transaction(unsigned_tx);
-        free_obj(signed_tx_rv->value);
-        free(signed_tx_rv);
+        size_t signed_tx_len;
+        BLSCT_RESULT signed_tx_r = sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, nullptr, 0, &signed_tx_len);
+        BOOST_REQUIRE_EQUAL(signed_tx_r, BLSCT_SUCCESS);
+        std::vector<char> signed_tx_buf(signed_tx_len + 1);
+        sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, signed_tx_buf.data(), signed_tx_buf.size(), nullptr);
+        const std::string signed_tx_hex(signed_tx_buf.data());
 
         return signed_tx_hex;
     };
@@ -729,16 +579,14 @@ BOOST_AUTO_TEST_CASE(test_aggregate_transactions)
     const std::string tx1 = build_signed_tx(31, "1111111111111111111111111111111111111111111111111111111111111111", 400, 125);
     const std::string tx2 = build_signed_tx(41, "2222222222222222222222222222222222222222222222222222222222222222", 300, 200);
 
-    void* tx_hex_vec = create_tx_hex_vec();
-    BOOST_REQUIRE(tx_hex_vec != nullptr);
-    add_to_tx_hex_vec(tx_hex_vec, tx1.c_str());
-    add_to_tx_hex_vec(tx_hex_vec, tx2.c_str());
+    const char* tx_hexes[] = {tx1.c_str(), tx2.c_str()};
 
-    auto* aggregate_rv = aggregate_transactions(tx_hex_vec);
-    BOOST_REQUIRE(aggregate_rv != nullptr);
-    BOOST_REQUIRE_EQUAL(aggregate_rv->result, BLSCT_SUCCESS);
-    const char* aggregate_hex = static_cast<const char*>(aggregate_rv->value);
-    BOOST_REQUIRE(aggregate_hex != nullptr);
+    size_t agg_len;
+    BLSCT_RESULT agg_r = aggregate_transactions(tx_hexes, 2, nullptr, 0, &agg_len);
+    BOOST_REQUIRE_EQUAL(agg_r, BLSCT_SUCCESS);
+    std::vector<char> agg_buf(agg_len + 1);
+    aggregate_transactions(tx_hexes, 2, agg_buf.data(), agg_buf.size(), nullptr);
+    const char* aggregate_hex = agg_buf.data();
 
     CMutableTransaction decoded;
     BOOST_REQUIRE(DecodeHexTx(decoded, aggregate_hex));
@@ -749,10 +597,1927 @@ BOOST_AUTO_TEST_CASE(test_aggregate_transactions)
     BOOST_CHECK_EQUAL(aggregated_tx.vout.back().nValue, 325);
     auto fee_predicate = blsct::ParsePredicate(aggregated_tx.vout.back().predicate);
     BOOST_CHECK(fee_predicate.IsPayFeePredicate());
+}
 
-    delete_tx_hex_vec(tx_hex_vec);
-    free_obj(aggregate_rv->value);
-    free(aggregate_rv);
+// ---------------------------------------------------------------------------
+// Smoke tests for previously untested CTx accessor functions
+// ---------------------------------------------------------------------------
+
+// Helper: build a signed tx hex via the unsigned-tx C API
+static std::string BuildSignedTxHex(uint64_t seed_base, uint64_t input_amount, uint64_t output_amount, uint64_t fee)
+{
+    auto view_key_rv = gen_scalar(seed_base + 1);
+    auto spend_key_rv = gen_scalar(seed_base + 2);
+    auto input_sk_rv = gen_scalar(seed_base + 3);
+    auto gamma_rv = gen_scalar(seed_base + 4);
+    auto blind_rv = gen_scalar(seed_base + 5);
+    auto tid_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(view_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(input_sk_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(blind_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult spend_pub_rv = scalar_to_pub_key(&spend_key_rv.value);
+    BlsctSubAddrIdResult sub_id_rv = gen_sub_addr_id(0, seed_base);
+    BOOST_REQUIRE_EQUAL(spend_pub_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(sub_id_rv.result, BLSCT_SUCCESS);
+    auto* spend_pub = &spend_pub_rv.value;
+    auto* sub_id = &sub_id_rv.value;
+    BlsctSubAddrResult dest_rv2 = derive_sub_address(&view_key_rv.value, spend_pub, sub_id);
+    BOOST_REQUIRE_EQUAL(dest_rv2.result, BLSCT_SUCCESS);
+    auto* dest = &dest_rv2.value;
+
+    auto op_rv = gen_out_point("aabbccdd0011223344556677889900aabbccddeeff00112233445566778899aa");
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+
+    auto in_rv = build_tx_in(input_amount,
+                             &gamma_rv.value,
+                             &input_sk_rv.value,
+                             &tid_rv.value,
+                             &op_rv.value, false, false);
+    BOOST_REQUIRE_EQUAL(in_rv.result, BLSCT_SUCCESS);
+
+    size_t uin_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&in_rv.value, nullptr, 0, &uin_len), BLSCT_SUCCESS);
+    std::vector<char> uin_hex(uin_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&in_rv.value, uin_hex.data(), uin_hex.size(), &uin_len), BLSCT_SUCCESS);
+
+    auto out_rv = build_tx_out(dest, output_amount, "smoke",
+                               &tid_rv.value,
+                               TxOutputType::Normal, 0, false,
+                               &blind_rv.value);
+    BOOST_REQUIRE_EQUAL(out_rv.result, BLSCT_SUCCESS);
+
+    size_t uout_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&out_rv.value, nullptr, 0, &uout_len), BLSCT_SUCCESS);
+    std::vector<char> uout_hex(uout_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&out_rv.value, uout_hex.data(), uout_hex.size(), &uout_len), BLSCT_SUCCESS);
+
+    const char* in_hexes[] = {uin_hex.data()};
+    const char* out_hexes[] = {uout_hex.data()};
+
+    size_t signed_len;
+    BLSCT_RESULT signed_r = sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, nullptr, 0, &signed_len);
+    BOOST_REQUIRE_EQUAL(signed_r, BLSCT_SUCCESS);
+    std::vector<char> signed_buf(signed_len + 1);
+    sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, signed_buf.data(), signed_buf.size(), nullptr);
+    std::string hex(signed_buf.data());
+
+    return hex;
+}
+
+// Build a signed CMutableTransaction from hex
+static CMutableTransaction DecodeTx(const std::string& hex)
+{
+    CMutableTransaction tx;
+    BOOST_REQUIRE(DecodeHexTx(tx, hex));
+    return tx;
+}
+
+// Build a signed tx hex via the unsigned-tx C API (ctx-level accessor input)
+static std::string BuildCtxViaApi(uint64_t input_amount, uint64_t output_amount, uint64_t fee = 125)
+{
+    auto view_key_rv = gen_scalar(201);
+    auto spend_key_rv = gen_scalar(202);
+    auto input_sk_rv = gen_scalar(203);
+    auto gamma_rv = gen_scalar(204);
+    auto blind_rv = gen_scalar(205);
+    auto tid_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(view_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_key_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(input_sk_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(blind_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult spend_pub_rv2 = scalar_to_pub_key(&spend_key_rv.value);
+    BlsctSubAddrIdResult sub_id_rv2 = gen_sub_addr_id(0, 7);
+    BOOST_REQUIRE_EQUAL(spend_pub_rv2.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(sub_id_rv2.result, BLSCT_SUCCESS);
+    auto* spend_pub = &spend_pub_rv2.value;
+    auto* sub_id = &sub_id_rv2.value;
+    BlsctSubAddrResult dest_rv3 = derive_sub_address(&view_key_rv.value, spend_pub, sub_id);
+    BOOST_REQUIRE_EQUAL(dest_rv3.result, BLSCT_SUCCESS);
+    auto* dest = &dest_rv3.value;
+
+    auto op_rv = gen_out_point("deadbeef0000000000000000000000000000000000000000000000000000cafe");
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+
+    auto in_rv = build_tx_in(input_amount,
+                             &gamma_rv.value,
+                             &input_sk_rv.value,
+                             &tid_rv.value,
+                             &op_rv.value, false, false);
+    BOOST_REQUIRE_EQUAL(in_rv.result, BLSCT_SUCCESS);
+
+    size_t uin_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&in_rv.value, nullptr, 0, &uin_len), BLSCT_SUCCESS);
+    std::vector<char> uin_hex(uin_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&in_rv.value, uin_hex.data(), uin_hex.size(), &uin_len), BLSCT_SUCCESS);
+
+    auto out_rv = build_tx_out(dest, output_amount, "ctxtest",
+                               &tid_rv.value,
+                               TxOutputType::Normal, 0, false,
+                               &blind_rv.value);
+    BOOST_REQUIRE_EQUAL(out_rv.result, BLSCT_SUCCESS);
+
+    size_t uout_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&out_rv.value, nullptr, 0, &uout_len), BLSCT_SUCCESS);
+    std::vector<char> uout_hex(uout_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_output(&out_rv.value, uout_hex.data(), uout_hex.size(), &uout_len), BLSCT_SUCCESS);
+
+    const char* in_hexes[] = {uin_hex.data()};
+    const char* out_hexes[] = {uout_hex.data()};
+
+    size_t signed_len;
+    BLSCT_RESULT signed_r = sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, nullptr, 0, &signed_len);
+    BOOST_REQUIRE_EQUAL(signed_r, BLSCT_SUCCESS);
+    std::vector<char> signed_buf(signed_len + 1);
+    sign_unsigned_transaction(in_hexes, 1, out_hexes, 1, fee, signed_buf.data(), signed_buf.size(), nullptr);
+
+    return std::string(signed_buf.data());
+}
+
+BOOST_AUTO_TEST_CASE(test_build_ctx_and_serialization)
+{
+    init();
+
+    std::string ctx_hex = BuildCtxViaApi(1000, 500);
+    BOOST_REQUIRE(!ctx_hex.empty());
+
+    // get_ctx_id returns a non-empty hex string
+    BlsctCTxIdHexResult ctx_id_rv = get_ctx_id(ctx_hex.c_str());
+    BOOST_REQUIRE_EQUAL(ctx_id_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::strlen(ctx_id_rv.value), 64u); // 32 bytes = 64 hex chars
+
+    // same hex produces same id (round-trip is implicit — the hex IS the serialized form)
+    BlsctCTxIdHexResult ctx_id2_rv = get_ctx_id(ctx_hex.c_str());
+    BOOST_REQUIRE_EQUAL(ctx_id2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(ctx_id_rv.value), std::string(ctx_id2_rv.value));
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_in_vector_accessors)
+{
+    init();
+
+    std::string tx_hex = BuildSignedTxHex(51, 1000, 400, 100);
+    CMutableTransaction mtx = DecodeTx(tx_hex);
+    BOOST_CHECK(!mtx.vin.empty());
+
+    std::string ctx_hex = BuildCtxViaApi(1000, 400);
+    BOOST_REQUIRE(!ctx_hex.empty());
+
+    auto ins_sz_rv = get_ctx_ins_size(ctx_hex.c_str());
+    BOOST_REQUIRE_EQUAL(ins_sz_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(ins_sz_rv.value, 1u);
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_in_field_accessors)
+{
+    init();
+
+    std::string ctx_hex = BuildCtxViaApi(1000, 500);
+    BOOST_REQUIRE(!ctx_hex.empty());
+
+    // prev_out_hash is a 32-byte CTxId
+    BlsctCTxIdResult prev_hash_rv = get_ctx_in_prev_out_hash_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(prev_hash_rv.result, BLSCT_SUCCESS);
+    // BuildCtxViaApi uses a hard-coded non-zero outpoint hash ("deadbeef..."), so must be non-zero
+    bool all_zero = true;
+    for (size_t i = 0; i < CTX_ID_SIZE; ++i) {
+        if (prev_hash_rv.value[i] != 0) {
+            all_zero = false;
+            break;
+        }
+    }
+    BOOST_CHECK(!all_zero);
+
+    // scriptSig (blsct inputs have empty scriptSig)
+    BlsctScriptResult script_sig_rv = get_ctx_in_script_sig_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(script_sig_rv.result, BLSCT_SUCCESS);
+
+    // sequence — non-rbf input => 0xffffffff
+    auto seq_rv = get_ctx_in_sequence_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(seq_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(seq_rv.value, 0xffffffffU);
+
+    // scriptWitness
+    BlsctScriptResult witness_rv = get_ctx_in_script_witness_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(witness_rv.result, BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_out_vector_and_field_accessors)
+{
+    init();
+
+    const uint64_t test_fee = 125;
+    std::string ctx_hex = BuildCtxViaApi(2000, 800, test_fee);
+    BOOST_REQUIRE(!ctx_hex.empty());
+
+    // 1 data output + 1 fee output = 2
+    auto outs_sz_rv = get_ctx_outs_size(ctx_hex.c_str());
+    BOOST_REQUIRE_EQUAL(outs_sz_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(outs_sz_rv.value, 2u);
+
+    // out0 = data output, out1 = fee output
+    // data output nValue is 0 (actual amount is in the range proof)
+    BOOST_CHECK_EQUAL(get_ctx_out_value_at(ctx_hex.c_str(), 0).value, 0u);
+
+    // fee output nValue is the fee amount
+    BOOST_CHECK_EQUAL(get_ctx_out_value_at(ctx_hex.c_str(), 1).value, test_fee);
+
+    // data output: scriptPubKey
+    BlsctScriptResult spk_rv = get_ctx_out_script_pub_key_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(spk_rv.result, BLSCT_SUCCESS);
+
+    // data output: token_id
+    BlsctTokenIdResult tok_rv = get_ctx_out_token_id_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(tok_rv.result, BLSCT_SUCCESS);
+
+    // data output: spending_key, ephemeral_key, blinding_key
+    BlsctPointResult sk_rv = get_ctx_out_spending_key_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+
+    BlsctPointResult ek_rv = get_ctx_out_ephemeral_key_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(ek_rv.result, BLSCT_SUCCESS);
+
+    BlsctPointResult bk_rv = get_ctx_out_blinding_key_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(bk_rv.result, BLSCT_SUCCESS);
+
+    // data output: view_tag
+    BlsctUint16Result vt_rv = get_ctx_out_view_tag_at(ctx_hex.c_str(), 0);
+    BOOST_REQUIRE_EQUAL(vt_rv.result, BLSCT_SUCCESS);
+
+    // data output: range_proof (non-empty)
+    size_t rp_len = 0;
+    BOOST_REQUIRE_EQUAL(get_ctx_out_range_proof_at(ctx_hex.c_str(), 0, nullptr, 0, &rp_len), BLSCT_SUCCESS);
+    BOOST_CHECK(rp_len > 0);
+    std::vector<uint8_t> rp_buf(rp_len);
+    BOOST_REQUIRE_EQUAL(get_ctx_out_range_proof_at(ctx_hex.c_str(), 0, rp_buf.data(), rp_buf.size(), &rp_len), BLSCT_SUCCESS);
+
+    // fee output: vector_predicate (PayFeePredicate)
+    size_t pred_len = 0;
+    BOOST_REQUIRE_EQUAL(get_ctx_out_vector_predicate_at(ctx_hex.c_str(), 1, nullptr, 0, &pred_len), BLSCT_SUCCESS);
+    BOOST_CHECK(pred_len > 0);
+
+    // are_ctx_outs_equal — same hex compared to itself
+    BOOST_CHECK(are_ctx_outs_equal(ctx_hex.c_str(), ctx_hex.c_str()));
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_vector_equal_handles_null_inputs)
+{
+    init();
+
+    BOOST_CHECK(!are_ctx_ins_equal(nullptr, nullptr));
+    BOOST_CHECK(!are_ctx_outs_equal(nullptr, nullptr));
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_in_equal_handles_null_inputs)
+{
+    init();
+
+    uint256 hash;
+    hash.SetHex("1111111111111111111111111111111111111111111111111111111111111111");
+    CTxIn tx_in{COutPoint{hash}};
+    const void* p = reinterpret_cast<const void*>(&tx_in);
+
+    BOOST_CHECK(!are_ctx_in_equal(nullptr, nullptr));
+    BOOST_CHECK(!are_ctx_in_equal(nullptr, p));
+    BOOST_CHECK(!are_ctx_in_equal(p, nullptr));
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_out_equal_handles_null_inputs)
+{
+    init();
+
+    CTxOut tx_out{};
+    const void* p = reinterpret_cast<const void*>(&tx_out);
+
+    BOOST_CHECK(!are_ctx_out_equal(nullptr, nullptr));
+    BOOST_CHECK(!are_ctx_out_equal(nullptr, p));
+    BOOST_CHECK(!are_ctx_out_equal(p, nullptr));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_vector_predicate_handles_null)
+{
+    init();
+
+    size_t pred_len = 0;
+    BLSCT_RESULT rv = get_ctx_out_vector_predicate(nullptr, nullptr, 0, &pred_len);
+    BOOST_CHECK(rv != BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_ins_equality_across_instances)
+{
+    init();
+
+    // Build two ctxs via BuildCtxViaApi and compare their ins/outs
+    std::string hex_a = BuildCtxViaApi(1500, 600);
+    std::string hex_b = BuildCtxViaApi(1500, 600);
+    BOOST_REQUIRE(!hex_a.empty() && !hex_b.empty());
+
+    // Both have 1 input
+    auto ins_a_rv = get_ctx_ins_size(hex_a.c_str());
+    BOOST_REQUIRE_EQUAL(ins_a_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(ins_a_rv.value, 1u);
+    auto ins_b_rv = get_ctx_ins_size(hex_b.c_str());
+    BOOST_REQUIRE_EQUAL(ins_b_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(ins_b_rv.value, 1u);
+
+    auto outs_a_rv = get_ctx_outs_size(hex_a.c_str());
+    BOOST_REQUIRE_EQUAL(outs_a_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(outs_a_rv.value, 2u);
+    auto outs_b_rv = get_ctx_outs_size(hex_b.c_str());
+    BOOST_REQUIRE_EQUAL(outs_b_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(outs_b_rv.value, 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Smoke tests for range proof functions
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_range_proof_build_and_verify)
+{
+    init();
+
+    auto tid_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+
+    // Create a nonce
+    auto nonce_rv = gen_base_point();
+    BOOST_REQUIRE_EQUAL(nonce_rv.result, BLSCT_SUCCESS);
+
+    // Build range proof
+    uint64_t amounts[] = {42};
+    size_t rp_len = 0;
+    BOOST_REQUIRE_EQUAL(build_range_proof(amounts, 1, &nonce_rv.value, "smoke_test", &tid_rv.value, nullptr, 0, &rp_len), BLSCT_SUCCESS);
+    BOOST_CHECK(rp_len > 0);
+    std::vector<uint8_t> rp_buf(rp_len);
+    BOOST_REQUIRE_EQUAL(build_range_proof(amounts, 1, &nonce_rv.value, "smoke_test", &tid_rv.value, rp_buf.data(), rp_buf.size(), &rp_len), BLSCT_SUCCESS);
+
+    // Accessor getters — each returns a typed result struct
+    BlsctPointResult rp_A_rv = get_range_proof_A(rp_buf.data(), rp_len);
+    BlsctPointResult rp_A_wip_rv = get_range_proof_A_wip(rp_buf.data(), rp_len);
+    BlsctPointResult rp_B_rv = get_range_proof_B(rp_buf.data(), rp_len);
+    BOOST_REQUIRE_EQUAL(rp_A_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_A_wip_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_B_rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarResult rp_r_prime_rv = get_range_proof_r_prime(rp_buf.data(), rp_len);
+    BlsctScalarResult rp_s_prime_rv = get_range_proof_s_prime(rp_buf.data(), rp_len);
+    BlsctScalarResult rp_delta_prime_rv = get_range_proof_delta_prime(rp_buf.data(), rp_len);
+    BlsctScalarResult rp_alpha_hat_rv = get_range_proof_alpha_hat(rp_buf.data(), rp_len);
+    BlsctScalarResult rp_tau_x_rv = get_range_proof_tau_x(rp_buf.data(), rp_len);
+    BOOST_REQUIRE_EQUAL(rp_r_prime_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_s_prime_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_delta_prime_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_alpha_hat_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rp_tau_x_rv.result, BLSCT_SUCCESS);
+
+    // Verify
+    const BlsctRangeProof* proofs[] = {rp_buf.data()};
+    size_t proof_sizes[] = {rp_len};
+    auto verify_rv = verify_range_proofs(proofs, proof_sizes, 1);
+    BOOST_REQUIRE_EQUAL(verify_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(verify_rv.value);
+
+    // Serialize / deserialize round-trip
+    auto rp_sz_rv = serialize_range_proof(rp_buf.data(), rp_len, nullptr, 0);
+    BOOST_REQUIRE_EQUAL(rp_sz_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(rp_sz_rv.value > 0);
+    std::vector<char> rp_hex(rp_sz_rv.value + 1);
+    auto rp_w_rv = serialize_range_proof(rp_buf.data(), rp_len, rp_hex.data(), rp_hex.size());
+    BOOST_REQUIRE_EQUAL(rp_w_rv.result, BLSCT_SUCCESS);
+
+    size_t deser_len = 0;
+    BOOST_REQUIRE_EQUAL(deserialize_range_proof(rp_hex.data(), rp_len, nullptr, 0, &deser_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> deser_buf(deser_len);
+    BOOST_REQUIRE_EQUAL(deserialize_range_proof(rp_hex.data(), rp_len, deser_buf.data(), deser_buf.size(), &deser_len), BLSCT_SUCCESS);
+}
+
+// ---------------------------------------------------------------------------
+// Smoke test for are_vector_predicate_equal
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_vector_predicate_equality)
+{
+    init();
+
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+
+    size_t pred_a_len = 0;
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, nullptr, 0, &pred_a_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> pred_a_buf(pred_a_len);
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, pred_a_buf.data(), pred_a_buf.size(), &pred_a_len), BLSCT_SUCCESS);
+
+    size_t pred_b_len = 0;
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, nullptr, 0, &pred_b_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> pred_b_buf(pred_b_len);
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, pred_b_buf.data(), pred_b_buf.size(), &pred_b_len), BLSCT_SUCCESS);
+
+    // Same predicate bytes => equal
+    BOOST_CHECK_EQUAL(are_vector_predicate_equal(pred_a_buf.data(), pred_a_len, pred_b_buf.data(), pred_b_len), 1);
+
+    // Different size => not equal
+    BOOST_CHECK_EQUAL(are_vector_predicate_equal(pred_a_buf.data(), pred_a_len, pred_b_buf.data(), pred_b_len - 1), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Scalar operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_scalar_serialize_deserialize_roundtrip)
+{
+    init();
+
+    auto rv = gen_scalar(42);
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarHexResult hex_rv = serialize_scalar(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(strlen(hex_rv.value) > 0);
+
+    auto deser_rv = deserialize_scalar(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(are_scalar_equal(&rv.value, &deser_rv.value), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_scalar_to_uint64)
+{
+    init();
+
+    auto rv = gen_scalar(12345);
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK_EQUAL(scalar_to_uint64(&rv.value).value, 12345u);
+}
+
+BOOST_AUTO_TEST_CASE(test_scalar_to_str)
+{
+    init();
+
+    auto rv = gen_scalar(1);
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    auto sz_rv = scalar_to_str(&rv.value, nullptr, 0);
+    BOOST_REQUIRE_EQUAL(sz_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(sz_rv.value > 0);
+    std::vector<char> str(sz_rv.value + 1);
+    auto w_rv = scalar_to_str(&rv.value, str.data(), str.size());
+    BOOST_REQUIRE_EQUAL(w_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(strlen(str.data()) > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Point operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_point_serialize_deserialize_roundtrip)
+{
+    init();
+
+    auto rv = gen_base_point();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctPointHexResult hex_rv = serialize_point(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), POINT_SIZE * 2u);
+
+    auto deser_rv = deserialize_point(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(are_point_equal(&rv.value, &deser_rv.value), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_gen_random_point)
+{
+    init();
+
+    auto rv = gen_random_point();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_are_point_equal)
+{
+    init();
+
+    auto rv_a = gen_base_point();
+    auto rv_b = gen_base_point();
+    auto rv_c = gen_random_point();
+    BOOST_REQUIRE_EQUAL(rv_a.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rv_b.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(rv_c.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK_EQUAL(are_point_equal(&rv_a.value, &rv_b.value), 1);
+    BOOST_CHECK_EQUAL(are_point_equal(&rv_a.value, &rv_c.value), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_is_valid_point)
+{
+    init();
+
+    auto rv = gen_base_point();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK(is_valid_point(&rv.value));
+}
+
+BOOST_AUTO_TEST_CASE(test_point_to_str)
+{
+    init();
+
+    auto rv = gen_base_point();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    auto sz_rv = point_to_str(&rv.value, nullptr, 0);
+    BOOST_REQUIRE_EQUAL(sz_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(sz_rv.value > 0);
+    std::vector<char> str(sz_rv.value + 1);
+    auto w_rv = point_to_str(&rv.value, str.data(), str.size());
+    BOOST_REQUIRE_EQUAL(w_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(strlen(str.data()) > 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_scalar_multiply_point)
+{
+    init();
+
+    auto p_rv = gen_base_point();
+    auto s_rv = gen_scalar(2);
+    BOOST_REQUIRE_EQUAL(p_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+
+    BlsctPointResult result_rv = scalar_muliply_point(&p_rv.value, &s_rv.value);
+    BOOST_REQUIRE_EQUAL(result_rv.result, BLSCT_SUCCESS);
+    // 2*G != G
+    BOOST_CHECK_EQUAL(are_point_equal(&result_rv.value, &p_rv.value), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_point_from_scalar)
+{
+    init();
+
+    auto s_rv = gen_scalar(1);
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+
+    BlsctPointResult p_rv2 = point_from_scalar(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(p_rv2.result, BLSCT_SUCCESS);
+
+    auto base_rv = gen_base_point();
+    BOOST_REQUIRE_EQUAL(base_rv.result, BLSCT_SUCCESS);
+
+    // 1*G == G
+    BOOST_CHECK_EQUAL(are_point_equal(&p_rv2.value, &base_rv.value), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Public key operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_public_key_serialize_deserialize_roundtrip)
+{
+    init();
+
+    auto rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctPointHexResult hex_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&rv.value));
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+
+    auto deser_rv = deserialize_public_key(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_public_key_point_and_back)
+{
+    init();
+
+    auto rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctPointResult pt_rv = get_public_key_point(&rv.value);
+    BOOST_REQUIRE_EQUAL(pt_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult pk2_rv = point_to_public_key(&pt_rv.value);
+    BOOST_REQUIRE_EQUAL(pk2_rv.result, BLSCT_SUCCESS);
+
+    // round-trip: pk == pk2
+    BlsctPointHexResult hex1_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&rv.value));
+    BlsctPointHexResult hex2_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&pk2_rv.value));
+    BOOST_REQUIRE_EQUAL(hex1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(hex2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(hex1_rv.value), std::string(hex2_rv.value));
+}
+
+// ---------------------------------------------------------------------------
+// Double public key (DPK) operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_gen_double_pub_key_and_serialize_roundtrip)
+{
+    init();
+
+    auto pk1_rv = gen_random_public_key();
+    auto pk2_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(pk2_rv.result, BLSCT_SUCCESS);
+
+    auto dpk_rv = gen_double_pub_key(&pk1_rv.value, &pk2_rv.value);
+    BOOST_REQUIRE_EQUAL(dpk_rv.result, BLSCT_SUCCESS);
+
+    BlsctDoublePubKeyHexResult hex_rv = serialize_dpk(&dpk_rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), DOUBLE_PUBLIC_KEY_SIZE * 2u);
+
+    auto deser_rv = deserialize_dpk(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_dpk_to_sub_addr_and_back)
+{
+    init();
+
+    auto pk1_rv = gen_random_public_key();
+    auto pk2_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(pk2_rv.result, BLSCT_SUCCESS);
+
+    auto dpk_rv = gen_double_pub_key(&pk1_rv.value, &pk2_rv.value);
+    BOOST_REQUIRE_EQUAL(dpk_rv.result, BLSCT_SUCCESS);
+
+    auto sub_rv = dpk_to_sub_addr(&dpk_rv.value);
+    BOOST_REQUIRE_EQUAL(sub_rv.result, BLSCT_SUCCESS);
+
+    BlsctDoublePubKeyResult dpk2_rv = sub_addr_to_dpk(&sub_rv.value);
+    BOOST_REQUIRE_EQUAL(dpk2_rv.result, BLSCT_SUCCESS);
+
+    BlsctDoublePubKeyHexResult h1_rv = serialize_dpk(&dpk_rv.value);
+    BlsctDoublePubKeyHexResult h2_rv = serialize_dpk(&dpk2_rv.value);
+    BOOST_REQUIRE_EQUAL(h1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(h2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(h1_rv.value), std::string(h2_rv.value));
+}
+
+// ---------------------------------------------------------------------------
+// Address encode/decode
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_encode_decode_address_roundtrip)
+{
+    init();
+
+    auto pk1_rv = gen_random_public_key();
+    auto pk2_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(pk2_rv.result, BLSCT_SUCCESS);
+
+    auto dpk_rv = gen_double_pub_key(&pk1_rv.value, &pk2_rv.value);
+    BOOST_REQUIRE_EQUAL(dpk_rv.result, BLSCT_SUCCESS);
+
+    size_t addr_len;
+    BLSCT_RESULT enc_r = encode_address(&dpk_rv.value, Bech32, nullptr, 0, &addr_len);
+    BOOST_REQUIRE_EQUAL(enc_r, BLSCT_SUCCESS);
+    std::vector<char> addr_buf(addr_len + 1);
+    encode_address(&dpk_rv.value, Bech32, addr_buf.data(), addr_buf.size(), nullptr);
+    const char* addr = addr_buf.data();
+
+    auto dec_rv = decode_address(addr);
+    BOOST_REQUIRE_EQUAL(dec_rv.result, BLSCT_SUCCESS);
+
+    BlsctDoublePubKeyHexResult h1_rv = serialize_dpk(&dpk_rv.value);
+    BlsctDoublePubKeyHexResult h2_rv = serialize_dpk(&dec_rv.value);
+    BOOST_REQUIRE_EQUAL(h1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(h2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(h1_rv.value), std::string(h2_rv.value));
+}
+
+// ---------------------------------------------------------------------------
+// Key ID operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_calc_key_id_and_serialize_roundtrip)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult blind_pk_rv = scalar_to_pub_key(&s_rv.value);
+    BlsctPubKeyResult spend_pk_rv = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_pk_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_pk_rv.result, BLSCT_SUCCESS);
+
+    BlsctKeyIdResult key_id_rv = calc_key_id(&blind_pk_rv.value, &spend_pk_rv.value, &s_rv.value);
+    BOOST_REQUIRE_EQUAL(key_id_rv.result, BLSCT_SUCCESS);
+
+    BlsctKeyIdHexResult hex_rv = serialize_key_id(&key_id_rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), KEY_ID_SIZE * 2u);
+
+    auto deser_rv = deserialize_key_id(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+}
+
+// ---------------------------------------------------------------------------
+// Sub-address operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_serialize_deserialize_sub_addr_roundtrip)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult spend_pk_rv2 = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(spend_pk_rv2.result, BLSCT_SUCCESS);
+    auto* spend_pk = &spend_pk_rv2.value;
+
+    BlsctSubAddrIdResult sub_id_rv3 = gen_sub_addr_id(0, 0);
+    BOOST_REQUIRE_EQUAL(sub_id_rv3.result, BLSCT_SUCCESS);
+    auto* sub_id = &sub_id_rv3.value;
+
+    BlsctSubAddrResult sub_rv2 = derive_sub_address(&s_rv.value, spend_pk, sub_id);
+    BOOST_REQUIRE_EQUAL(sub_rv2.result, BLSCT_SUCCESS);
+    auto* sub = &sub_rv2.value;
+
+    BlsctSubAddrHexResult hex_rv = serialize_sub_addr(sub);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), SUB_ADDR_SIZE * 2u);
+
+    auto deser_rv = deserialize_sub_addr(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+}
+
+// ---------------------------------------------------------------------------
+// Sub-address ID operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_sub_addr_id_fields_and_roundtrip)
+{
+    init();
+
+    BlsctSubAddrIdResult sub_id_rv4 = gen_sub_addr_id(7, 42);
+    BOOST_REQUIRE_EQUAL(sub_id_rv4.result, BLSCT_SUCCESS);
+    auto* sub_id = &sub_id_rv4.value;
+
+    auto acct_rv = get_sub_addr_id_account(sub_id);
+    BOOST_REQUIRE_EQUAL(acct_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(acct_rv.value, 7);
+    auto addr_rv = get_sub_addr_id_address(sub_id);
+    BOOST_REQUIRE_EQUAL(addr_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(addr_rv.value, 42u);
+
+    BlsctSubAddrIdHexResult hex_rv = serialize_sub_addr_id(sub_id);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), SUB_ADDR_ID_SIZE * 2u);
+
+    auto deser_rv = deserialize_sub_addr_id(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+    auto acct_rv2 = get_sub_addr_id_account(&deser_rv.value);
+    BOOST_REQUIRE_EQUAL(acct_rv2.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(acct_rv2.value, 7);
+    auto addr_rv2 = get_sub_addr_id_address(&deser_rv.value);
+    BOOST_REQUIRE_EQUAL(addr_rv2.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(addr_rv2.value, 42u);
+}
+
+// ---------------------------------------------------------------------------
+// Out point operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_out_point_serialize_deserialize_roundtrip)
+{
+    init();
+
+    std::string txid_hex(64, '1');
+    auto rv = gen_out_point(txid_hex.c_str());
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctOutPointHexResult hex_rv = serialize_out_point(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+
+    auto deser_rv = deserialize_out_point(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_gen_out_point_bad_inputs)
+{
+    init();
+
+    BOOST_CHECK_EQUAL(gen_out_point(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(gen_out_point("").result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(gen_out_point("deadbeef").result, BLSCT_FAILURE);
+    // one char short
+    BOOST_CHECK_EQUAL(gen_out_point(std::string(63, '0').c_str()).result, BLSCT_FAILURE);
+    // one char long
+    BOOST_CHECK_EQUAL(gen_out_point(std::string(65, '0').c_str()).result, BLSCT_FAILURE);
+
+    uninit();
+}
+
+// ---------------------------------------------------------------------------
+// Token ID operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_token_id_fields_and_roundtrip)
+{
+    init();
+
+    auto rv = gen_token_id_with_token_and_subid(99, 7);
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK_EQUAL(get_token_id_token(&rv.value).value, 99u);
+    BOOST_CHECK_EQUAL(get_token_id_subid(&rv.value).value, 7u);
+
+    BlsctTokenIdHexResult hex_rv = serialize_token_id(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+
+    auto deser_rv = deserialize_token_id(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(get_token_id_token(&deser_rv.value).value, 99u);
+    BOOST_CHECK_EQUAL(get_token_id_subid(&deser_rv.value).value, 7u);
+}
+
+BOOST_AUTO_TEST_CASE(test_gen_token_id)
+{
+    init();
+
+    auto rv = gen_token_id(55);
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(get_token_id_token(&rv.value).value, 55u);
+}
+
+// ---------------------------------------------------------------------------
+// CTx ID operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_ctx_id_serialize_deserialize_roundtrip)
+{
+    init();
+
+    std::string hex64(64, 'a');
+    auto rv = deserialize_ctx_id(hex64.c_str());
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctCTxIdHexResult hex_rv = serialize_ctx_id(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(hex_rv.value), hex64);
+}
+
+// ---------------------------------------------------------------------------
+// Script operations
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_script_serialize_deserialize_roundtrip)
+{
+    init();
+
+    std::string hex56(SCRIPT_SIZE * 2, 'b');
+    auto rv = deserialize_script(hex56.c_str());
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+
+    BlsctScriptHexResult hex_rv = serialize_script(&rv.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(hex_rv.value), hex56);
+}
+
+// ---------------------------------------------------------------------------
+// Signature: sign + verify + serialize/deserialize
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_sign_and_verify_message)
+{
+    init();
+
+    auto sk_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult pk_rv = scalar_to_pub_key(&sk_rv.value);
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+    auto* pk = &pk_rv.value;
+
+    const char* msg = "hello blsct";
+    BlsctSignatureResult sig_rv = sign_message(&sk_rv.value, msg);
+    BOOST_REQUIRE_EQUAL(sig_rv.result, BLSCT_SUCCESS);
+    auto* sig = &sig_rv.value;
+
+    BOOST_CHECK(verify_msg_sig(pk, msg, sig));
+    BOOST_CHECK(!verify_msg_sig(pk, "wrong message", sig));
+
+    BlsctSignatureHexResult hex_rv = serialize_signature(sig);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), SIGNATURE_SIZE * 2u);
+
+    auto deser_rv = deserialize_signature(hex_rv.value);
+    BOOST_REQUIRE_EQUAL(deser_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(verify_msg_sig(pk, msg, &deser_rv.value));
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation chain
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_key_derivation_chain)
+{
+    init();
+
+    auto seed_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(seed_rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarResult child_rv = from_seed_to_child_key(&seed_rv.value);
+    BOOST_REQUIRE_EQUAL(child_rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarResult blind_rv = from_child_key_to_blinding_key(&child_rv.value);
+    BlsctScalarResult token_rv = from_child_key_to_token_key(&child_rv.value);
+    BlsctScalarResult txkey_rv = from_child_key_to_tx_key(&child_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(token_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(txkey_rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarResult view_rv = from_tx_key_to_view_key(&txkey_rv.value);
+    BlsctScalarResult spend_rv = from_tx_key_to_spending_key(&txkey_rv.value);
+    BOOST_REQUIRE_EQUAL(view_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_rv.result, BLSCT_SUCCESS);
+
+    // All derived keys succeed — smoke test only
+}
+
+BOOST_AUTO_TEST_CASE(test_key_derivation_chain_null_inputs)
+{
+    init();
+
+    BOOST_CHECK_EQUAL(from_seed_to_child_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(from_child_key_to_blinding_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(from_child_key_to_token_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(from_child_key_to_tx_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(from_tx_key_to_view_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(from_tx_key_to_spending_key(nullptr).result, BLSCT_FAILURE);
+
+    uninit();
+}
+
+// ---------------------------------------------------------------------------
+// calc_nonce, calc_view_tag, calc_priv_spending_key, gen_dpk_with_keys_acct_addr
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_calc_nonce_and_view_tag)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult blind_pk_rv2 = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_pk_rv2.result, BLSCT_SUCCESS);
+    auto* blind_pk = &blind_pk_rv2.value;
+
+    BlsctPointResult nonce_rv2 = calc_nonce(blind_pk, &s_rv.value);
+    BOOST_REQUIRE_EQUAL(nonce_rv2.result, BLSCT_SUCCESS);
+
+    auto tag_rv = calc_view_tag(blind_pk, &s_rv.value);
+    BOOST_REQUIRE_EQUAL(tag_rv.result, BLSCT_SUCCESS);
+    // tag is deterministic — calling again must give same value
+    auto tag_rv2 = calc_view_tag(blind_pk, &s_rv.value);
+    BOOST_REQUIRE_EQUAL(tag_rv2.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(tag_rv2.value, tag_rv.value);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_calc_nonce_null_inputs)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult blind_pk_rv = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_pk_rv.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK_EQUAL(calc_nonce(nullptr, &s_rv.value).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_nonce(&blind_pk_rv.value, nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_nonce(nullptr, nullptr).result, BLSCT_FAILURE);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_calc_priv_spending_key)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult blind_pk_rv3 = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_pk_rv3.result, BLSCT_SUCCESS);
+    auto* blind_pk = &blind_pk_rv3.value;
+
+    BlsctScalarResult priv_spend_rv = calc_priv_spending_key(blind_pk, &s_rv.value, &s_rv.value, 0, 0);
+    BOOST_REQUIRE_EQUAL(priv_spend_rv.result, BLSCT_SUCCESS);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_calc_priv_spending_key_null_inputs)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult blind_pk_rv = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(blind_pk_rv.result, BLSCT_SUCCESS);
+    auto* blind_pk = &blind_pk_rv.value;
+    auto* scalar = &s_rv.value;
+
+    BOOST_CHECK_EQUAL(calc_priv_spending_key(nullptr, scalar, scalar, 0, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_priv_spending_key(blind_pk, nullptr, scalar, 0, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_priv_spending_key(blind_pk, scalar, nullptr, 0, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_priv_spending_key(nullptr, nullptr, nullptr, 0, 0).result, BLSCT_FAILURE);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_gen_dpk_with_keys_acct_addr)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BlsctPubKeyResult spend_pk_rv4 = scalar_to_pub_key(&s_rv.value);
+    BOOST_REQUIRE_EQUAL(spend_pk_rv4.result, BLSCT_SUCCESS);
+    auto* spend_pk = &spend_pk_rv4.value;
+
+    BlsctDoublePubKeyResult dpk_rv2 = gen_dpk_with_keys_acct_addr(&s_rv.value, spend_pk, 0, 0);
+    BOOST_REQUIRE_EQUAL(dpk_rv2.result, BLSCT_SUCCESS);
+
+    BlsctDoublePubKeyHexResult hex_rv = serialize_dpk(&dpk_rv2.value);
+    BOOST_REQUIRE_EQUAL(hex_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(strlen(hex_rv.value), DOUBLE_PUBLIC_KEY_SIZE * 2u);
+}
+
+// ---------------------------------------------------------------------------
+// TxIn / TxOut accessor round-trips
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_tx_in_accessors)
+{
+    init();
+
+    auto gamma_rv = gen_scalar(10);
+    auto sk_rv = gen_scalar(20);
+    auto tid_rv = gen_default_token_id();
+    auto op_rv = gen_out_point(std::string(64, '0').c_str());
+    BOOST_REQUIRE_EQUAL(gamma_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+
+    auto tx_in_rv = build_tx_in(1000, &gamma_rv.value, &sk_rv.value, &tid_rv.value, &op_rv.value, true, true);
+    BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
+    auto* tx_in = &tx_in_rv.value;
+
+    auto amt_rv2 = get_tx_in_amount(tx_in);
+    BOOST_REQUIRE_EQUAL(amt_rv2.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(amt_rv2.value, 1000u);
+    auto staked_rv = get_tx_in_staked_commitment(tx_in);
+    BOOST_REQUIRE_EQUAL(staked_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(staked_rv.value);
+    auto rbf_rv = get_tx_in_rbf(tx_in);
+    BOOST_REQUIRE_EQUAL(rbf_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(rbf_rv.value);
+
+    BlsctScalarResult sk2_rv = get_tx_in_spending_key(tx_in);
+    BOOST_REQUIRE_EQUAL(sk2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(are_scalar_equal(&sk_rv.value, &sk2_rv.value), 1);
+
+    BlsctTokenIdResult tid2_rv = get_tx_in_token_id(tx_in);
+    BOOST_REQUIRE_EQUAL(tid2_rv.result, BLSCT_SUCCESS);
+
+    BlsctOutPointResult op2_rv = get_tx_in_out_point(tx_in);
+    BOOST_REQUIRE_EQUAL(op2_rv.result, BLSCT_SUCCESS);
+}
+
+BOOST_AUTO_TEST_CASE(test_tx_out_accessors)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    auto tid_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+
+    BlsctPubKeyResult spend_pk_rv5 = scalar_to_pub_key(&s_rv.value);
+    BlsctSubAddrIdResult sub_id_rv5 = gen_sub_addr_id(0, 0);
+    BOOST_REQUIRE_EQUAL(spend_pk_rv5.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(sub_id_rv5.result, BLSCT_SUCCESS);
+    auto* spend_pk = &spend_pk_rv5.value;
+    auto* sub_id = &sub_id_rv5.value;
+    BlsctSubAddrResult dest_rv4 = derive_sub_address(&s_rv.value, spend_pk, sub_id);
+    BOOST_REQUIRE_EQUAL(dest_rv4.result, BLSCT_SUCCESS);
+    auto* dest = &dest_rv4.value;
+
+    auto blind_rv = gen_random_scalar();
+    BOOST_REQUIRE_EQUAL(blind_rv.result, BLSCT_SUCCESS);
+
+    auto tx_out_rv = build_tx_out(dest, 500, "memo_test", &tid_rv.value, Normal, 10, false, &blind_rv.value);
+    BOOST_REQUIRE_EQUAL(tx_out_rv.result, BLSCT_SUCCESS);
+    auto* tx_out = &tx_out_rv.value;
+
+    auto out_amt_rv = get_tx_out_amount(tx_out);
+    BOOST_REQUIRE_EQUAL(out_amt_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(out_amt_rv.value, 500u);
+    auto otype_rv = get_tx_out_output_type(tx_out);
+    BOOST_REQUIRE_EQUAL(otype_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(otype_rv.value, Normal);
+    auto min_stake_rv = get_tx_out_min_stake(tx_out);
+    BOOST_REQUIRE_EQUAL(min_stake_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(min_stake_rv.value, 10u);
+    auto sfa_rv = get_tx_out_subtract_fee_from_amount(tx_out);
+    BOOST_REQUIRE_EQUAL(sfa_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK(!sfa_rv.value);
+
+    auto memo_rv = get_tx_out_memo(tx_out);
+    BOOST_REQUIRE_EQUAL(memo_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(memo_rv.value != nullptr);
+    BOOST_CHECK_EQUAL(std::string(memo_rv.value), "memo_test");
+
+    BlsctSubAddrResult dest2_rv = get_tx_out_destination(tx_out);
+    BOOST_REQUIRE_EQUAL(dest2_rv.result, BLSCT_SUCCESS);
+
+    BlsctTokenIdResult tid2_rv = get_tx_out_token_id(tx_out);
+    BOOST_REQUIRE_EQUAL(tid2_rv.result, BLSCT_SUCCESS);
+
+    BlsctScalarResult blind2_rv = get_tx_out_blinding_key(tx_out);
+    BOOST_REQUIRE_EQUAL(blind2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(are_scalar_equal(&blind_rv.value, &blind2_rv.value), 1);
+}
+
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// set/get blsct chain
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_set_get_blsct_chain)
+{
+    init();
+
+    enum BlsctChain original = get_blsct_chain();
+
+    set_blsct_chain(Testnet);
+    BOOST_CHECK_EQUAL(get_blsct_chain(), Testnet);
+
+    set_blsct_chain(Regtest);
+    BOOST_CHECK_EQUAL(get_blsct_chain(), Regtest);
+
+    set_blsct_chain(original);
+    BOOST_CHECK_EQUAL(get_blsct_chain(), original);
+}
+
+// ---------------------------------------------------------------------------
+// Hex utilities
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_serialize_raw_obj_roundtrip)
+{
+    init();
+
+    uint8_t data[] = {0x01, 0x02, 0x03, 0x04};
+    auto sz_rv = serialize_raw_obj(data, sizeof(data), nullptr, 0);
+    BOOST_REQUIRE_EQUAL(sz_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(sz_rv.value > 0);
+    std::vector<char> hex(sz_rv.value + 1);
+    auto w_rv = serialize_raw_obj(data, sizeof(data), hex.data(), hex.size());
+    BOOST_REQUIRE_EQUAL(w_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(hex.data()), "01020304");
+
+    size_t obj_len = 0;
+    BOOST_REQUIRE_EQUAL(deserialize_raw_obj(hex.data(), nullptr, 0, &obj_len), BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(obj_len, sizeof(data));
+    std::vector<uint8_t> obj_buf(obj_len);
+    BOOST_REQUIRE_EQUAL(deserialize_raw_obj(hex.data(), obj_buf.data(), obj_buf.size(), &obj_len), BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(memcmp(obj_buf.data(), data, sizeof(data)), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Unsigned input/output serialize/deserialize roundtrip
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_unsigned_input_serialize_deserialize_roundtrip)
+{
+    init();
+
+    auto s_rv = gen_random_scalar();
+    auto tid_rv = gen_default_token_id();
+    auto op_rv = gen_out_point(std::string(64, '0').c_str());
+    BOOST_REQUIRE_EQUAL(s_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(op_rv.result, BLSCT_SUCCESS);
+
+    auto tx_in_rv = build_tx_in(1000, &s_rv.value, &s_rv.value, &tid_rv.value, &op_rv.value, false, false);
+    BOOST_REQUIRE_EQUAL(tx_in_rv.result, BLSCT_SUCCESS);
+
+    size_t uin_len = 0;
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, nullptr, 0, &uin_len), BLSCT_SUCCESS);
+    BOOST_REQUIRE(uin_len > 0);
+    std::vector<char> uin_hex(uin_len + 1);
+    BOOST_REQUIRE_EQUAL(build_unsigned_input(&tx_in_rv.value, uin_hex.data(), uin_hex.size(), &uin_len), BLSCT_SUCCESS);
+
+    // verify that a deserialized UnsignedInput can be passed to sign_unsigned_transaction
+    const char* in_hexes[] = {uin_hex.data()};
+    size_t dummy_len = 0;
+    // sign without any outputs just to verify deserialization doesn't crash
+    // (signing may fail due to missing outputs, that's acceptable here)
+    sign_unsigned_transaction(in_hexes, 1, nullptr, 0, 0, nullptr, 0, &dummy_len);
+}
+
+// ---------------------------------------------------------------------------
+// Vector predicate serialize/deserialize roundtrip
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_vector_predicate_serialize_deserialize_roundtrip)
+{
+    init();
+
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+
+    size_t pred_len = 0;
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, nullptr, 0, &pred_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> pred_buf(pred_len);
+    BOOST_REQUIRE_EQUAL(build_mint_token_predicate(&pk_rv.value, 100, pred_buf.data(), pred_buf.size(), &pred_len), BLSCT_SUCCESS);
+
+    auto vp_sz_rv = serialize_vector_predicate(pred_buf.data(), pred_len, nullptr, 0);
+    BOOST_REQUIRE_EQUAL(vp_sz_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE(vp_sz_rv.value > 0);
+    std::vector<char> hex(vp_sz_rv.value + 1);
+    auto vp_w_rv = serialize_vector_predicate(pred_buf.data(), pred_len, hex.data(), hex.size());
+    BOOST_REQUIRE_EQUAL(vp_w_rv.result, BLSCT_SUCCESS);
+
+    size_t deser_len = 0;
+    BOOST_REQUIRE_EQUAL(deserialize_vector_predicate(hex.data(), nullptr, 0, &deser_len), BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(deser_len, pred_len);
+    std::vector<uint8_t> deser_buf(deser_len);
+    BOOST_REQUIRE_EQUAL(deserialize_vector_predicate(hex.data(), deser_buf.data(), deser_buf.size(), &deser_len), BLSCT_SUCCESS);
+}
+
+// ---------------------------------------------------------------------------
+// Token info public key accessor
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_token_info_public_key)
+{
+    init();
+
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+
+    size_t info_len = 0;
+    BOOST_REQUIRE_EQUAL(build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, nullptr, 0, &info_len), BLSCT_SUCCESS);
+    std::vector<char> info_hex(info_len + 1);
+    BOOST_REQUIRE_EQUAL(build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, info_hex.data(), info_hex.size(), &info_len), BLSCT_SUCCESS);
+
+    BlsctPubKeyResult pk2_rv = get_token_info_public_key(info_hex.data());
+    BOOST_REQUIRE_EQUAL(pk2_rv.result, BLSCT_SUCCESS);
+
+    BlsctPointHexResult h1_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&pk_rv.value));
+    BlsctPointHexResult h2_rv = serialize_public_key(reinterpret_cast<const BlsctPoint*>(&pk2_rv.value));
+    BOOST_REQUIRE_EQUAL(h1_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(h2_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(h1_rv.value), std::string(h2_rv.value));
+}
+
+// ---------------------------------------------------------------------------
+// Amount recovery: result size and msg accessors
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_amount_recovery_result_size_and_msg)
+{
+    init();
+
+    uint64_t amount = 77;
+    std::string msg = "recovery_msg";
+
+    auto tid_rv = gen_default_token_id();
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+
+    TokenId token_id;
+    UNSERIALIZE_FROM_BYTE_ARRAY_WITH_STREAM(tid_rv.value, TOKEN_ID_SIZE, token_id);
+
+    Mcl::Point nonce_pt = Mcl::Point::Rand();
+    BlsctPoint blsct_nonce;
+    SERIALIZE_AND_COPY(nonce_pt, blsct_nonce);
+
+    uint64_t amounts[] = {amount};
+    size_t rp_len = 0;
+    BOOST_REQUIRE_EQUAL(build_range_proof(amounts, 1, &blsct_nonce, msg.c_str(), &tid_rv.value, nullptr, 0, &rp_len), BLSCT_SUCCESS);
+    std::vector<uint8_t> rp_buf(rp_len);
+    BOOST_REQUIRE_EQUAL(build_range_proof(amounts, 1, &blsct_nonce, msg.c_str(), &tid_rv.value, rp_buf.data(), rp_buf.size(), &rp_len), BLSCT_SUCCESS);
+
+    BlsctAmountRecoveryReq req{};
+    req.range_proof = rp_buf.data();
+    req.range_proof_size = rp_len;
+    std::memcpy(req.nonce, blsct_nonce, POINT_SIZE);
+    std::memcpy(req.token_id, tid_rv.value, TOKEN_ID_SIZE);
+
+    BlsctAmountRecoveryResult result{};
+    BOOST_REQUIRE_EQUAL(recover_amount(&req, 1, &result), BLSCT_SUCCESS);
+
+    BOOST_CHECK(result.is_succ);
+    BOOST_CHECK_EQUAL(result.amount, amount);
+    BOOST_CHECK_EQUAL(std::string(result.msg), msg);
+}
+
+// Regression tests for CScript memcpy bugs in script accessor functions.
+//
+// CScript = prevector<28, unsigned char>. Its first 28 bytes ARE the inline
+// (direct) storage array, so memcpy(&script, 28) is accidentally correct for
+// scripts up to 28 bytes. For scripts > 28 bytes prevector switches to
+// indirect (heap) mode: the first 12 bytes become {char* ptr, uint32_t cap}
+// and the copy returns pointer bytes instead of script content.
+//
+// All real BLSCT scripts are <= 28 bytes, so the bug is latent. These tests
+// force indirect mode with a 34-byte script to verify the accessor returns
+// the actual script bytes rather than the prevector header.
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_in_script_sig_oversized_returns_bad_size)
+{
+    CScript large_sig;
+    large_sig.push_back(0x00);
+    large_sig.push_back(0x20);
+    for (int i = 0; i < 32; ++i)
+        large_sig.push_back(static_cast<uint8_t>(i + 1));
+    BOOST_REQUIRE_GT(large_sig.size(), (size_t)SCRIPT_SIZE);
+
+    CTxIn txin;
+    txin.scriptSig = large_sig;
+
+    BlsctScriptResult rv = get_ctx_in_script_sig(static_cast<const void*>(&txin));
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_in_script_sig_fits_returns_success)
+{
+    CScript small_sig;
+    for (int i = 0; i < SCRIPT_SIZE; ++i)
+        small_sig.push_back(static_cast<uint8_t>(i + 1));
+    BOOST_REQUIRE_EQUAL(small_sig.size(), (size_t)SCRIPT_SIZE);
+
+    CTxIn txin;
+    txin.scriptSig = small_sig;
+
+    BlsctScriptResult rv = get_ctx_in_script_sig(static_cast<const void*>(&txin));
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+    for (size_t i = 0; i < SCRIPT_SIZE; ++i)
+        BOOST_CHECK_EQUAL(rv.value[i], small_sig[i]);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_in_script_witness_oversized_returns_bad_size)
+{
+    std::vector<uint8_t> large_item(SCRIPT_SIZE + 1, 0xab);
+
+    CTxIn txin;
+    txin.scriptWitness.stack.push_back(large_item);
+
+    BlsctScriptResult rv = get_ctx_in_script_witness(static_cast<const void*>(&txin));
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_in_script_witness_fits_returns_success)
+{
+    std::vector<uint8_t> item(SCRIPT_SIZE);
+    for (int i = 0; i < SCRIPT_SIZE; ++i)
+        item[i] = static_cast<uint8_t>(i + 1);
+
+    CTxIn txin;
+    txin.scriptWitness.stack.push_back(item);
+
+    BlsctScriptResult rv = get_ctx_in_script_witness(static_cast<const void*>(&txin));
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+    for (size_t i = 0; i < SCRIPT_SIZE; ++i)
+        BOOST_CHECK_EQUAL(rv.value[i], item[i]);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_script_pub_key_oversized_returns_bad_size)
+{
+    CScript large_spk;
+    large_spk.push_back(0x00);
+    large_spk.push_back(0x20);
+    for (int i = 0; i < 32; ++i)
+        large_spk.push_back(static_cast<uint8_t>(i + 1));
+    BOOST_REQUIRE_GT(large_spk.size(), (size_t)SCRIPT_SIZE);
+
+    CTxOut txout(0, large_spk);
+
+    BlsctScriptResult rv = get_ctx_out_script_pub_key(static_cast<const void*>(&txout));
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_script_pub_key_fits_returns_success)
+{
+    CScript small_spk;
+    for (int i = 0; i < SCRIPT_SIZE; ++i)
+        small_spk.push_back(static_cast<uint8_t>(i + 1));
+    BOOST_REQUIRE_EQUAL(small_spk.size(), (size_t)SCRIPT_SIZE);
+
+    CTxOut txout(0, small_spk);
+
+    BlsctScriptResult rv = get_ctx_out_script_pub_key(static_cast<const void*>(&txout));
+    BOOST_REQUIRE_EQUAL(rv.result, BLSCT_SUCCESS);
+    for (size_t i = 0; i < SCRIPT_SIZE; ++i)
+        BOOST_CHECK_EQUAL(rv.value[i], small_spk[i]);
+}
+
+BOOST_AUTO_TEST_CASE(test_recover_amount_without_init_returns_error)
+{
+    uninit();
+    BOOST_CHECK_EQUAL(recover_amount(nullptr, 0, nullptr), BLSCT_INIT_NOT_CALLED);
+}
+
+BOOST_AUTO_TEST_CASE(test_recover_amount_null_range_proof_returns_failure)
+{
+    init();
+
+    BlsctAmountRecoveryReq req{};
+    req.range_proof = nullptr;
+    BlsctAmountRecoveryResult result{};
+    BOOST_CHECK_EQUAL(recover_amount(&req, 1, &result), BLSCT_FAILURE);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_build_range_proof_without_init_returns_error)
+{
+    uninit();
+    uint64_t amounts[] = {42};
+    size_t rp_len = 0;
+    BLSCT_RESULT rv = build_range_proof(amounts, 1, nullptr, "memo", nullptr, nullptr, 0, &rp_len);
+    BOOST_CHECK_EQUAL(rv, BLSCT_INIT_NOT_CALLED);
+    init();
+}
+
+BOOST_AUTO_TEST_CASE(test_verify_range_proofs_without_init_returns_error)
+{
+    uninit();
+    BlsctBoolResult rv = verify_range_proofs(nullptr, nullptr, 0);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_INIT_NOT_CALLED);
+    init();
+}
+
+// ---------------------------------------------------------------------------
+// BlsctUint64Result failure cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_value_null_returns_failure)
+{
+    BlsctUint64Result rv = get_ctx_out_value(nullptr);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_value_at_bad_hex_returns_failure)
+{
+    BlsctUint64Result rv = get_ctx_out_value_at("notahex", 0);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_out_value_at_out_of_bounds_returns_failure)
+{
+    init();
+    // valid tx hex from test_cmutable_transaction_sizes
+    std::string tx_hex = "200000000100000000000000000000000000000000000000000000000000000000000000000503615d0200ffffffff02ffffffffffffff7f0100000000000000015101855f4e35c5fbe93bf5b8a7a2dc55420144388fd0736ce7d9c8289e793da409d89f2bf2f4f4ac9364d81922d9255c33880683ed1c387aa2555b28af1c6d2b4a2725af9551263c00962daeec3736de0724167d18579973ff9cfcaeedc9ed59036aaaa2ad79cef575dc618d14729169a88c87edb5d3303efab1109572ca4a98800d61c45d8ca9074a7beb9c5c4123e7af8054b4bce1a360c663b86e8af1f06dea120fce8d7529b90ff383fd69c7dd9a50215881df91544949b95eaeac780c133699bdb030b321c32c0efbafa29fe840fe93b01bffc47e096a4577f5ba7d6745506f5e658cbd21c0c7f4c5fc28fdb28dd1c27a8027da5ca650a48ced1c52725abc54a1bd54e9823341753de270ea7882fd54b5b7513d9184635b9dbf0812ccf769df4cb50985bfa52fa515fa7034a317b2da1453d2d919797a22e6889c8aada6fe25e2dfda8f57f57de8fc2a9fa957d264240d06b8548ad7eec8b644df2e89b9a5a1d83ecce4ca94005b7d61782743e74ed011f7cc96c634327b67cfbc954de4effa0d7884f88d27ac1c1686bad02f527975ed9f3e7b2570120dc68ad88ddd350119d00c6df24916d5fc361f20f4f4d4482711b5850b3f91c9315beb1af544d63ed7049b6a1af783e0171526ba9c31466de735527d2d1bfeaf292a73ecf0312e6e784ae18dc6949e4a452fadc0734bff7bdf56074434f7a311290ba2ec6cbe960e29829d2b8ad6fb7946e356580b5a40f9676274a8336c5eecc36a9ddb58bb81cd8d08dfda7714aa9634941a94076cbc3ed74561d9043146dc81f1ccafd4e06f98faae3da017fe07af9ac407d0b81e6e1e634e5b53f5f98728850298673e355093844d0443466fad33d233ed7c40c1788a43d4d48d63778e8cf80e9cd5d01e789637b0cae99a372dd0bc8b5dbf2bc2df9fea229d71eaebab6a9277bb3bb3ba07c14edef6a7fcdcf02e8c1e927872003b9683d3b3ff1e740d5ec8a8145361166b33da8dcda6edf5d7bf32f63d27a5b72e515e6641b672275eee06f3bd5abd6790eded07d49b9e55e5c29e136eb5ad4857f9f55b6e7be10d2002ed91244243ea0fe7b6dea43ea70eb0d3d438ae2a335ced8e1620392562a2c503d2c4b53bed0d39c3749cb032741cacd0ca73bc6d72d350184cc82a45ad8df2e3443599ba51dfd5dce328362f9032cb350f579234f36c282d4b0acdf27d6a8d66f62713adf6481c8c9f240f59a15c6e064a5c05b56e6c068801f639ee1e83003a6a8dd97d5c24b5236c30d43efa0d75709fcaba4ca72077232f537900b2697973d2a08ee405d4298d4a8afeb24f6066b9648b3265e10931756678606fc173b92525567648af5408ff6af65eece8bbe70c671f9f8b94f012dd97eb3f8efcbeae6b34fc2fa3932ffac63b68c7167eeea1b7798872c92e40c057663cd1bdd07ce887a175b0feb74c394f9232dbaf3c8bd84e5624c2b6ca3605cfe3a1acfd1c5871a54d5a5b497588916840d422eeabc75d528275e0f7db46d95654ec9453c20000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9000000008a8c3b2f2bafb7b71f9192b2b8e02df5caf27c04b535ef577c0703f820a110155984f294bc01fccaf6957b622156a97712e57526ce7ef914af67e7aea2fd3daf8a4176660300ea64be6ab6c87b1a597cb96f7d5ac0ab59fe115190bc33946ba3";
+    BlsctUint64Result rv = get_ctx_out_value_at(tx_hex.c_str(), 9999);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_scalar_to_uint64_null_returns_failure)
+{
+    BlsctUint64Result rv = scalar_to_uint64(nullptr);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_token_id_token_null_returns_failure)
+{
+    BlsctUint64Result rv = get_token_id_token(nullptr);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_token_id_subid_null_returns_failure)
+{
+    BlsctUint64Result rv = get_token_id_subid(nullptr);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_token_info_total_supply_bad_hex_returns_failure)
+{
+    BlsctUint64Result rv = get_token_info_total_supply("notahex");
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_mint_token_predicate_amount_wrong_type_returns_failure)
+{
+    // use a create-token predicate — wrong type for mint-token query
+    init();
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+    size_t token_info_len = 0;
+    build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, nullptr, 0, &token_info_len);
+    std::vector<char> token_info_hex(token_info_len + 1);
+    build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, token_info_hex.data(), token_info_hex.size(), &token_info_len);
+
+    size_t pred_len = 0;
+    build_create_token_predicate(token_info_hex.data(), nullptr, 0, &pred_len);
+    std::vector<uint8_t> pred_buf(pred_len);
+    build_create_token_predicate(token_info_hex.data(), pred_buf.data(), pred_buf.size(), &pred_len);
+
+    BlsctUint64Result rv = get_mint_token_predicate_amount(pred_buf.data(), pred_len);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_mint_nft_predicate_nft_id_wrong_type_returns_failure)
+{
+    // use a mint-token predicate — wrong type for mint-nft query
+    init();
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+
+    size_t pred_len = 0;
+    build_mint_token_predicate(&pk_rv.value, 42, nullptr, 0, &pred_len);
+    std::vector<uint8_t> pred_buf(pred_len);
+    build_mint_token_predicate(&pk_rv.value, 42, pred_buf.data(), pred_buf.size(), &pred_len);
+
+    BlsctUint64Result rv = get_mint_nft_predicate_nft_id(pred_buf.data(), pred_len);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// Null/bad-input failure cases fixed in earlier refactor
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_deserialize_raw_obj_null_returns_failure)
+{
+    uint8_t buf[4];
+    size_t out_len = 0;
+    BOOST_CHECK_EQUAL(deserialize_raw_obj(nullptr, buf, sizeof(buf), &out_len), BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_build_ctx_empty_ins_or_outs_returns_failure)
+{
+    char buf[1];
+    size_t out_len = 0;
+    BlsctTxOutData dummy_out{};
+    BlsctTxInData dummy_in{};
+    BOOST_CHECK_EQUAL(build_ctx(nullptr, 0, &dummy_out, 1, buf, sizeof(buf), &out_len).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(build_ctx(&dummy_in, 1, nullptr, 0, buf, sizeof(buf), &out_len).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_token_id_wrong_size_returns_bad_size)
+{
+    // 4 bytes instead of TOKEN_ID_SIZE (40)
+    BlsctTokenIdResult rv = deserialize_token_id("deadbeef");
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_build_tx_out_null_dest_returns_failure)
+{
+    init();
+    auto tid_rv = gen_default_token_id();
+    auto sk_rv = gen_random_scalar();
+    BlsctTxOutResult rv = build_tx_out(
+        nullptr, 100, "memo", &tid_rv.value,
+        TxOutputType::Normal, 0, false, &sk_rv.value);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_build_tx_out_null_memo_returns_failure)
+{
+    init();
+    auto sa_rv = gen_sub_addr_id(0, 0);
+    auto tid_rv = gen_default_token_id();
+    auto sk_rv = gen_random_scalar();
+    // derive a valid sub address to use as dest
+    auto view_rv = gen_random_scalar();
+    auto spend_rv = gen_random_public_key();
+    auto sub_rv = derive_sub_address(&view_rv.value, &spend_rv.value, &sa_rv.value);
+    BOOST_REQUIRE_EQUAL(sub_rv.result, BLSCT_SUCCESS);
+    BlsctTxOutResult rv = build_tx_out(
+        &sub_rv.value, 100, nullptr, &tid_rv.value,
+        TxOutputType::Normal, 0, false, &sk_rv.value);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_FAILURE);
+
+    uninit();
+}
+
+BOOST_AUTO_TEST_CASE(test_build_tx_out_memo_boundary)
+{
+    init();
+    auto sa_rv = gen_sub_addr_id(0, 0);
+    auto tid_rv = gen_default_token_id();
+    auto sk_rv = gen_random_scalar();
+    auto view_rv = gen_random_scalar();
+    auto spend_rv = gen_random_public_key();
+    auto sub_rv = derive_sub_address(&view_rv.value, &spend_rv.value, &sa_rv.value);
+    BOOST_REQUIRE_EQUAL(sub_rv.result, BLSCT_SUCCESS);
+
+    // exactly MAX_MEMO_LEN chars — must succeed
+    std::string max_memo(MAX_MEMO_LEN, 'x');
+    auto ok_rv = build_tx_out(&sub_rv.value, 100, max_memo.c_str(), &tid_rv.value, TxOutputType::Normal, 0, false, &sk_rv.value);
+    BOOST_CHECK_EQUAL(ok_rv.result, BLSCT_SUCCESS);
+    BOOST_CHECK_EQUAL(std::string(ok_rv.value.memo_c_str), max_memo);
+
+    // MAX_MEMO_LEN + 1 chars — must fail
+    std::string over_memo(MAX_MEMO_LEN + 1, 'x');
+    auto fail_rv = build_tx_out(&sub_rv.value, 100, over_memo.c_str(), &tid_rv.value, TxOutputType::Normal, 0, false, &sk_rv.value);
+    BOOST_CHECK_EQUAL(fail_rv.result, BLSCT_MEMO_TOO_LONG);
+
+    uninit();
+}
+
+// ---------------------------------------------------------------------------
+// Null pointer safety for ctx_in / ctx_out void* accessors
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_ctx_in_accessors_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_in_prev_out_hash(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_script_sig(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_sequence(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_script_witness(nullptr).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_out_accessors_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_out_script_pub_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_spending_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_ephemeral_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_blinding_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_range_proof(nullptr, nullptr, 0, nullptr), BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_view_tag(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_token_id(nullptr).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctTxInData / BlsctTxOutData null accessor failure cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_tx_in_null_accessors_return_failure)
+{
+    BOOST_CHECK_EQUAL(get_tx_in_amount(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_gamma(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_spending_key(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_token_id(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_out_point(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_staked_commitment(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_in_rbf(nullptr).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_tx_out_null_accessors_return_failure)
+{
+    BOOST_CHECK_EQUAL(get_tx_out_destination(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_amount(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_memo(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_token_id(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_output_type(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_min_stake(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_subtract_fee_from_amount(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_tx_out_blinding_key(nullptr).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctInt64Result / BlsctUint64Result null pointer safety for sub_addr_id
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_sub_addr_id_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_sub_addr_id_account(nullptr).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_sub_addr_id_address(nullptr).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctSizeTResult null pointer safety
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_sizeresult_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(point_to_str(nullptr, nullptr, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(scalar_to_str(nullptr, nullptr, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(serialize_range_proof(nullptr, 0, nullptr, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(serialize_vector_predicate(nullptr, 0, nullptr, 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(serialize_raw_obj(nullptr, 0, nullptr, 0).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctUint64Result null pointer safety for calc_view_tag
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_calc_view_tag_null_returns_failure)
+{
+    init();
+    auto view_rv = gen_scalar(1);
+    BOOST_REQUIRE_EQUAL(view_rv.result, BLSCT_SUCCESS);
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+
+    BOOST_CHECK_EQUAL(calc_view_tag(nullptr, &view_rv.value).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(calc_view_tag(&pk_rv.value, nullptr).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctSizeTResult bad-hex failure cases (get_ctx_ins_size / get_ctx_outs_size)
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_ins_size_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_ins_size("notahex").result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_outs_size_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_outs_size("notahex").result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctCTxIdHexResult bad-hex failure case (get_ctx_id)
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_ctx_id_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_id("notahex").result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// _at indexed accessors: bad hex → BLSCT_FAILURE
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_ctx_in_at_accessors_bad_hex_return_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_in_prev_out_hash_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_script_sig_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_sequence_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_in_script_witness_at("notahex", 0).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_ctx_out_at_accessors_bad_hex_return_failure)
+{
+    BOOST_CHECK_EQUAL(get_ctx_out_script_pub_key_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_token_id_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_spending_key_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_ephemeral_key_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_blinding_key_at("notahex", 0).result, BLSCT_FAILURE);
+    BOOST_CHECK_EQUAL(get_ctx_out_view_tag_at("notahex", 0).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// Deserializer bad-hex / wrong-size failure cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_deserialize_dpk_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_dpk("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_key_id_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_key_id("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_out_point_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_out_point("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_point_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(deserialize_point("notahex").result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_public_key_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(deserialize_public_key("notahex").result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_scalar_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(deserialize_scalar("notahex").result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_script_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_script("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_signature_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_signature("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_sub_addr_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_sub_addr("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(test_deserialize_sub_addr_id_bad_hex_returns_bad_size)
+{
+    BOOST_CHECK_EQUAL(deserialize_sub_addr_id("deadbeef").result, BLSCT_BAD_SIZE);
+}
+
+// ---------------------------------------------------------------------------
+// Token info bad-input failure cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_token_info_type_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_token_info_type(nullptr).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_token_info_type_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_token_info_type("notahex").result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_token_info_public_key_bad_hex_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_token_info_public_key("notahex").result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctPredicateTypeResult null pointer safety
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_vector_predicate_type_null_returns_failure)
+{
+    BOOST_CHECK_EQUAL(get_vector_predicate_type(nullptr, 0).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctPubKeyResult wrong-predicate-type failure cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_get_mint_token_predicate_public_key_wrong_type_returns_failure)
+{
+    init();
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+    size_t token_info_len = 0;
+    build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, nullptr, 0, &token_info_len);
+    std::vector<char> token_info_hex(token_info_len + 1);
+    build_token_info(BlsctToken, &pk_rv.value, nullptr, nullptr, 0, 1000, token_info_hex.data(), token_info_hex.size(), &token_info_len);
+    size_t pred_len = 0;
+    build_create_token_predicate(token_info_hex.data(), nullptr, 0, &pred_len);
+    std::vector<uint8_t> pred_buf(pred_len);
+    build_create_token_predicate(token_info_hex.data(), pred_buf.data(), pred_buf.size(), &pred_len);
+
+    BOOST_CHECK_EQUAL(get_mint_token_predicate_public_key(pred_buf.data(), pred_len).result, BLSCT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_mint_nft_predicate_public_key_wrong_type_returns_failure)
+{
+    init();
+    auto pk_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(pk_rv.result, BLSCT_SUCCESS);
+    size_t pred_len = 0;
+    build_mint_token_predicate(&pk_rv.value, 42, nullptr, 0, &pred_len);
+    std::vector<uint8_t> pred_buf(pred_len);
+    build_mint_token_predicate(&pk_rv.value, 42, pred_buf.data(), pred_buf.size(), &pred_len);
+
+    BOOST_CHECK_EQUAL(get_mint_nft_predicate_public_key(pred_buf.data(), pred_len).result, BLSCT_FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctDoublePubKeyResult bad-address failure case (decode_address)
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_decode_address_bad_input_returns_exception)
+{
+    BOOST_CHECK_EQUAL(decode_address("notanaddress").result, BLSCT_EXCEPTION);
+}
+
+// ---------------------------------------------------------------------------
+// BlsctTxOutResult memo-too-long failure case
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_build_tx_out_memo_too_long_returns_memo_too_long)
+{
+    init();
+    auto sa_rv = gen_sub_addr_id(0, 0);
+    auto tid_rv = gen_default_token_id();
+    auto sk_rv = gen_random_scalar();
+    auto view_rv = gen_random_scalar();
+    auto spend_rv = gen_random_public_key();
+    BOOST_REQUIRE_EQUAL(sa_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(tid_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(sk_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(view_rv.result, BLSCT_SUCCESS);
+    BOOST_REQUIRE_EQUAL(spend_rv.result, BLSCT_SUCCESS);
+    auto sub_rv = derive_sub_address(&view_rv.value, &spend_rv.value, &sa_rv.value);
+    BOOST_REQUIRE_EQUAL(sub_rv.result, BLSCT_SUCCESS);
+
+    std::string long_memo(MAX_MEMO_LEN + 1, 'x');
+    BlsctTxOutResult rv = build_tx_out(
+        &sub_rv.value, 100, long_memo.c_str(), &tid_rv.value,
+        TxOutputType::Normal, 0, false, &sk_rv.value);
+    BOOST_CHECK_EQUAL(rv.result, BLSCT_MEMO_TOO_LONG);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Eliminates all `void*` from the blsct external API. Resolves #199.

## What changed

**Return types** — `BlsctRetVal* (void* value)` replaced by typed result structs (`BlsctDoublePubKeyResult`, `BlsctUint256Result`, `BlsctSizeTResult`, etc.) returned by value. No malloc on return path.

**Output buffers** — functions that returned heap-allocated strings now take caller-supplied `char* buf, size_t buf_size, size_t* out_len`. Callers size buffers using new `BLSCT_*_HEX_SIZE` macros.

**Collections** — opaque `void*` vector management (`create_tx_in_vec`, `add_to_tx_in_vec`, `create_amount_recovery_req_vec`, etc.) removed. Callers pass typed arrays directly.

**String map** — `StringMapFromOpaque(void*)` replaced by `StringMapFromArrays(keys, values, count)` + `InvokeCallbackForMap` callback pattern.

**Internals** — `DeserializeSerializableObject` → `DeserializeObj` returns `std::optional<T>`; `typed_err<R>` template replaces `succ`/`err` heap allocators.

**Lifecycle** — `uninit()` added for symmetric teardown; `g_init_mutex` upgraded to `shared_mutex` for concurrent reads during `recover_amount`.

**Renames** — `BlsctTxIn` → `BlsctTxInData`, `BlsctTxOut` → `BlsctTxOutData`.

**Removed** — `free_obj`, `free_amounts_ret_val`, `StrToAllocCStr`, `SerializeToHex`, `DeserializeFromHex`, `get_amount_recovery_result_*` accessors, `g_is_little_endian`.

@aguycalled @gogoex — the external binding interface has changed; callers will need to be updated to pass buffers and typed arrays instead of managing opaque pointers.