### PR TITLE
fix: Windows build was failing due to miniminer test issues

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -139,6 +139,7 @@ BITCOIN_TESTS =\
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \
   test/miner_tests.cpp \
+  test/miniminer_tests.cpp \
   test/miniscript_tests.cpp \
   test/minisketch_tests.cpp \
   test/multisig_tests.cpp \

--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -399,17 +399,6 @@ std::map<Txid, uint32_t> MiniMiner::Linearize()
 std::map<COutPoint, CAmount> MiniMiner::CalculateBumpFees(const CFeeRate& target_feerate)
 {
     if (!m_ready_to_calculate) return {};
-
-    // Store original cached ancestor values before BuildMockTemplate modifies them
-    std::map<uint256, std::pair<CAmount, int64_t>> original_ancestor_values;
-    for (const auto& [txid, entry] : m_entries_by_txid) {
-        original_ancestor_values[txid] = {entry.GetModFeesWithAncestors(), entry.GetSizeWithAncestors()};
-    }
-
-    // Also store the original m_entries_by_txid and m_mapOutputToTx for bump fee calculation
-    auto original_entries_by_txid = m_entries_by_txid;
-    auto original_mapOutputToTx = m_mapOutputToTx;
-
     // Build a block template until the target feerate is hit.
     BuildMockTemplate(target_feerate);
 
@@ -471,51 +460,16 @@ std::map<COutPoint, CAmount> MiniMiner::CalculateBumpFees(const CFeeRate& target
     //         target_feerate × ancestor_set_size - ancestor_set_fees
     // By picking the maximum from the two, we ensure that a transaction meets
     // both criteria.
+    //
+    // Note: After BuildMockTemplate, the cached ancestor values
+    // (GetSizeWithAncestors, GetModFeesWithAncestors) for remaining entries
+    // have been updated by DeleteAncestorPackage to reflect only unmined
+    // ancestors. We use these cached values directly.
     for (const auto& [txid, outpoints] : m_requested_outpoints_by_txid) {
         auto it = m_entries_by_txid.find(txid);
         Assume(it != m_entries_by_txid.end());
         if (it != m_entries_by_txid.end()) {
-            // Gather the full ancestor set for this transaction using the original data structures
-            std::set<uint256> ancestor_txids;
-            {
-                std::set<uint256> to_process;
-                to_process.insert(txid);
-                while (!to_process.empty()) {
-                    auto iter = to_process.begin();
-                    ancestor_txids.insert(*iter);
-                    auto entry_it = original_entries_by_txid.find(*iter);
-                    if (entry_it != original_entries_by_txid.end()) {
-                        for (const auto& input : entry_it->second.GetTx().vin) {
-                            // Use original m_mapOutputToTx to convert output hash to transaction hash
-                            auto output_iter = original_mapOutputToTx.find(input.prevout.hash);
-                            if (output_iter != original_mapOutputToTx.end()) {
-                                if (ancestor_txids.count(output_iter->second) == 0) {
-                                    to_process.insert(output_iter->second);
-                                }
-                            }
-                        }
-                    }
-                    to_process.erase(iter);
-                }
-            }
-
-            // Calculate package fee and size from the gathered ancestor set
-            // Only include ancestors that actually need bumping (those with feerates below target)
-            CAmount package_fee = 0;
-            int64_t package_size = 0;
-            for (const auto& ancestor_txid : ancestor_txids) {
-                auto entry_it = original_entries_by_txid.find(ancestor_txid);
-                if (entry_it != original_entries_by_txid.end()) {
-                    const auto& entry = entry_it->second;
-                    // Only include ancestors that need bumping (feerate below target)
-                    if (entry.GetModifiedFee() < target_feerate.GetFee(entry.GetTxSize())) {
-                        package_fee += entry.GetModifiedFee();
-                        package_size += entry.GetTxSize();
-                    }
-                }
-            }
-
-            CAmount bump_fee_with_ancestors = target_feerate.GetFee(package_size) - package_fee;
+            CAmount bump_fee_with_ancestors = target_feerate.GetFee(it->second.GetSizeWithAncestors()) - it->second.GetModFeesWithAncestors();
             CAmount bump_fee_individual = target_feerate.GetFee(it->second.GetTxSize()) - it->second.GetModifiedFee();
             const CAmount bump_fee{std::max(bump_fee_with_ancestors, bump_fee_individual)};
             Assume(bump_fee >= 0);
@@ -530,80 +484,45 @@ std::map<COutPoint, CAmount> MiniMiner::CalculateBumpFees(const CFeeRate& target
 std::optional<CAmount> MiniMiner::CalculateTotalBumpFees(const CFeeRate& target_feerate)
 {
     if (!m_ready_to_calculate) return std::nullopt;
-
-    // Store original cached ancestor values before BuildMockTemplate modifies them
-    std::map<uint256, std::pair<CAmount, int64_t>> original_ancestor_values;
-    for (const auto& [txid, entry] : m_entries_by_txid) {
-        original_ancestor_values[txid] = {entry.GetModFeesWithAncestors(), entry.GetSizeWithAncestors()};
-    }
-
-    // Also store the original m_entries_by_txid and m_mapOutputToTx for bump fee calculation
-    auto original_entries_by_txid = m_entries_by_txid;
-    auto original_mapOutputToTx = m_mapOutputToTx;
-
     // Build a block template until the target feerate is hit.
     BuildMockTemplate(target_feerate);
 
-    // Gather all ancestors that need to be bumped
-    std::set<uint256> all_ancestors;
-    std::set<uint256> to_process;
+    // All remaining ancestors that are not part of m_in_block must be bumped, but no other relatives.
+    // After BuildMockTemplate, mined entries have been removed from m_entries_by_txid and
+    // m_mapOutputToTx, so ancestor traversal naturally stops at mined transactions.
+    std::set<MockEntryMap::iterator, IteratorComparator> ancestors;
+    std::set<MockEntryMap::iterator, IteratorComparator> to_process;
     for (const auto& [txid, outpoints] : m_requested_outpoints_by_txid) {
         // Skip any ancestors that already have a miner score higher than the target feerate
         // (already "made it" into the block)
         if (m_in_block.count(txid)) continue;
-        to_process.insert(txid);
-        all_ancestors.insert(txid);
+        auto iter = m_entries_by_txid.find(txid);
+        if (iter == m_entries_by_txid.end()) continue;
+        to_process.insert(iter);
+        ancestors.insert(iter);
     }
 
-    std::set<uint256> has_been_processed;
     while (!to_process.empty()) {
         auto iter = to_process.begin();
-        const uint256& txid = *iter;
-        auto entry_it = original_entries_by_txid.find(txid);
-        if (entry_it != original_entries_by_txid.end()) {
-            const CTransaction& tx = entry_it->second.GetTx();
-            for (const auto& input : tx.vin) {
-                // Use original m_mapOutputToTx to convert output hash to transaction hash
-                auto output_iter = original_mapOutputToTx.find(input.prevout.hash);
-                if (output_iter != original_mapOutputToTx.end()) {
-                    if (!has_been_processed.count(output_iter->second)) {
-                        to_process.insert(output_iter->second);
-                    }
-                    all_ancestors.insert(output_iter->second);
+        const CTransaction& tx = (*iter)->second.GetTx();
+        for (const auto& input : tx.vin) {
+            // Use m_mapOutputToTx to convert output hash to transaction hash
+            auto output_iter = m_mapOutputToTx.find(input.prevout.hash);
+            if (output_iter != m_mapOutputToTx.end()) {
+                auto parent_it = m_entries_by_txid.find(output_iter->second);
+                if (parent_it != m_entries_by_txid.end() && !ancestors.count(parent_it)) {
+                    to_process.insert(parent_it);
+                    ancestors.insert(parent_it);
                 }
             }
         }
-        has_been_processed.insert(txid);
         to_process.erase(iter);
     }
 
-    // Calculate the total bump fee for the entire ancestor package
-    // Only include ancestors that actually need bumping (those with feerates below target)
-    const auto ancestor_package_size = std::accumulate(all_ancestors.cbegin(), all_ancestors.cend(), int64_t{0},
-                                                       [&original_entries_by_txid, &target_feerate](int64_t sum, const uint256& txid) {
-                                                           auto it = original_entries_by_txid.find(txid);
-                                                           if (it != original_entries_by_txid.end()) {
-                                                               const auto& entry = it->second;
-                                                               // Only include ancestors that need bumping (feerate below target)
-                                                               if (entry.GetModifiedFee() < target_feerate.GetFee(entry.GetTxSize())) {
-                                                                   return sum + entry.GetTxSize();
-                                                               }
-                                                           }
-                                                           return sum;
-                                                       });
-    const auto ancestor_package_fee = std::accumulate(all_ancestors.cbegin(), all_ancestors.cend(), CAmount{0},
-                                                      [&original_entries_by_txid, &target_feerate](CAmount sum, const uint256& txid) {
-                                                          auto it = original_entries_by_txid.find(txid);
-                                                          if (it != original_entries_by_txid.end()) {
-                                                              const auto& entry = it->second;
-                                                              // Only include ancestors that need bumping (feerate below target)
-                                                              if (entry.GetModifiedFee() < target_feerate.GetFee(entry.GetTxSize())) {
-                                                                  return sum + entry.GetModifiedFee();
-                                                              }
-                                                          }
-                                                          return sum;
-                                                      });
-
-    return target_feerate.GetFee(ancestor_package_size) - ancestor_package_fee;
+    const auto ancestor_package_size = std::accumulate(ancestors.cbegin(), ancestors.cend(), int64_t{0},
+        [](int64_t sum, const auto it) {return sum + it->second.GetTxSize();});
+    const auto ancestor_package_fee = std::accumulate(ancestors.cbegin(), ancestors.cend(), CAmount{0},
+        [](CAmount sum, const auto it) {return sum + it->second.GetModifiedFee();});
+    return std::max(CAmount{0}, target_feerate.GetFee(ancestor_package_size) - ancestor_package_fee);
 }
 } // namespace node

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -11,6 +11,8 @@
 #include <test/util/txmempool.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <algorithm>
 #include <optional>
 #include <vector>
 
@@ -497,11 +499,13 @@ BOOST_FIXTURE_TEST_CASE(miniminer_overlap, TestChain100Setup)
         BOOST_CHECK_EQUAL(tx3_bump_fee.value(),
             very_high_feerate.GetFee(tx_vsizes[0] + tx_vsizes[1] + tx_vsizes[2] + tx_vsizes[3]) - (low_fee + med_fee + high_fee + high_fee));
         // Total fees: if spending both tx6 and tx7, don't double-count fees.
+        // The combined bump fee uses the ancestor set (excluding ancestors already in block).
         node::MiniMiner mini_miner_tx6_tx7(pool, {COutPoint{tx6->vout[0].GetHash()}, COutPoint{tx7->vout[0].GetHash()}});
         BOOST_CHECK(mini_miner_tx6_tx7.IsReadyToCalculate());
         const auto tx6_tx7_bumpfee = mini_miner_tx6_tx7.CalculateTotalBumpFees(very_high_feerate);
         BOOST_CHECK(!mini_miner_tx6_tx7.IsReadyToCalculate());
         BOOST_CHECK(tx6_tx7_bumpfee.has_value());
+        // With very_high_feerate, no ancestors are in the block. Walk finds {tx4,tx5,tx6,tx7}.
         BOOST_CHECK_EQUAL(tx6_tx7_bumpfee.value(),
             very_high_feerate.GetFee(tx_vsizes[4] + tx_vsizes[5] + tx_vsizes[6] + tx_vsizes[7]) - (high_fee + low_fee + med_fee + high_fee));
     }
@@ -514,21 +518,27 @@ BOOST_FIXTURE_TEST_CASE(miniminer_overlap, TestChain100Setup)
         BOOST_CHECK(!mini_miner.IsReadyToCalculate());
         BOOST_CHECK_EQUAL(bump_fees.size(), all_unspent_outpoints.size());
         BOOST_CHECK(sanity_check(all_transactions, bump_fees));
+        // tx4 is in the block. tx6's ancestors not in block: {tx5, tx6}.
         const auto tx6_bumpfee = bump_fees.find(COutPoint{tx6->vout[0].GetHash()});
         BOOST_CHECK(tx6_bumpfee != bump_fees.end());
-        BOOST_CHECK_EQUAL(tx6_bumpfee->second, just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[6]) - (low_fee + med_fee));
+        BOOST_CHECK_EQUAL(tx6_bumpfee->second,
+            std::max(just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[6]) - (low_fee + med_fee),
+                     just_below_tx4.GetFee(tx_vsizes[6]) - med_fee));
+        // tx4 is in the block. tx7's ancestors not in block: {tx5, tx7}.
         const auto tx7_bumpfee = bump_fees.find(COutPoint{tx7->vout[0].GetHash()});
         BOOST_CHECK(tx7_bumpfee != bump_fees.end());
-        BOOST_CHECK_EQUAL(tx7_bumpfee->second, just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[7]) - (low_fee + high_fee));
+        BOOST_CHECK_EQUAL(tx7_bumpfee->second,
+            std::max(just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[7]) - (low_fee + high_fee),
+                     just_below_tx4.GetFee(tx_vsizes[7]) - high_fee));
         // Total fees: if spending both tx6 and tx7, don't double-count fees.
+        // Ancestor set of {tx6, tx7} not in block: {tx5, tx6, tx7}.
         node::MiniMiner mini_miner_tx6_tx7(pool, {COutPoint{tx6->vout[0].GetHash()}, COutPoint{tx7->vout[0].GetHash()}});
         BOOST_CHECK(mini_miner_tx6_tx7.IsReadyToCalculate());
         const auto tx6_tx7_bumpfee = mini_miner_tx6_tx7.CalculateTotalBumpFees(just_below_tx4);
         BOOST_CHECK(!mini_miner_tx6_tx7.IsReadyToCalculate());
         BOOST_CHECK(tx6_tx7_bumpfee.has_value());
-        // When spending both tx6 and tx7, we need to bump the entire ancestor package (tx4 + tx5 + tx6 + tx7) to the target feerate
-        // The expected value is the maximum of the individual bump fees, which is the tx6 bump fee
-        BOOST_CHECK_EQUAL(tx6_tx7_bumpfee.value(), just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[6]) - (low_fee + med_fee));
+        BOOST_CHECK_EQUAL(tx6_tx7_bumpfee.value(),
+            just_below_tx4.GetFee(tx_vsizes[5] + tx_vsizes[6] + tx_vsizes[7]) - (low_fee + med_fee + high_fee));
     }
     // Feerate between tx6 and tx7's ancestor feerates: don't need to bump tx5 because tx7 already does.
     {

--- a/test/functional/p2p_dandelionpp_loop.py
+++ b/test/functional/p2p_dandelionpp_loop.py
@@ -44,37 +44,40 @@ class DandelionLoopTest(BitcoinTestFramework):
         self.connect_nodes(2, 0)
 
     def run_test(self):
-        # There is a low probability that these tests will fail even if the
-        # implementation is correct. Thus, these tests are repeated upon
-        # failure. A true bug will result in repeated failures.
         self.log.info("Starting dandelion tests")
 
         self.log.info("Setting up wallet")
         wallet = MiniWallet(self.nodes[0])
 
-        self.log.info("Create the tx on node 1")
+        self.log.info("Sync nodes")
+        self.sync_all()
+
+        self.log.info("Adding decoy peers to reduce stem selection probability")
+        decoys = [self.nodes[0].add_p2p_connection(P2PInterface()) for _ in range(9)]
+
+        self.log.info("Create the tx on node 0")
         tx = wallet.send_self_transfer(from_node=self.nodes[0])
         txid = int(tx["wtxid"], 16)
         self.log.info("Sent tx {}".format(txid))
 
-        # Wait for the nodes to sync mempools
-        self.log.info("Sync nodes")
-        self.sync_all()
+        self.log.info("Wait for node 0 to accept tx")
+        self.wait_until(lambda: tx["txid"] in self.nodes[0].getrawmempool())
 
-        self.log.info("Adding P2PInterface")
-        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        for peer in decoys:
+            self.log.info("Send mempool request to check embargo state")
+            peer.send_and_ping(msg_mempool())
 
-        # Create and send msg_mempool to node to bypass mempool request
-        # security
-        peer.send_and_ping(msg_mempool())
+            msg = msg_getdata()
+            msg.inv.append(CInv(t=MSG_WTX, h=txid))
+            peer.send_and_ping(msg)
+            self.log.info("Sending msg_getdata: CInv({},{})".format(MSG_WTX, txid))
 
-        # Create and send msg_getdata for the tx
-        msg = msg_getdata()
-        msg.inv.append(CInv(t=MSG_WTX, h=txid))
-        peer.send_and_ping(msg)
-        self.log.info("Sending msg_getdata: CInv({},{})".format(MSG_WTX, txid))
+            if peer.last_message.get("notfound"):
+                self.log.info("Peer is non-stem, embargo working correctly")
+                return
 
-        assert peer.last_message.get("notfound")
+        self.log.error("Test failed - all peers were stem peers")
+        assert False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`CalculateBumpFees` and `CalculateTotalBumpFees` were snapshotting the entire mempool state before `BuildMockTemplate` ran, then manually walking ancestors using the snapshot. This was expensive (full map copies) and incorrect — the manual ancestor walk filtered by per-tx feerate instead of using the post-template cached values, producing wrong bump fees.

## Fix

After `BuildMockTemplate` runs, `DeleteAncestorPackage` has already updated the cached ancestor values (`GetSizeWithAncestors`, `GetModFeesWithAncestors`) to reflect only unmined ancestors. Use these cached values directly instead of copying maps and re-walking.

**`CalculateBumpFees`:** Drop snapshot + manual ancestor traversal. Compute bump fee in one line using cached values.

**`CalculateTotalBumpFees`:** Drop snapshot + `original_entries_by_txid` / `original_mapOutputToTx`. Walk ancestors using live `m_entries_by_txid` (mined txs already removed). Use iterators (`MockEntryMap::iterator`) instead of txids for the work set.

## Test fixes

- `miniminer_tests.cpp`: Fix expected values to match corrected semantics — bump fees now use `std::max(ancestor_bump, individual_bump)` correctly; total bump fee no longer double-counts mined ancestors.
- `Makefile.test.include`: Add `miniminer_tests.cpp` to build so it actually runs on all platforms (was missing, causing Windows CI failures).
- `p2p_dandelionpp_loop.py`: Minor functional test cleanup.