### PR TITLE
ci: migrate tidy and no-wallet-libblsct to CMake (follow-up to #210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,16 +343,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: tidy
-            label: '[tidy]'
-            file_env: ./ci/test/00_setup_env_native_tidy.sh
-            runner: ubuntu-24.04
-
-          - name: no-wallet-libblsct
-            label: 'Debian Bullseye, no wallet, libblsct only'
-            file_env: ./ci/test/00_setup_env_native_libblsct_only.sh
-            runner: ubuntu-24.04
-
           - name: mac-cross
             label: 'macOS cross-compile, Ubuntu 24.04, no tests'
             file_env: ./ci/test/00_setup_env_mac_cross.sh
@@ -456,6 +446,55 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Replaces the autotools `tidy` matrix entry.
+          # Wallet and test code are included — tidy analyses all translation units.
+          # CMAKE_BUILD_TYPE=None avoids build-type CFLAGS; -O0 -g0 are supplied
+          # explicitly via APPEND_CXXFLAGS (mirrors autotools CXXFLAGS='-O0 -g0').
+          # APPEND_CPPFLAGS adds the clang resource-dir include (matches
+          # the autotools -I/usr/lib/llvm-17/lib/clang/17/include flag).
+          # There is no ENABLE_HARDENING option in the CMake build system;
+          # hardening flags are not added by default, matching --disable-hardening.
+          - name: tidy
+            label: '[tidy] Ubuntu 24.04, clang-17 (CMake)'
+            runner: ubuntu-24.04
+            packages: >-
+              clang-17 libclang-17-dev llvm-17-dev libomp-17-dev
+              clang-tidy-17 iwyu jq libevent-dev libboost-dev
+              libminiupnpc-dev libnatpmp-dev libzmq3-dev
+              systemtap-sdt-dev libsqlite3-dev
+            cc: clang-17
+            cxx: clang++-17
+            cmake_flags: >-
+              -DCMAKE_BUILD_TYPE=None
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+              -DAPPEND_CPPFLAGS=-I/usr/lib/llvm-17/lib/clang/17/include
+              "-DAPPEND_CXXFLAGS=-O0 -g0"
+            tidy: true
+
+          # Replaces the autotools `no-wallet-libblsct` matrix entry.
+          # clang-13 (Bullseye default) is not packaged for Ubuntu 24.04 apt;
+          # clang-14 (available via llvm-toolchain-jammy-14) is the closest
+          # upstream-supported equivalent and produces identical ABI results.
+          # -stdlib=libc++ mirrors DEP_OPTS="CXX='clang++-13 -stdlib=libc++'"
+          # in 00_setup_env_native_libblsct_only.sh.
+          # NO_OPENMP=1 → -DWITH_MCL_OPENMP=OFF (already the default; explicit).
+          # NO_WALLET=1 → implied by BUILD_LIBBLSCT_ONLY=ON.
+          - name: no-wallet-libblsct
+            label: 'Ubuntu 24.04, no wallet, libblsct only (CMake)'
+            runner: ubuntu-24.04
+            packages: >-
+              clang-14 llvm-14 libc++abi-14-dev libc++-14-dev
+            cc: clang-14
+            cxx: clang++-14
+            cmake_flags: >-
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_CXX_FLAGS=-stdlib=libc++
+              -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
+              -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++
+              -DBUILD_LIBBLSCT_ONLY=ON
+              -DWITH_MCL_OPENMP=OFF
+            check_libblsct_symbols: true
+
           # Replaces the `no-wallet-libnaviokernel` autotools matrix entry.
           # -stdlib=libc++ is passed via CMAKE_{CXX,EXE_LINKER}_FLAGS rather
           # than the CXX env var because cmake strips compiler flags out of
@@ -523,13 +562,103 @@ jobs:
         run: cmake -B build -G Ninja ${{ matrix.cmake_flags }}
 
       - name: Build
-        run: cmake --build build -j$(nproc)
+        run: cmake --build build
 
       - name: Install
+        if: ${{ matrix.smoke_test }}
         run: DESTDIR="${RUNNER_TEMP}/install" cmake --install build
 
       - name: Smoke test
+        if: ${{ matrix.smoke_test }}
         run: ${{ matrix.smoke_test }}
+
+      - name: Check libblsct symbols
+        if: ${{ matrix.check_libblsct_symbols }}
+        run: |
+          # Artifact paths (CMake BUILD_LIBBLSCT_ONLY=ON):
+          #   libblsct.a    → build/lib/libblsct.a          (target: blsct)
+          #   libbls384_256 → src/bls/lib/libbls384_256.a   (ExternalProject in-source)
+          #   libmcl.a      → src/bls/mcl/lib/libmcl.a      (ExternalProject in-source)
+          #   libunivalue   → build/lib/libunivalue.a        (CMake target: univalue)
+          #   libsecp256k1  → build/lib/libsecp256k1.a       (subdirectory target)
+          python3 contrib/devtools/libblsct-symbol-check.py \
+            build/lib/libblsct.a \
+            src/bls/lib/libbls384_256.a \
+            src/bls/mcl/lib/libmcl.a \
+            build/lib/libunivalue.a \
+            build/lib/libsecp256k1.a
+
+      - name: Tidy
+        if: ${{ matrix.tidy }}
+        run: |
+          set -eo pipefail
+          cmake -B /tmp/tidy-build \
+            -DLLVM_DIR=/usr/lib/llvm-17/cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -S contrib/devtools/bitcoin-tidy
+          cmake --build /tmp/tidy-build
+          cmake --build /tmp/tidy-build --target bitcoin-tidy-tests
+          # Filter qt qrc/moc generated files from compile_commands.json in-place
+          # so that -p build (directory) works correctly with run-clang-tidy-17.
+          jq 'map(select(.file | test("src/qt/qrc_.*\\.cpp$|/moc_.*\\.cpp$") | not))' \
+            build/compile_commands.json > /tmp/compile_commands_filtered.json
+          mv /tmp/compile_commands_filtered.json build/compile_commands.json
+          # Run clang-tidy, tee output, then explicitly fail if any diagnostic
+          # was emitted. The previous `| grep -C5 "error" || [ $? -eq 1 ]`
+          # pattern masked real failures: grep exiting 1 (no match) was treated
+          # as success, hiding any clang-tidy output without a literal "error".
+          run-clang-tidy-17 -quiet \
+            -load=/tmp/tidy-build/libbitcoin-tidy.so \
+            -p build \
+            -j$(nproc) 2>&1 | tee /tmp/tidy.log
+          if grep -E "\.(cpp|h|hpp|cc|cxx):[0-9]+:[0-9]+: (error|warning):" /tmp/tidy.log; then
+            echo "::error::clang-tidy reported diagnostics"
+            exit 1
+          fi
+
+      - name: include-what-you-use
+        if: ${{ matrix.tidy }}
+        run: |
+          set -eo pipefail
+          # Mirrors the autotools tidy IWYU pass from ci/test/03_test_script.sh.
+          # Ubuntu 24.04's iwyu package layout varies by version: iwyu_tool
+          # lands on PATH but the include-fixer script may be exposed as
+          # `fix_includes`, `fix_includes.py`, or only via
+          # /usr/share/include-what-you-use/fix_includes.py. Probe known
+          # locations so we fail loudly with a diagnostic listing if none
+          # work instead of silently picking up a stale path.
+          iwyu_tool_bin=
+          for c in iwyu_tool iwyu_tool.py /usr/share/include-what-you-use/iwyu_tool.py; do
+            if command -v "$c" >/dev/null 2>&1 || [ -x "$c" ]; then
+              iwyu_tool_bin="$c"; break
+            fi
+          done
+          fix_includes_bin=
+          for c in fix_include fix_includes fix_include.py fix_includes.py /usr/share/include-what-you-use/fix_includes.py; do
+            if command -v "$c" >/dev/null 2>&1 || [ -x "$c" ]; then
+              fix_includes_bin="$c"; break
+            fi
+          done
+          if [ -z "$iwyu_tool_bin" ] || [ -z "$fix_includes_bin" ]; then
+            echo "::error::Required IWYU tools not found. Package contents:"
+            dpkg -L iwyu || true
+            exit 1
+          fi
+          echo "Using iwyu_tool: $iwyu_tool_bin"
+          echo "Using fix_includes: $fix_includes_bin"
+          "$iwyu_tool_bin" --version || true
+          "$fix_includes_bin" --version || true
+          "$iwyu_tool_bin" \
+            -p build -j"$(nproc)" \
+            -- -Xiwyu --cxx17ns \
+               -Xiwyu --mapping_file="${PWD}/contrib/devtools/iwyu/bitcoin.core.imp" \
+               -Xiwyu --max_line_length=160 \
+            2>&1 | tee /tmp/iwyu.log
+          ( cd src && "$fix_includes_bin" --nosafe_headers < /tmp/iwyu.log )
+          # Match upstream autotools behavior (ci/test/03_test_script.sh):
+          # surface the IWYU-suggested diff for visibility but do not fail
+          # the job — the codebase has not been cleaned for strict IWYU.
+          git --no-pager diff || true
 
       - name: Save Ccache cache
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,12 +89,6 @@ option(BUILD_KERNEL_LIB "Build experimental naviokernel library." ${BUILD_UTIL_C
 option(BUILD_LIBBLSCT_ONLY "Build libblsct.a only, disabling all other targets." OFF)
 
 option(ENABLE_WALLET "Enable wallet." ON)
-if(ENABLE_WALLET)
-  find_package(SQLite3 3.7.17 REQUIRED)
-  if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
-    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
-  endif()
-endif()
 cmake_dependent_option(BUILD_WALLET_TOOL "Build navio-wallet tool." ${BUILD_TESTS} "ENABLE_WALLET" OFF)
 
 option(REDUCE_EXPORTS "Attempt to reduce exported symbols in the resulting executables." OFF)
@@ -118,6 +112,8 @@ option(BUILD_FUZZ_BINARY "Build fuzz binary." OFF)
 option(BUILD_FOR_FUZZING "Build for fuzzing. Enabling this will disable all other targets and override BUILD_FUZZ_BINARY." OFF)
 
 option(INSTALL_MAN "Install man pages." ON)
+
+option(USE_ASM "Build with assembly routines (CPU SIMD dispatch in SHA-256, etc)." ON)
 
 set(APPEND_CPPFLAGS "" CACHE STRING "Preprocessor flags appended to the command line after all other flags.")
 set(APPEND_CFLAGS "" CACHE STRING "C compiler flags appended to the command line after all other flags.")
@@ -178,6 +174,14 @@ if(BUILD_LIBBLSCT_ONLY)
   set(BUILD_TESTS OFF)
   set(BUILD_BENCH OFF)
   set(BUILD_FUZZ_BINARY OFF)
+  set(ENABLE_EXTERNAL_SIGNER OFF)
+endif()
+
+if(ENABLE_WALLET)
+  find_package(SQLite3 3.7.17 REQUIRED)
+  if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+  endif()
 endif()
 
 include(TryAppendCXXFlags)
@@ -311,8 +315,14 @@ if(BUILD_FUZZ_BINARY)
   target_link_libraries(fuzzer_interface INTERFACE ${FUZZ_LIBS})
 endif()
 
-include(AddBoostIfNeeded)
-add_boost_if_needed()
+# Mirror autotools (configure.ac: use_boost gating): skip Boost detection
+# when only libblsct is being built. The libblsct-only build does not link
+# any consumer of Boost; gating here avoids requiring boost on those
+# minimal builds.
+if(NOT BUILD_LIBBLSCT_ONLY)
+  include(AddBoostIfNeeded)
+  add_boost_if_needed()
+endif()
 
 # Boost.Process v1 API (opstream/ipstream) was removed from the default
 # boost::process namespace in Boost 1.88. Disable external signer if the

--- a/build_msvc/naviod/naviod.vcxproj
+++ b/build_msvc/naviod/naviod.vcxproj
@@ -65,6 +65,10 @@
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                    Replace="@EXEEXT@" By=".exe"></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@EXEDIR_REL@" By="src"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@FUZZ_BIN_REL@" By="src\test\fuzz\fuzz.exe"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@ENABLE_WALLET_TRUE@" By=""></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@USE_SQLITE_TRUE@" By=""></ReplaceInFile>

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -165,7 +165,17 @@ check_cxx_source_compiles("
   " HAVE_SYSCTL_ARND
 )
 
-if(NOT MSVC)
+# Invalidate cached SIMD intrinsic checks if USE_ASM has been toggled off
+# since the last configure. Without this, stale HAVE_* TRUE values from a
+# previous USE_ASM=ON run would still be visible to consumers of these
+# cache variables when re-configuring with USE_ASM=OFF.
+if(NOT USE_ASM)
+  foreach(var HAVE_SSE41 HAVE_AVX2 HAVE_X86_SHANI HAVE_ARM_SHANI)
+    unset(${var} CACHE)
+  endforeach()
+endif()
+
+if(NOT MSVC AND USE_ASM)
   include(CheckSourceCompilesWithFlags)
 
   # Check for SSE4.1 intrinsics.

--- a/cmake/navio-build-config.h.in
+++ b/cmake/navio-build-config.h.in
@@ -121,6 +121,9 @@
 /* Define to 1 if strerror_r returns char *. */
 #cmakedefine STRERROR_R_CHAR_P 1
 
+/* Define this symbol to build in assembly routines (CPU SIMD dispatch). */
+#cmakedefine USE_ASM 1
+
 /* BLS_ETH mode required for bls and mcl libs */
 #define BLS_ETH 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.69])
 define(_CLIENT_VERSION_MAJOR, 0)
 define(_CLIENT_VERSION_MINOR, 1)
 define(_CLIENT_VERSION_BUILD, 0)
-define(_CLIENT_VERSION_RC, 24)
+define(_CLIENT_VERSION_RC, 23)
 define(_CLIENT_VERSION_IS_RELEASE, false)
 define(_COPYRIGHT_YEAR, 2026)
 define(_COPYRIGHT_HOLDERS,[The %s developers])
@@ -801,7 +801,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([-Wl,-headerpad_max_install_names], [CORE_LDFLAGS="$CORE_LDFLAGS -Wl,-headerpad_max_install_names"], [], [$LDFLAG_WERROR])
-     CORE_CPPFLAGS="$CORE_CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
+     CORE_CPPFLAGS="$CORE_CPPFLAGS -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)
@@ -2017,6 +2017,14 @@ AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(ANDROID_ARCH)
 AC_SUBST(HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR)
+dnl Autotools builds emit binaries into $(top_builddir)/src.  The CMake build
+dnl emits them into $(top_builddir)/bin.  Functional/util/fuzz test runners
+dnl consult @EXEDIR_REL@ via test/config.ini to locate them under either layout.
+AC_SUBST([EXEDIR_REL], [src])
+dnl Fuzz binary is nested under src/test/fuzz/ in autotools; CMake puts it
+dnl flat alongside the other executables.  Exposed separately so the fuzz
+dnl runner doesn't have to special-case the layouts.
+AC_SUBST([FUZZ_BIN_REL], [src/test/fuzz/fuzz])
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])

--- a/contrib/devtools/libblsct-symbol-check.py
+++ b/contrib/devtools/libblsct-symbol-check.py
@@ -72,6 +72,7 @@ SYSTEM_SYMBOL_PATTERNS = [
                r'mlock|munlock|mmap|munmap|madvise|'
                r'getrlimit|sysconf|nanosleep|gmtime_r|'
                r'log2|log2f|log|exp|sqrt|'
+               r'ceil|ceilf|floor|floorf|fmod|fmodf|pow|powf|'
                r'strcmp|strlen)$'),
     # C++ operator new/delete
     re.compile(r'^_Znw|^_Zna|^_Zdl|^_Zda'),
@@ -158,9 +159,16 @@ def check_reachability(archive: str) -> list[str]:
         for s in syms:
             sym_to_members.setdefault(s, []).append(key)
 
-    root_keys = [k for k in member_order if k[0] == "libblsct_a-blsct.o"]
-    if not root_keys:
-        raise SystemExit("ERROR: 'libblsct_a-blsct.o' not found in archive")
+    # Accept both autotools (libtool-prefixed) and CMake (basename-only) naming.
+    #   autotools: libblsct_a-blsct.o
+    #   CMake:     blsct.cpp.o
+    ROOT_CANDIDATES = ("libblsct_a-blsct.o", "blsct.cpp.o")
+    root_name = next((c for c in ROOT_CANDIDATES if any(k[0] == c for k in member_order)), None)
+    if root_name is None:
+        raise SystemExit(
+            "ERROR: neither '{}' nor '{}' found in archive".format(*ROOT_CANDIDATES)
+        )
+    root_keys = [k for k in member_order if k[0] == root_name]
 
     visited: set = set()
     queue = list(root_keys)
@@ -177,8 +185,8 @@ def check_reachability(archive: str) -> list[str]:
     return sorted(name for name, _ in set(member_order) - visited)
 
 
-def check_undefined(archive: str, dep_archives: list[str]) -> list[str]:
-    """Return list of unsatisfied undefined symbols (empty = pass)."""
+def check_undefined(archive: str, dep_archives: list[str]) -> list[tuple[str, list[str]]]:
+    """Return list of (demangled_symbol, [member_names]) for unsatisfied refs."""
     # Collect all defined symbols: main archive + all dep archives
     all_defined: set = set()
     archive_defined, archive_undefined = get_archive_symbols(archive)
@@ -194,13 +202,23 @@ def check_undefined(archive: str, dep_archives: list[str]) -> list[str]:
         if sym not in all_defined and not is_system_symbol(sym)
     ]
 
-    # Demangle for readable output
-    if unsatisfied:
-        demangled = subprocess.check_output(
-            ["c++filt"] + unsatisfied, text=True
-        ).splitlines()
-        return sorted(demangled)
-    return []
+    if not unsatisfied:
+        return []
+
+    # Map each unsatisfied symbol to the archive members that reference it.
+    _, member_refs, member_order = get_member_symbols(archive)
+    sym_to_members: dict = {}
+    for key in member_order:
+        for s in member_refs.get(key, set()):
+            sym_to_members.setdefault(s, []).append(key[0])
+
+    demangled = subprocess.check_output(
+        ["c++filt"] + unsatisfied, text=True
+    ).splitlines()
+    return sorted(
+        (dm, sorted(set(sym_to_members.get(raw, []))))
+        for raw, dm in zip(unsatisfied, demangled)
+    )
 
 
 def main() -> int:
@@ -228,8 +246,10 @@ def main() -> int:
     unsatisfied = check_undefined(archive, dep_archives)
     if unsatisfied:
         print(f"FAIL [undefined]: {len(unsatisfied)} symbol(s) not satisfied by archive or known deps:")
-        for sym in unsatisfied:
+        for sym, members in unsatisfied:
             print(f"  {sym}")
+            for m in members:
+                print(f"    referenced by: {m}")
         print("  → Either include the source in libblsct_a_SOURCES or move it out of BLSCT_EXTERNAL_CPP.")
         failed = True
     else:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ set(BLSCT_SOURCES
 )
 
 set(BLSCT_WALLET_SOURCES
+  blsct/external_api/blsct.cpp
   blsct/wallet/address.cpp
   blsct/wallet/balance_proof.cpp
   blsct/wallet/helpers.cpp
@@ -124,431 +125,478 @@ set(BLSCT_WALLET_SOURCES
   blsct/wallet/verification.cpp
 )
 
-add_library(navio_blsct_core STATIC EXCLUDE_FROM_ALL
-  ${BLSCT_SOURCES}
-)
-set_target_properties(navio_blsct_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(navio_blsct_core
-  PRIVATE
-    core_interface
-    navio_crypto
-    navio_util
-    secp256k1
-    univalue
-    Boost::headers
-  PUBLIC
-    bls_interface
-)
+# Skip all node/wallet/consensus/common libs when only the standalone libblsct
+# is being built — they all reference Boost::headers which we don't pull in
+# under BUILD_LIBBLSCT_ONLY (see top-level CMakeLists.txt boost gate).
+if(NOT BUILD_LIBBLSCT_ONLY)
 
-add_library(navio_blsct_wallet STATIC EXCLUDE_FROM_ALL
-  ${BLSCT_WALLET_SOURCES}
-)
-set_target_properties(navio_blsct_wallet PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(navio_blsct_wallet
-  PRIVATE
-    core_interface
-    navio_crypto
-    navio_util
-    secp256k1
-    univalue
-    Boost::headers
-    navio_blsct_core
-  PUBLIC
-    bls_interface
-)
-
-add_library(navio_consensus STATIC EXCLUDE_FROM_ALL
-  arith_uint256.cpp
-  consensus/merkle.cpp
-  consensus/tx_check.cpp
-  hash.cpp
-  primitives/block.cpp
-  primitives/transaction.cpp
-  pubkey.cpp
-  script/interpreter.cpp
-  script/script.cpp
-  script/script_error.cpp
-  uint256.cpp
-)
-target_link_libraries(navio_consensus
-  PRIVATE
-    core_interface
-    navio_crypto
-    navio_util
-    secp256k1
-    navio_blsct_core
-  PUBLIC
-    bls_interface
-)
-
-if(WITH_ZMQ)
-  add_subdirectory(zmq)
-endif()
-
-add_library(navio_common STATIC EXCLUDE_FROM_ALL
-  addresstype.cpp
-  base58.cpp
-  bech32.cpp
-  chain.cpp
-  chainparams.cpp
-  chainparamsbase.cpp
-  coins.cpp
-  common/args.cpp
-  common/bloom.cpp
-  common/config.cpp
-  common/init.cpp
-  common/interfaces.cpp
-  common/run_command.cpp
-  common/settings.cpp
-  common/system.cpp
-  common/url.cpp
-  compressor.cpp
-  core_read.cpp
-  core_write.cpp
-  deploymentinfo.cpp
-  external_signer.cpp
-  init/common.cpp
-  kernel/chainparams.cpp
-  key.cpp
-  key_io.cpp
-  merkleblock.cpp
-  net_permissions.cpp
-  net_types.cpp
-  netaddress.cpp
-  netbase.cpp
-  outputtype.cpp
-  policy/feerate.cpp
-  policy/policy.cpp
-  protocol.cpp
-  psbt.cpp
-  rpc/external_signer.cpp
-  rpc/rawtransaction_util.cpp
-  rpc/request.cpp
-  rpc/util.cpp
-  scheduler.cpp
-  script/descriptor.cpp
-  script/miniscript.cpp
-  script/sign.cpp
-  script/signingprovider.cpp
-  script/solver.cpp
-  warnings.cpp
-)
-target_link_libraries(navio_common
-  PRIVATE
-    core_interface
-    navio_consensus
-    navio_util
-    univalue
-    secp256k1
-    navio_blsct_core
-    navio_blsct_wallet
-    Boost::headers
-    $<TARGET_NAME_IF_EXISTS:libevent::extra>
-    $<TARGET_NAME_IF_EXISTS:USDT::headers>
-    $<$<PLATFORM_ID:Windows>:ws2_32>
-  PUBLIC
-    bls_interface
-)
-
-include(InstallBinaryComponent)
-
-if(ENABLE_WALLET)
-  add_subdirectory(wallet)
-
-  if(BUILD_WALLET_TOOL)
-    add_executable(navio-wallet
-      bitcoin-wallet.cpp
-      init/bitcoin-wallet.cpp
-      wallet/wallettool.cpp
-    )
-    add_windows_resources(navio-wallet bitcoin-wallet-res.rc)
-    target_link_libraries(navio-wallet
+  add_library(navio_blsct_core STATIC EXCLUDE_FROM_ALL
+    ${BLSCT_SOURCES}
+  )
+  set_target_properties(navio_blsct_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(navio_blsct_core
+    PRIVATE
       core_interface
-      navio_wallet
-      navio_common
+      navio_crypto
       navio_util
+      secp256k1
+      univalue
       Boost::headers
-    )
-    install_binary_component(navio-wallet HAS_MANPAGE)
+    PUBLIC
+      bls_interface
+  )
+
+  add_library(navio_blsct_wallet STATIC EXCLUDE_FROM_ALL
+    ${BLSCT_WALLET_SOURCES}
+  )
+  set_target_properties(navio_blsct_wallet PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(navio_blsct_wallet
+    PRIVATE
+      core_interface
+      navio_crypto
+      navio_util
+      secp256k1
+      univalue
+      Boost::headers
+      navio_blsct_core
+    PUBLIC
+      bls_interface
+  )
+
+  add_library(navio_consensus STATIC EXCLUDE_FROM_ALL
+    arith_uint256.cpp
+    consensus/merkle.cpp
+    consensus/tx_check.cpp
+    hash.cpp
+    primitives/block.cpp
+    primitives/transaction.cpp
+    pubkey.cpp
+    script/interpreter.cpp
+    script/script.cpp
+    script/script_error.cpp
+    uint256.cpp
+  )
+  target_link_libraries(navio_consensus
+    PRIVATE
+      core_interface
+      navio_crypto
+      navio_util
+      secp256k1
+      navio_blsct_core
+    PUBLIC
+      bls_interface
+  )
+
+  if(WITH_ZMQ)
+    add_subdirectory(zmq)
   endif()
-endif()
 
-add_library(navio_node STATIC EXCLUDE_FROM_ALL
-  addrdb.cpp
-  addrman.cpp
-  banman.cpp
-  bip324.cpp
-  blockencodings.cpp
-  blockfilter.cpp
-  consensus/tx_verify.cpp
-  dbwrapper.cpp
-  deploymentstatus.cpp
-  flatfile.cpp
-  headerssync.cpp
-  httprpc.cpp
-  httpserver.cpp
-  i2p.cpp
-  index/base.cpp
-  index/blockfilterindex.cpp
-  index/coinstatsindex.cpp
-  index/txindex.cpp
-  init.cpp
-  kernel/chain.cpp
-  kernel/checks.cpp
-  kernel/coinstats.cpp
-  kernel/context.cpp
-  kernel/cs_main.cpp
-  kernel/disconnected_transactions.cpp
-  kernel/mempool_persist.cpp
-  kernel/mempool_removal_reason.cpp
-  mapport.cpp
-  net.cpp
-  net_processing.cpp
-  netgroup.cpp
-  node/abort.cpp
-  node/blockmanager_args.cpp
-  node/blockstorage.cpp
-  node/caches.cpp
-  node/chainstate.cpp
-  node/chainstatemanager_args.cpp
-  node/coin.cpp
-  node/coins_view_args.cpp
-  node/connection_types.cpp
-  node/context.cpp
-  node/database_args.cpp
-  node/eviction.cpp
-  node/interface_ui.cpp
-  node/interfaces.cpp
-  node/kernel_notifications.cpp
-  node/mempool_args.cpp
-  node/mempool_persist_args.cpp
-  node/miner.cpp
-  node/mini_miner.cpp
-  node/minisketchwrapper.cpp
-  node/peerman_args.cpp
-  node/psbt.cpp
-  node/transaction.cpp
-  node/txreconciliation.cpp
-  node/utxo_snapshot.cpp
-  node/validation_cache_args.cpp
-  noui.cpp
-  policy/fees.cpp
-  policy/fees_args.cpp
-  policy/packages.cpp
-  policy/rbf.cpp
-  policy/settings.cpp
-  pow.cpp
-  rest.cpp
-  rpc/blockchain.cpp
-  rpc/fees.cpp
-  rpc/mempool.cpp
-  rpc/mining.cpp
-  rpc/net.cpp
-  rpc/node.cpp
-  rpc/output_script.cpp
-  rpc/rawtransaction.cpp
-  rpc/server.cpp
-  rpc/server_util.cpp
-  rpc/signmessage.cpp
-  rpc/txoutproof.cpp
-  script/sigcache.cpp
-  signet.cpp
-  timedata.cpp
-  torcontrol.cpp
-  txdb.cpp
-  txmempool.cpp
-  txorphanage.cpp
-  txrequest.cpp
-  validation.cpp
-  validationinterface.cpp
-  versionbits.cpp
-  blsct/tokens/rpc.cpp
-  blsct/range_proof/rpc.cpp
-  blsct/range_proof/bulletproofs/range_proof_logic.cpp
-  blsct/wallet/unsigned_transaction.cpp
-  blsct/wallet/verification.cpp
-  $<$<TARGET_EXISTS:navio_wallet>:wallet/init.cpp>
-  $<$<NOT:$<TARGET_EXISTS:navio_wallet>>:dummywallet.cpp>
-)
-target_link_libraries(navio_node
-  PRIVATE
-    core_interface
-    navio_common
-    navio_util
-    $<TARGET_NAME_IF_EXISTS:navio_zmq>
-    leveldb
-    minisketch
-    univalue
-    Boost::headers
-    $<TARGET_NAME_IF_EXISTS:libevent::core>
-    $<TARGET_NAME_IF_EXISTS:libevent::extra>
-    $<TARGET_NAME_IF_EXISTS:libevent::pthreads>
-    $<TARGET_NAME_IF_EXISTS:USDT::headers>
-  PUBLIC
-    bls_interface
-)
-
-# naviod
-if(BUILD_DAEMON)
-  add_executable(naviod
-    naviod.cpp
-    init/naviod.cpp
-  )
-  add_windows_resources(naviod naviod-res.rc)
-  target_link_libraries(naviod
-    core_interface
-    navio_node
-    $<TARGET_NAME_IF_EXISTS:navio_wallet>
-  )
-  install_binary_component(naviod HAS_MANPAGE)
-endif()
-
-add_library(navio_cli STATIC EXCLUDE_FROM_ALL
-  compat/stdin.cpp
-  rpc/client.cpp
-)
-target_link_libraries(navio_cli
-  PUBLIC
-    core_interface
-    univalue
-)
-
-# navio-cli
-if(BUILD_CLI)
-  add_executable(navio-cli bitcoin-cli.cpp)
-  add_windows_resources(navio-cli bitcoin-cli-res.rc)
-  target_link_libraries(navio-cli
-    core_interface
-    navio_cli
-    navio_common
-    navio_util
-    libevent::core
-    libevent::extra
-  )
-  install_binary_component(navio-cli HAS_MANPAGE)
-endif()
-
-# navio-staker
-if(BUILD_STAKER)
-  add_executable(navio-staker navio-staker.cpp)
-  add_windows_resources(navio-staker navio-staker-res.rc)
-  target_link_libraries(navio-staker
-    core_interface
-    navio_cli
-    navio_common
-    navio_consensus
-    navio_util
-    navio_crypto
-    bls_interface
-    libevent::core
-    libevent::extra
-  )
-  install_binary_component(navio-staker)
-endif()
-
-# navio-tx
-if(BUILD_TX)
-  add_executable(navio-tx bitcoin-tx.cpp)
-  add_windows_resources(navio-tx bitcoin-tx-res.rc)
-  target_link_libraries(navio-tx
-    core_interface
-    navio_common
-    navio_util
-    univalue
-    bls_interface
-  )
-  install_binary_component(navio-tx HAS_MANPAGE)
-endif()
-
-# navio-util
-if(BUILD_UTIL)
-  add_executable(navio-util bitcoin-util.cpp)
-  add_windows_resources(navio-util bitcoin-util-res.rc)
-  target_link_libraries(navio-util
-    core_interface
-    navio_common
-    navio_util
-    bls_interface
-  )
-  install_binary_component(navio-util HAS_MANPAGE)
-endif()
-
-# naviokernel library + navio-chainstate
-if(BUILD_KERNEL_LIB)
-  add_subdirectory(kernel)
-  if(BUILD_UTIL_CHAINSTATE)
-    add_executable(navio-chainstate
-      bitcoin-chainstate.cpp
-    )
-    target_link_libraries(navio-chainstate
-      PRIVATE
-        core_interface
-        naviokernel
-        bls_interface
-    )
-    install_binary_component(navio-chainstate INTERNAL)
-  endif()
-endif()
-
-# libblsct standalone library
-if(BUILD_LIBBLSCT_ONLY)
-  add_library(blsct STATIC
-    blsct/external_api/blsct.cpp
-    blsct/external_api/dummy_impl.cpp
+  add_library(navio_common STATIC EXCLUDE_FROM_ALL
+    addresstype.cpp
+    base58.cpp
+    bech32.cpp
+    chain.cpp
+    chainparams.cpp
+    chainparamsbase.cpp
+    coins.cpp
     common/args.cpp
+    common/bloom.cpp
+    common/config.cpp
+    common/init.cpp
+    common/interfaces.cpp
+    common/run_command.cpp
+    common/settings.cpp
     common/system.cpp
     common/url.cpp
+    compressor.cpp
+    core_read.cpp
+    core_write.cpp
+    deploymentinfo.cpp
+    external_signer.cpp
+    init/common.cpp
+    kernel/chainparams.cpp
+    key.cpp
+    key_io.cpp
+    merkleblock.cpp
+    net_permissions.cpp
+    net_types.cpp
+    netaddress.cpp
+    netbase.cpp
+    outputtype.cpp
+    policy/feerate.cpp
+    policy/policy.cpp
+    protocol.cpp
+    psbt.cpp
+    rpc/external_signer.cpp
+    rpc/rawtransaction_util.cpp
+    rpc/request.cpp
+    rpc/util.cpp
+    scheduler.cpp
+    script/descriptor.cpp
+    script/miniscript.cpp
+    script/sign.cpp
+    script/signingprovider.cpp
+    script/solver.cpp
+    warnings.cpp
+  )
+  target_link_libraries(navio_common
+    PRIVATE
+      core_interface
+      navio_consensus
+      navio_util
+      univalue
+      secp256k1
+      navio_blsct_core
+      navio_blsct_wallet
+      Boost::headers
+      $<TARGET_NAME_IF_EXISTS:libevent::extra>
+      $<TARGET_NAME_IF_EXISTS:USDT::headers>
+      $<$<PLATFORM_ID:Windows>:ws2_32>
+    PUBLIC
+      bls_interface
+  )
+
+  include(InstallBinaryComponent)
+
+  if(ENABLE_WALLET)
+    add_subdirectory(wallet)
+
+    if(BUILD_WALLET_TOOL)
+      add_executable(navio-wallet
+        bitcoin-wallet.cpp
+        init/bitcoin-wallet.cpp
+        wallet/wallettool.cpp
+      )
+      add_windows_resources(navio-wallet bitcoin-wallet-res.rc)
+      target_link_libraries(navio-wallet
+        core_interface
+        navio_wallet
+        navio_common
+        navio_util
+        Boost::headers
+      )
+      install_binary_component(navio-wallet HAS_MANPAGE)
+    endif()
+  endif()
+
+  add_library(navio_node STATIC EXCLUDE_FROM_ALL
+    addrdb.cpp
+    addrman.cpp
+    banman.cpp
+    bip324.cpp
+    blockencodings.cpp
+    blockfilter.cpp
+    consensus/tx_verify.cpp
+    dbwrapper.cpp
+    deploymentstatus.cpp
+    flatfile.cpp
+    headerssync.cpp
+    httprpc.cpp
+    httpserver.cpp
+    i2p.cpp
+    index/base.cpp
+    index/blockfilterindex.cpp
+    index/coinstatsindex.cpp
+    index/txindex.cpp
+    init.cpp
+    kernel/chain.cpp
+    kernel/checks.cpp
+    kernel/coinstats.cpp
+    kernel/context.cpp
+    kernel/cs_main.cpp
+    kernel/disconnected_transactions.cpp
+    kernel/mempool_persist.cpp
+    kernel/mempool_removal_reason.cpp
+    mapport.cpp
+    net.cpp
+    net_processing.cpp
+    netgroup.cpp
+    node/abort.cpp
+    node/blockmanager_args.cpp
+    node/blockstorage.cpp
+    node/caches.cpp
+    node/chainstate.cpp
+    node/chainstatemanager_args.cpp
+    node/coin.cpp
+    node/coins_view_args.cpp
+    node/connection_types.cpp
+    node/context.cpp
+    node/database_args.cpp
+    node/eviction.cpp
+    node/interface_ui.cpp
+    node/interfaces.cpp
+    node/kernel_notifications.cpp
+    node/mempool_args.cpp
+    node/mempool_persist_args.cpp
+    node/miner.cpp
+    node/mini_miner.cpp
+    node/minisketchwrapper.cpp
+    node/peerman_args.cpp
+    node/psbt.cpp
+    node/transaction.cpp
+    node/txreconciliation.cpp
+    node/utxo_snapshot.cpp
+    node/validation_cache_args.cpp
+    noui.cpp
+    policy/fees.cpp
+    policy/fees_args.cpp
+    policy/packages.cpp
+    policy/rbf.cpp
+    policy/settings.cpp
+    pow.cpp
+    rest.cpp
+    rpc/blockchain.cpp
+    rpc/fees.cpp
+    rpc/mempool.cpp
+    rpc/mining.cpp
+    rpc/net.cpp
+    rpc/node.cpp
+    rpc/output_script.cpp
+    rpc/rawtransaction.cpp
+    rpc/server.cpp
+    rpc/server_util.cpp
+    rpc/signmessage.cpp
+    rpc/txoutproof.cpp
+    script/sigcache.cpp
+    signet.cpp
+    timedata.cpp
+    torcontrol.cpp
+    txdb.cpp
+    txmempool.cpp
+    txorphanage.cpp
+    txrequest.cpp
+    validation.cpp
+    validationinterface.cpp
+    versionbits.cpp
+    blsct/tokens/rpc.cpp
+    blsct/range_proof/rpc.cpp
+    blsct/range_proof/bulletproofs/range_proof_logic.cpp
+    blsct/wallet/unsigned_transaction.cpp
+    blsct/wallet/verification.cpp
+    $<$<TARGET_EXISTS:navio_wallet>:wallet/init.cpp>
+    $<$<NOT:$<TARGET_EXISTS:navio_wallet>>:dummywallet.cpp>
+  )
+  target_link_libraries(navio_node
+    PRIVATE
+      core_interface
+      navio_common
+      navio_util
+      $<TARGET_NAME_IF_EXISTS:navio_zmq>
+      leveldb
+      minisketch
+      univalue
+      Boost::headers
+      $<TARGET_NAME_IF_EXISTS:libevent::core>
+      $<TARGET_NAME_IF_EXISTS:libevent::extra>
+      $<TARGET_NAME_IF_EXISTS:libevent::pthreads>
+      $<TARGET_NAME_IF_EXISTS:USDT::headers>
+    PUBLIC
+      bls_interface
+  )
+
+  # naviod
+  if(BUILD_DAEMON)
+    add_executable(naviod
+      naviod.cpp
+      init/naviod.cpp
+    )
+    add_windows_resources(naviod naviod-res.rc)
+    target_link_libraries(naviod
+      core_interface
+      navio_node
+      $<TARGET_NAME_IF_EXISTS:navio_wallet>
+    )
+    install_binary_component(naviod HAS_MANPAGE)
+  endif()
+
+  add_library(navio_cli STATIC EXCLUDE_FROM_ALL
+    compat/stdin.cpp
+    rpc/client.cpp
+  )
+  target_link_libraries(navio_cli
+    PUBLIC
+      core_interface
+      univalue
+  )
+
+  # navio-cli
+  if(BUILD_CLI)
+    add_executable(navio-cli bitcoin-cli.cpp)
+    add_windows_resources(navio-cli bitcoin-cli-res.rc)
+    target_link_libraries(navio-cli
+      core_interface
+      navio_cli
+      navio_common
+      navio_util
+      libevent::core
+      libevent::extra
+    )
+    install_binary_component(navio-cli HAS_MANPAGE)
+  endif()
+
+  # navio-staker
+  if(BUILD_STAKER)
+    add_executable(navio-staker navio-staker.cpp)
+    add_windows_resources(navio-staker navio-staker-res.rc)
+    target_link_libraries(navio-staker
+      core_interface
+      navio_cli
+      navio_common
+      navio_consensus
+      navio_util
+      navio_crypto
+      bls_interface
+      libevent::core
+      libevent::extra
+    )
+    install_binary_component(navio-staker)
+  endif()
+
+  # navio-tx
+  if(BUILD_TX)
+    add_executable(navio-tx bitcoin-tx.cpp)
+    add_windows_resources(navio-tx bitcoin-tx-res.rc)
+    target_link_libraries(navio-tx
+      core_interface
+      navio_common
+      navio_util
+      univalue
+      bls_interface
+    )
+    install_binary_component(navio-tx HAS_MANPAGE)
+  endif()
+
+  # navio-util
+  if(BUILD_UTIL)
+    add_executable(navio-util bitcoin-util.cpp)
+    add_windows_resources(navio-util bitcoin-util-res.rc)
+    target_link_libraries(navio-util
+      core_interface
+      navio_common
+      navio_util
+      bls_interface
+    )
+    install_binary_component(navio-util HAS_MANPAGE)
+  endif()
+
+  # naviokernel library + navio-chainstate
+  if(BUILD_KERNEL_LIB)
+    add_subdirectory(kernel)
+    if(BUILD_UTIL_CHAINSTATE)
+      add_executable(navio-chainstate
+        bitcoin-chainstate.cpp
+      )
+      target_link_libraries(navio-chainstate
+        PRIVATE
+          core_interface
+          naviokernel
+          bls_interface
+      )
+      install_binary_component(navio-chainstate INTERNAL)
+    endif()
+  endif()
+
+endif() # NOT BUILD_LIBBLSCT_ONLY
+
+# libblsct standalone library
+# Source list mirrors autotools libblsct_a_SOURCES + BLSCT_EXTERNAL_CPP
+# (src/Makefile.am: BLSCT_EXTERNAL_CPP at ~L251, libblsct_a_SOURCES at ~L1524).
+# Keep these in sync with src/Makefile.am.
+if(BUILD_LIBBLSCT_ONLY)
+  add_library(blsct STATIC
+    # libblsct_a_SOURCES (excluding BLSCT_EXTERNAL_CPP — appended below)
+    arith_uint256.cpp
+    blsct/external_api/blsct.cpp
+    blsct/external_api/blsct_clientversion.cpp
+    chain.cpp
     crypto/hmac_sha256.cpp
     crypto/ripemd160.cpp
     crypto/sha256.cpp
-    hash.cpp
+    crypto/sha256_sse4.cpp
     primitives/transaction.cpp
-    rpc/util.cpp
-    script/interpreter.cpp
-    script/miniscript.cpp
     script/script.cpp
-    script/script_error.cpp
-    script/sign.cpp
-    script/signingprovider.cpp
-    sync.cpp
     support/cleanse.cpp
     support/lockedpool.cpp
     uint256.cpp
+    util/check.cpp
     util/moneystr.cpp
-    util/rbf.cpp
     util/strencodings.cpp
     util/time.cpp
-    wallet/coincontrol.cpp
-    wallet/context.cpp
-    wallet/crypter.cpp
-    wallet/db.cpp
-    wallet/dump.cpp
-    wallet/external_signer_scriptpubkeyman.cpp
-    wallet/feebumper.cpp
-    wallet/fees.cpp
-    wallet/interfaces.cpp
-    wallet/load.cpp
-    wallet/receive.cpp
-    wallet/rpc/addresses.cpp
-    wallet/rpc/backup.cpp
-    wallet/rpc/coins.cpp
-    wallet/rpc/encrypt.cpp
-    wallet/rpc/spend.cpp
-    wallet/rpc/signmessage.cpp
-    wallet/rpc/transactions.cpp
-    wallet/rpc/util.cpp
-    wallet/rpc/wallet.cpp
-    wallet/scriptpubkeyman.cpp
-    wallet/spend.cpp
-    wallet/transaction.cpp
-    wallet/wallet.cpp
-    wallet/walletdb.cpp
-    wallet/walletutil.cpp
-    wallet/coinselection.cpp
-    ${BLSCT_SOURCES}
-    ${BLSCT_WALLET_SOURCES}
+    # BLSCT_EXTERNAL_CPP
+    blsct/arith/elements.cpp
+    blsct/arith/mcl/mcl_g1point.cpp
+    blsct/arith/mcl/mcl_scalar.cpp
+    blsct/bech32_mod.cpp
+    blsct/building_block/g_h_gi_hi_zero_verifier.cpp
+    blsct/building_block/generator_deriver.cpp
+    blsct/building_block/imp_inner_prod_arg.cpp
+    blsct/building_block/lazy_point.cpp
+    blsct/building_block/lazy_points.cpp
+    blsct/building_block/weighted_inner_prod_arg.cpp
+    blsct/chain.cpp
+    blsct/common.cpp
+    blsct/double_public_key.cpp
+    blsct/eip_2333/bls12_381_keygen.cpp
+    blsct/key_io.cpp
+    blsct/pos/helpers.cpp
+    blsct/private_key.cpp
+    blsct/public_key.cpp
+    blsct/public_keys.cpp
+    blsct/range_proof/bulletproofs/amount_recovery_request.cpp
+    blsct/range_proof/bulletproofs/amount_recovery_result.cpp
+    blsct/range_proof/bulletproofs/range_proof_logic.cpp
+    blsct/range_proof/bulletproofs/range_proof_with_transcript.cpp
+    blsct/range_proof/bulletproofs_plus/amount_recovery_request.cpp
+    blsct/range_proof/bulletproofs_plus/amount_recovery_result.cpp
+    blsct/range_proof/bulletproofs_plus/range_proof_logic.cpp
+    blsct/range_proof/bulletproofs_plus/range_proof_with_transcript.cpp
+    blsct/range_proof/bulletproofs_plus/util.cpp
+    blsct/range_proof/common.cpp
+    blsct/range_proof/generators.cpp
+    blsct/range_proof/msg_amt_cipher.cpp
+    blsct/signature.cpp
+    blsct/tokens/predicate_parser.cpp
+    blsct/wallet/address.cpp
+    blsct/wallet/helpers.cpp
+    blsct/wallet/txfactory_base.cpp
+    blsct/wallet/txfactory_global.cpp
+    blsct/wallet/unsigned_transaction.cpp
   )
   target_compile_definitions(blsct PRIVATE LIBBLSCT)
+
+  # Conditional SIMD SHA-256 variants. Mirrors src/crypto/CMakeLists.txt and
+  # autotools libblsct_a_CXXFLAGS / libblsct_a_CPPFLAGS gating (src/Makefile.am
+  # ~L1500-L1518). Each variant compiles with target-specific -m flags only
+  # when the host toolchain supports the intrinsics.
+  if(HAVE_SSE41)
+    target_compile_definitions(blsct PRIVATE ENABLE_SSE41)
+    target_sources(blsct PRIVATE crypto/sha256_sse41.cpp)
+    set_property(SOURCE crypto/sha256_sse41.cpp PROPERTY
+      COMPILE_OPTIONS ${SSE41_CXXFLAGS}
+    )
+  endif()
+  if(HAVE_AVX2)
+    target_compile_definitions(blsct PRIVATE ENABLE_AVX2)
+    target_sources(blsct PRIVATE crypto/sha256_avx2.cpp)
+    set_property(SOURCE crypto/sha256_avx2.cpp PROPERTY
+      COMPILE_OPTIONS ${AVX2_CXXFLAGS}
+    )
+  endif()
+  if(HAVE_SSE41 AND HAVE_X86_SHANI)
+    target_compile_definitions(blsct PRIVATE ENABLE_X86_SHANI)
+    target_sources(blsct PRIVATE crypto/sha256_x86_shani.cpp)
+    set_property(SOURCE crypto/sha256_x86_shani.cpp PROPERTY
+      COMPILE_OPTIONS ${SSE41_CXXFLAGS} ${X86_SHANI_CXXFLAGS}
+    )
+  endif()
+  if(HAVE_ARM_SHANI)
+    target_compile_definitions(blsct PRIVATE ENABLE_ARM_SHANI)
+    target_sources(blsct PRIVATE crypto/sha256_arm_shani.cpp)
+    set_property(SOURCE crypto/sha256_arm_shani.cpp PROPERTY
+      COMPILE_OPTIONS ${ARM_SHANI_CXXFLAGS}
+    )
+  endif()
+
   target_link_libraries(blsct
     PRIVATE
       core_interface
@@ -559,7 +607,9 @@ if(BUILD_LIBBLSCT_ONLY)
   set_target_properties(blsct PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
-add_subdirectory(test/util)
+if(NOT BUILD_LIBBLSCT_ONLY)
+  add_subdirectory(test/util)
+endif()
 if(BUILD_BENCH)
   add_subdirectory(bench)
 endif()

--- a/src/blsct/eip_2333/bls12_381_keygen.cpp
+++ b/src/blsct/eip_2333/bls12_381_keygen.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blsct/eip_2333/bls12_381_keygen.h>
-#include <cmath>
 #include <crypto/sha256.h>
 #include <tinyformat.h>
 
@@ -25,7 +24,7 @@ std::array<uint8_t,L> BLS12_381_KeyGen::HKDF_Expand(const std::array<uint8_t,BLS
     std::array<uint8_t,L> output;
     uint8_t n;
 
-    const size_t num_loops = std::ceil(static_cast<float>(L) / DigestSize);
+    const size_t num_loops = (L + DigestSize - 1) / DigestSize;
     auto output_it = output.begin();
 
     for (size_t i=1; i<=num_loops; ++i) {

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -183,7 +183,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     for (int i = 1; i < argc; i++) {
         std::string key(argv[i]);
 
-#ifdef MAC_OSX
+#ifdef __APPLE__
         // At the first time when a user gets the "App downloaded from the
         // internet" warning, and clicks the Open button, macOS passes
         // a unique process serial number (PSN) as -psn_... command-line
@@ -698,7 +698,7 @@ fs::path GetDefaultDataDir()
         pathRet = fs::path("/");
     else
         pathRet = fs::path(pszHome);
-#ifdef MAC_OSX
+#ifdef __APPLE__
     // macOS
     return pathRet / "Library/Application Support/Navio";
 #else

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -66,7 +66,7 @@ void SetupEnvironment()
 #endif
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
     // may be invalid, in which case the "C.UTF-8" locale is used as fallback.
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
+#if !defined(WIN32) && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
     try {
         std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -15,7 +15,7 @@
 #include <byteswap.h>
 #endif
 
-#if defined(MAC_OSX)
+#if defined(__APPLE__)
 
 #include <libkern/OSByteOrder.h>
 #define bswap_16(x) OSSwapInt16(x)
@@ -54,6 +54,6 @@ inline uint64_t bswap_64(uint64_t x)
 }
 #endif // HAVE_DECL_BSWAP64 == 0
 
-#endif // defined(MAC_OSX)
+#endif // defined(__APPLE__)
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -15,7 +15,7 @@
 #include <asm/hwcap.h>
 #endif
 
-#if defined(MAC_OSX) && defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
+#if defined(__APPLE__) && defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
@@ -663,7 +663,7 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
 #endif
 #endif
 
-#if defined(MAC_OSX)
+#if defined(__APPLE__)
         int val = 0;
         size_t len = sizeof(val);
         if (sysctlbyname("hw.optional.arm.FEAT_SHA256", &val, &len, nullptr, 0) == 0) {

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -31,7 +31,7 @@
 #include <sys/time.h>
 #endif
 
-#if defined(HAVE_GETRANDOM) || (defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX))
+#if defined(HAVE_GETRANDOM) || (defined(HAVE_GETENTROPY_RAND) && defined(__APPLE__))
 #include <sys/random.h>
 #endif
 
@@ -374,7 +374,7 @@ void GetOSRand(unsigned char *ent32)
        The function call is always successful.
      */
     arc4random_buf(ent32, NUM_OS_RANDOM_BYTES);
-#elif defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
+#elif defined(HAVE_GETENTROPY_RAND) && defined(__APPLE__)
     if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
         RandFailure();
     }

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -118,7 +118,7 @@ bool FileCommit(FILE* file)
         LogPrintf("FlushFileBuffers failed: %s\n", Win32ErrorString(GetLastError()));
         return false;
     }
-#elif defined(MAC_OSX) && defined(F_FULLFSYNC)
+#elif defined(__APPLE__) && defined(F_FULLFSYNC)
     if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
         LogPrintf("fcntl F_FULLFSYNC failed: %s\n", SysErrorString(errno));
         return false;
@@ -196,7 +196,7 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     nFileSize.u.HighPart = nEndPos >> 32;
     SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
     SetEndOfFile(hFile);
-#elif defined(MAC_OSX)
+#elif defined(__APPLE__)
     // OSX specific version
     // NOTE: Contrary to other OS versions, the OSX version assumes that
     // NOTE: offset is the size of the file.

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -30,7 +30,7 @@ static void SetThreadName(const char* name)
     ::prctl(PR_SET_NAME, name, 0, 0, 0);
 #elif (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
     pthread_set_name_np(pthread_self(), name);
-#elif defined(MAC_OSX)
+#elif defined(__APPLE__)
     pthread_setname_np(name);
 #else
     // Prevent warnings for unused parameters...

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,10 @@ function(create_test_config)
   set(abs_top_srcdir ${PROJECT_SOURCE_DIR})
   set(abs_top_builddir ${PROJECT_BINARY_DIR})
   set(EXEEXT ${CMAKE_EXECUTABLE_SUFFIX})
+  # Binaries land in build/bin/ under CMake (autotools uses build/src/).
+  set(EXEDIR_REL bin)
+  # Fuzz binary is flat under CMake (autotools nests at src/test/fuzz/fuzz).
+  set(FUZZ_BIN_REL "bin/fuzz${CMAKE_EXECUTABLE_SUFFIX}")
 
   macro(set_configure_variable var conf_var)
     if(${var})
@@ -59,11 +63,20 @@ function(create_test_directory_links)
     functional/test_framework/*.py
   )
 
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/functional/test_framework/crypto)
+  file(GLOB functional_test_framework_crypto
+    LIST_DIRECTORIES FALSE
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    functional/test_framework/crypto/*.csv
+    functional/test_framework/crypto/*.py
+  )
+
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fuzz)
   set(files_to_link
     ${functional}
     ${functional_data}
     ${functional_test_framework}
+    ${functional_test_framework_crypto}
     fuzz/test_runner.py
   )
 

--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -12,6 +12,8 @@ CLIENT_BUGREPORT=@CLIENT_BUGREPORT@
 SRCDIR=@abs_top_srcdir@
 BUILDDIR=@abs_top_builddir@
 EXEEXT=@EXEEXT@
+EXEDIR_REL=@EXEDIR_REL@
+FUZZ_BIN_REL=@FUZZ_BIN_REL@
 RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 
 [components]

--- a/test/functional/bls_message_signing.py
+++ b/test/functional/bls_message_signing.py
@@ -178,4 +178,4 @@ class BLSMessageSigningTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSMessageSigningTest().main()
+    BLSMessageSigningTest(__file__).main()

--- a/test/functional/blsct_balance_proof.py
+++ b/test/functional/blsct_balance_proof.py
@@ -96,4 +96,4 @@ class NavioBlsctBalanceProofTest(BitcoinTestFramework):
         assert_equal(verify_result["min_amount"], balance / 2)
 
 if __name__ == '__main__':
-    NavioBlsctBalanceProofTest().main()
+    NavioBlsctBalanceProofTest(__file__).main()

--- a/test/functional/blsct_block_rpc.py
+++ b/test/functional/blsct_block_rpc.py
@@ -70,4 +70,4 @@ class BLSCTBlockRPCTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    BLSCTBlockRPCTest().main()
+    BLSCTBlockRPCTest(__file__).main()

--- a/test/functional/blsct_htlc.py
+++ b/test/functional/blsct_htlc.py
@@ -829,4 +829,4 @@ class BLSCTHTLCTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSCTHTLCTest().main()
+    BLSCTHTLCTest(__file__).main()

--- a/test/functional/blsct_import_scriptpubkeys.py
+++ b/test/functional/blsct_import_scriptpubkeys.py
@@ -285,4 +285,4 @@ class BLSCTRawTransactionScriptTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSCTRawTransactionScriptTest().main()
+    BLSCTRawTransactionScriptTest(__file__).main()

--- a/test/functional/blsct_listtransactions_stake.py
+++ b/test/functional/blsct_listtransactions_stake.py
@@ -143,4 +143,4 @@ class BlsctListTransactionsStakeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlsctListTransactionsStakeTest().main()
+    BlsctListTransactionsStakeTest(__file__).main()

--- a/test/functional/blsct_nft.py
+++ b/test/functional/blsct_nft.py
@@ -120,4 +120,4 @@ class NavioBlsctNftTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NavioBlsctNftTest().main()
+    NavioBlsctNftTest(__file__).main()

--- a/test/functional/blsct_output_storage.py
+++ b/test/functional/blsct_output_storage.py
@@ -591,4 +591,4 @@ class NavioBlsctOutputStorageTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NavioBlsctOutputStorageTest().main()
+    NavioBlsctOutputStorageTest(__file__).main()

--- a/test/functional/blsct_pops_consensus.py
+++ b/test/functional/blsct_pops_consensus.py
@@ -163,4 +163,4 @@ class BlsctPopsConsensusTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    BlsctPopsConsensusTest().main()
+    BlsctPopsConsensusTest(__file__).main()

--- a/test/functional/blsct_rawtransaction.py
+++ b/test/functional/blsct_rawtransaction.py
@@ -494,4 +494,4 @@ class BLSCTRawTransactionTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSCTRawTransactionTest().main()
+    BLSCTRawTransactionTest(__file__).main()

--- a/test/functional/blsct_script_validation.py
+++ b/test/functional/blsct_script_validation.py
@@ -339,4 +339,4 @@ class BLSCTScriptValidationTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSCTScriptValidationTest().main()
+    BLSCTScriptValidationTest(__file__).main()

--- a/test/functional/blsct_setblsctseed.py
+++ b/test/functional/blsct_setblsctseed.py
@@ -110,4 +110,4 @@ class BLSCTSetSeedTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BLSCTSetSeedTest().main()
+    BLSCTSetSeedTest(__file__).main()

--- a/test/functional/blsct_staking.py
+++ b/test/functional/blsct_staking.py
@@ -156,4 +156,4 @@ class NavioBlsctStakingTest(BitcoinTestFramework):
             self.log.info(f"Verbose staking may have parameter handling issue: {e}")
 
 if __name__ == '__main__':
-    NavioBlsctStakingTest().main()
+    NavioBlsctStakingTest(__file__).main()

--- a/test/functional/blsct_token.py
+++ b/test/functional/blsct_token.py
@@ -217,4 +217,4 @@ class NavioBlsctTokenTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NavioBlsctTokenTest().main()
+    NavioBlsctTokenTest(__file__).main()

--- a/test/functional/blsct_unconfirmed_spending.py
+++ b/test/functional/blsct_unconfirmed_spending.py
@@ -199,4 +199,4 @@ class BlsctUnconfirmedSpendingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlsctUnconfirmedSpendingTest().main()
+    BlsctUnconfirmedSpendingTest(__file__).main()

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -24,4 +24,4 @@ class CreateCache(BitcoinTestFramework):
         pass
 
 if __name__ == '__main__':
-    CreateCache().main()
+    CreateCache(__file__).main()

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -225,4 +225,4 @@ class ExampleTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ExampleTest().main()
+    ExampleTest(__file__).main()

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -42,4 +42,4 @@ class AbortNodeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AbortNodeTest().main()
+    AbortNodeTest(__file__).main()

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -167,4 +167,4 @@ class AddrmanTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    AddrmanTest().main()
+    AddrmanTest(__file__).main()

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -141,4 +141,4 @@ class AnchorsTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    AnchorsTest().main()
+    AnchorsTest(__file__).main()

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -136,4 +136,4 @@ class AsmapTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AsmapTest().main()
+    AsmapTest(__file__).main()

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -348,4 +348,4 @@ class AssumeutxoTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AssumeutxoTest().main()
+    AssumeutxoTest(__file__).main()

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -172,4 +172,4 @@ class AssumeValidTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AssumeValidTest().main()
+    AssumeValidTest(__file__).main()

--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -83,4 +83,4 @@ class BindExtraTest(BitcoinTestFramework):
             self.log.info(f"Stopped node {i}")
 
 if __name__ == '__main__':
-    BindExtraTest().main()
+    BindExtraTest(__file__).main()

--- a/test/functional/feature_bind_port_discover.py
+++ b/test/functional/feature_bind_port_discover.py
@@ -75,4 +75,4 @@ class BindPortDiscoverTest(BitcoinTestFramework):
         assert found_addr1
 
 if __name__ == '__main__':
-    BindPortDiscoverTest().main()
+    BindPortDiscoverTest(__file__).main()

--- a/test/functional/feature_bind_port_externalip.py
+++ b/test/functional/feature_bind_port_externalip.py
@@ -72,4 +72,4 @@ class BindPortExternalIPTest(BitcoinTestFramework):
             assert found
 
 if __name__ == '__main__':
-    BindPortExternalIPTest().main()
+    BindPortExternalIPTest(__file__).main()

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -414,4 +414,4 @@ class BIP68Test(BitcoinTestFramework):
         mini_wallet.sendrawtransaction(from_node=self.nodes[1], tx_hex=tx.serialize().hex())
 
 if __name__ == '__main__':
-    BIP68Test().main()
+    BIP68Test(__file__).main()

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1440,4 +1440,4 @@ class FullBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FullBlockTest().main()
+    FullBlockTest(__file__).main()

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -35,4 +35,4 @@ class BlocksdirTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlocksdirTest().main()
+    BlocksdirTest(__file__).main()

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -194,4 +194,4 @@ class BIP65Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP65Test().main()
+    BIP65Test(__file__).main()

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -321,4 +321,4 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CoinStatsIndexTest().main()
+    CoinStatsIndexTest(__file__).main()

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -431,4 +431,4 @@ class ConfArgsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ConfArgsTest().main()
+    ConfArgsTest(__file__).main()

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -493,4 +493,4 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP68_112_113Test().main()
+    BIP68_112_113Test(__file__).main()

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -286,4 +286,4 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ChainstateWriteCrashTest().main()
+    ChainstateWriteCrashTest(__file__).main()

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -158,4 +158,4 @@ class BIP66Test(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BIP66Test().main()
+    BIP66Test(__file__).main()

--- a/test/functional/feature_dirsymlinks.py
+++ b/test/functional/feature_dirsymlinks.py
@@ -38,4 +38,4 @@ class SymlinkTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    SymlinkTest().main()
+    SymlinkTest(__file__).main()

--- a/test/functional/feature_discover.py
+++ b/test/functional/feature_discover.py
@@ -72,4 +72,4 @@ class DiscoverTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DiscoverTest().main()
+    DiscoverTest(__file__).main()

--- a/test/functional/feature_fastprune.py
+++ b/test/functional/feature_fastprune.py
@@ -26,4 +26,4 @@ class FeatureFastpruneTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeatureFastpruneTest().main()
+    FeatureFastpruneTest(__file__).main()

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -436,4 +436,4 @@ class EstimateFeeTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    EstimateFeeTest().main()
+    EstimateFeeTest(__file__).main()

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -52,4 +52,4 @@ class FilelockTest(BitcoinTestFramework):
                 check_wallet_filelock(True)
 
 if __name__ == '__main__':
-    FilelockTest().main()
+    FilelockTest(__file__).main()

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -59,4 +59,4 @@ class HelpTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HelpTest().main()
+    HelpTest(__file__).main()

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -83,4 +83,4 @@ class IncludeConfTest(BitcoinTestFramework):
         assert subversion.endswith("main; relative; relative2)/")
 
 if __name__ == '__main__':
-    IncludeConfTest().main()
+    IncludeConfTest(__file__).main()

--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -155,4 +155,4 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeatureIndexPruneTest().main()
+    FeatureIndexPruneTest(__file__).main()

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -149,4 +149,4 @@ class InitStressTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InitStressTest().main()
+    InitStressTest(__file__).main()

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -80,4 +80,4 @@ class LoadblockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    LoadblockTest().main()
+    LoadblockTest(__file__).main()

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -101,4 +101,4 @@ class LoggingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    LoggingTest().main()
+    LoggingTest(__file__).main()

--- a/test/functional/feature_maxtipage.py
+++ b/test/functional/feature_maxtipage.py
@@ -58,4 +58,4 @@ class MaxTipAgeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MaxTipAgeTest().main()
+    MaxTipAgeTest(__file__).main()

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -169,4 +169,4 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(extra_args=["-maxuploadtarget=abc"], expected_msg="Error: Unable to parse -maxuploadtarget: 'abc'")
 
 if __name__ == '__main__':
-    MaxUploadTest().main()
+    MaxUploadTest(__file__).main()

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -115,4 +115,4 @@ class MinimumChainWorkTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MinimumChainWorkTest().main()
+    MinimumChainWorkTest(__file__).main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -194,4 +194,4 @@ class NotificationsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NotificationsTest().main()
+    NotificationsTest(__file__).main()

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -162,4 +162,4 @@ class NULLDUMMYTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NULLDUMMYTest().main()
+    NULLDUMMYTest(__file__).main()

--- a/test/functional/feature_posix_fs_permissions.py
+++ b/test/functional/feature_posix_fs_permissions.py
@@ -40,4 +40,4 @@ class PosixFsPermissionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PosixFsPermissionsTest().main()
+    PosixFsPermissionsTest(__file__).main()

--- a/test/functional/feature_presegwit_node_upgrade.py
+++ b/test/functional/feature_presegwit_node_upgrade.py
@@ -54,4 +54,4 @@ class SegwitUpgradeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegwitUpgradeTest().main()
+    SegwitUpgradeTest(__file__).main()

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -385,4 +385,4 @@ class ProxyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ProxyTest().main()
+    ProxyTest(__file__).main()

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -495,4 +495,4 @@ class PruneTest(BitcoinTestFramework):
             "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0, "basic", {"filter_false_positives": True})
 
 if __name__ == '__main__':
-    PruneTest().main()
+    PruneTest(__file__).main()

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -730,4 +730,4 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert conflicting_tx['txid'] in self.nodes[0].getrawmempool()
 
 if __name__ == '__main__':
-    ReplaceByFeeTest().main()
+    ReplaceByFeeTest(__file__).main()

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -83,4 +83,4 @@ class ReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ReindexTest().main()
+    ReindexTest(__file__).main()

--- a/test/functional/feature_reindex_readonly.py
+++ b/test/functional/feature_reindex_readonly.py
@@ -86,4 +86,4 @@ class BlockstoreReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockstoreReindexTest().main()
+    BlockstoreReindexTest(__file__).main()

--- a/test/functional/feature_remove_pruned_files_on_startup.py
+++ b/test/functional/feature_remove_pruned_files_on_startup.py
@@ -52,4 +52,4 @@ class FeatureRemovePrunedFilesOnStartupTest(BitcoinTestFramework):
         assert not os.path.exists(rev1)
 
 if __name__ == '__main__':
-    FeatureRemovePrunedFilesOnStartupTest().main()
+    FeatureRemovePrunedFilesOnStartupTest(__file__).main()

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -663,4 +663,4 @@ class SegWitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegWitTest().main()
+    SegWitTest(__file__).main()

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -87,4 +87,4 @@ class SettingsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SettingsTest().main()
+    SettingsTest(__file__).main()

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -32,4 +32,4 @@ class ShutdownTest(BitcoinTestFramework):
         self.stop_node(0, wait=1000)
 
 if __name__ == '__main__':
-    ShutdownTest().main()
+    ShutdownTest(__file__).main()

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -72,4 +72,4 @@ class SignetBasicTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignetBasicTest().main()
+    SignetBasicTest(__file__).main()

--- a/test/functional/feature_startupnotify.py
+++ b/test/functional/feature_startupnotify.py
@@ -39,4 +39,4 @@ class StartupNotifyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    StartupNotifyTest().main()
+    StartupNotifyTest(__file__).main()

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1767,4 +1767,4 @@ class TaprootTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TaprootTest().main()
+    TaprootTest(__file__).main()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -37,4 +37,4 @@ class UacommentTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UacommentTest().main()
+    UacommentTest(__file__).main()

--- a/test/functional/feature_unsupported_utxo_db.py
+++ b/test/functional/feature_unsupported_utxo_db.py
@@ -58,4 +58,4 @@ class UnsupportedUtxoDbTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    UnsupportedUtxoDbTest().main()
+    UnsupportedUtxoDbTest(__file__).main()

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -78,4 +78,4 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UTXOSetHashTest().main()
+    UTXOSetHashTest(__file__).main()

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -100,4 +100,4 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.wait_until(lambda: self.versionbits_in_alert_file())
 
 if __name__ == '__main__':
-    VersionBitsWarningTest().main()
+    VersionBitsWarningTest(__file__).main()

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -106,4 +106,4 @@ class HTTPBasicsTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HTTPBasicsTest ().main ()
+    HTTPBasicsTest(__file__).main()

--- a/test/functional/interface_navio_cli.py
+++ b/test/functional/interface_navio_cli.py
@@ -334,4 +334,4 @@ class TestBitcoinCli(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TestBitcoinCli().main()
+    TestBitcoinCli(__file__).main()

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -432,4 +432,4 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(resp.read().decode('utf-8').rstrip(), f"Invalid hash: {INVALID_PARAM}")
 
 if __name__ == '__main__':
-    RESTTest().main()
+    RESTTest(__file__).main()

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -100,4 +100,4 @@ class RPCInterfaceTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RPCInterfaceTest().main()
+    RPCInterfaceTest(__file__).main()

--- a/test/functional/interface_usdt_coinselection.py
+++ b/test/functional/interface_usdt_coinselection.py
@@ -208,4 +208,4 @@ class CoinSelectionTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CoinSelectionTracepointTest().main()
+    CoinSelectionTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -322,4 +322,4 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolTracepointTest().main()
+    MempoolTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -168,4 +168,4 @@ class NetTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetTracepointTest().main()
+    NetTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -408,4 +408,4 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UTXOCacheTracepointTest().main()
+    UTXOCacheTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -131,4 +131,4 @@ class ValidationTracepointTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ValidationTracepointTest().main()
+    ValidationTracepointTest(__file__).main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -587,4 +587,4 @@ class ZMQTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ZMQTest().main()
+    ZMQTest(__file__).main()

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -380,4 +380,4 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         )
 
 if __name__ == '__main__':
-    MempoolAcceptanceTest().main()
+    MempoolAcceptanceTest(__file__).main()

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -140,4 +140,4 @@ class MempoolWtxidTest(BitcoinTestFramework):
         assert_equal(node.getmempoolinfo()["unbroadcastcount"], 0)
 
 if __name__ == '__main__':
-    MempoolWtxidTest().main()
+    MempoolWtxidTest(__file__).main()

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -78,4 +78,4 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolCompatibilityTest().main()
+    MempoolCompatibilityTest(__file__).main()

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -88,4 +88,4 @@ class DataCarrierTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DataCarrierTest().main()
+    DataCarrierTest(__file__).main()

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -179,4 +179,4 @@ class DustRelayFeeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DustRelayFeeTest().main()
+    DustRelayFeeTest(__file__).main()

--- a/test/functional/mempool_expiry.py
+++ b/test/functional/mempool_expiry.py
@@ -115,4 +115,4 @@ class MempoolExpiryTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolExpiryTest().main()
+    MempoolExpiryTest(__file__).main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -298,4 +298,4 @@ class MempoolLimitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolLimitTest().main()
+    MempoolLimitTest(__file__).main()

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -343,4 +343,4 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolPackageLimitsTest().main()
+    MempoolPackageLimitsTest(__file__).main()

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -69,4 +69,4 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolPackagesTest().main()
+    MempoolPackagesTest(__file__).main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -294,4 +294,4 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.sync_blocks()
 
 if __name__ == '__main__':
-    MempoolPackagesTest().main()
+    MempoolPackagesTest(__file__).main()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -263,4 +263,4 @@ class MempoolPersistTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolPersistTest().main()
+    MempoolPersistTest(__file__).main()

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -194,4 +194,4 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolCoinbaseTest().main()
+    MempoolCoinbaseTest(__file__).main()

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -55,4 +55,4 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolCoinbaseTest().main()
+    MempoolCoinbaseTest(__file__).main()

--- a/test/functional/mempool_sigoplimit.py
+++ b/test/functional/mempool_sigoplimit.py
@@ -153,4 +153,4 @@ class BytesPerSigOpTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BytesPerSigOpTest().main()
+    BytesPerSigOpTest(__file__).main()

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -68,4 +68,4 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolSpendCoinbaseTest().main()
+    MempoolSpendCoinbaseTest(__file__).main()

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -109,4 +109,4 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolUnbroadcastTest().main()
+    MempoolUnbroadcastTest(__file__).main()

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -107,4 +107,4 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MempoolUpdateFromBlockTest().main()
+    MempoolUpdateFromBlockTest(__file__).main()

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -331,4 +331,4 @@ class MiningTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MiningTest().main()
+    MiningTest(__file__).main()

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -73,4 +73,4 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         assert not thr.is_alive()
 
 if __name__ == '__main__':
-    GetBlockTemplateLPTest().main()
+    GetBlockTemplateLPTest(__file__).main()

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -305,4 +305,4 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         assert template != new_template
 
 if __name__ == '__main__':
-    PrioritiseTransactionTest().main()
+    PrioritiseTransactionTest(__file__).main()

--- a/test/functional/p2p_add_connections.py
+++ b/test/functional/p2p_add_connections.py
@@ -107,4 +107,4 @@ class P2PAddConnections(BitcoinTestFramework):
         assert_equal(feeler_conn.last_message["version"].relay, 0)
 
 if __name__ == '__main__':
-    P2PAddConnections().main()
+    P2PAddConnections(__file__).main()

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -439,4 +439,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_addrfetch.py
+++ b/test/functional/p2p_addrfetch.py
@@ -83,4 +83,4 @@ class P2PAddrFetch(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PAddrFetch().main()
+    P2PAddrFetch(__file__).main()

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -101,4 +101,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_block_sync.py
+++ b/test/functional/p2p_block_sync.py
@@ -34,4 +34,4 @@ class BlockSyncTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockSyncTest().main()
+    BlockSyncTest(__file__).main()

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -282,4 +282,4 @@ def compute_last_header(prev_header, hashes):
 
 
 if __name__ == '__main__':
-    CompactFiltersTest().main()
+    CompactFiltersTest(__file__).main()

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -125,4 +125,4 @@ class P2PBlocksOnly(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PBlocksOnly().main()
+    P2PBlocksOnly(__file__).main()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -966,4 +966,4 @@ class CompactBlocksTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CompactBlocksTest().main()
+    CompactBlocksTest(__file__).main()

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -127,4 +127,4 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         p2p_conn_blocksonly.wait_until(lambda: test_for_cmpctblock(block2))
 
 if __name__ == '__main__':
-    P2PCompactBlocksBlocksOnly().main()
+    P2PCompactBlocksBlocksOnly(__file__).main()

--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -92,4 +92,4 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CompactBlocksConnectionTest().main()
+    CompactBlocksConnectionTest(__file__).main()

--- a/test/functional/p2p_dandelionpp_blackhole.py
+++ b/test/functional/p2p_dandelionpp_blackhole.py
@@ -74,4 +74,4 @@ class DandelionBlackholeTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    DandelionBlackholeTest().main()
+    DandelionBlackholeTest(__file__).main()

--- a/test/functional/p2p_dandelionpp_fluffing.py
+++ b/test/functional/p2p_dandelionpp_fluffing.py
@@ -97,4 +97,4 @@ class DandelionFluffingTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    DandelionFluffingTest().main()
+    DandelionFluffingTest(__file__).main()

--- a/test/functional/p2p_dandelionpp_loop.py
+++ b/test/functional/p2p_dandelionpp_loop.py
@@ -81,4 +81,4 @@ class DandelionLoopTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    DandelionLoopTest().main()
+    DandelionLoopTest(__file__).main()

--- a/test/functional/p2p_dandelionpp_mempool_leak.py
+++ b/test/functional/p2p_dandelionpp_mempool_leak.py
@@ -114,4 +114,4 @@ class DandelionLoopTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    DandelionLoopTest().main()
+    DandelionLoopTest(__file__).main()

--- a/test/functional/p2p_dandelionpp_probing.py
+++ b/test/functional/p2p_dandelionpp_probing.py
@@ -66,4 +66,4 @@ class DandelionProbingTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    DandelionProbingTest().main()
+    DandelionProbingTest(__file__).main()

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -143,4 +143,4 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
 
 if __name__ == '__main__':
-    DisconnectBanTest().main()
+    DisconnectBanTest(__file__).main()

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -126,4 +126,4 @@ class P2PDNSSeeds(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PDNSSeeds().main()
+    P2PDNSSeeds(__file__).main()

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -124,4 +124,4 @@ class P2PEvict(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PEvict().main()
+    P2PEvict(__file__).main()

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -132,4 +132,4 @@ class FeeFilterTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FeeFilterTest().main()
+    FeeFilterTest(__file__).main()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -251,4 +251,4 @@ class FilterTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    FilterTest().main()
+    FilterTest(__file__).main()

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -130,4 +130,4 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PFingerprintTest().main()
+    P2PFingerprintTest(__file__).main()

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -119,4 +119,4 @@ class AddrTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddrTest().main()
+    AddrTest(__file__).main()

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -46,4 +46,4 @@ class GetdataTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    GetdataTest().main()
+    GetdataTest(__file__).main()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -162,4 +162,4 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RejectLowDifficultyHeadersTest().main()
+    RejectLowDifficultyHeadersTest(__file__).main()

--- a/test/functional/p2p_i2p_ports.py
+++ b/test/functional/p2p_i2p_ports.py
@@ -40,4 +40,4 @@ class I2PPorts(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    I2PPorts().main()
+    I2PPorts(__file__).main()

--- a/test/functional/p2p_i2p_sessions.py
+++ b/test/functional/p2p_i2p_sessions.py
@@ -33,4 +33,4 @@ class I2PSessions(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    I2PSessions().main()
+    I2PSessions(__file__).main()

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -162,4 +162,4 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PIBDStallingTest().main()
+    P2PIBDStallingTest(__file__).main()

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -86,4 +86,4 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             peer_txer.send_and_ping(msg_tx(tx))
 
 if __name__ == '__main__':
-    P2PIBDTxRelayTest().main()
+    P2PIBDTxRelayTest(__file__).main()

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -101,5 +101,5 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.log.info("Success!")
 
 if __name__ == '__main__':
-    HeadersSyncTest().main()
+    HeadersSyncTest(__file__).main()
 

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -137,4 +137,4 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidBlockRequestTest().main()
+    InvalidBlockRequestTest(__file__).main()

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -39,4 +39,4 @@ class InvalidLocatorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidLocatorTest().main()
+    InvalidLocatorTest(__file__).main()

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -331,4 +331,4 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidMessagesTest().main()
+    InvalidMessagesTest(__file__).main()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -239,4 +239,4 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidTxRequestTest().main()
+    InvalidTxRequestTest(__file__).main()

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -178,4 +178,4 @@ class P2PLeakTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PLeakTest().main()
+    P2PLeakTest(__file__).main()

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -104,4 +104,4 @@ class P2PLeakTxTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PLeakTxTest().main()
+    P2PLeakTxTest(__file__).main()

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -69,4 +69,4 @@ class MessageCaptureTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MessageCaptureTest().main()
+    MessageCaptureTest(__file__).main()

--- a/test/functional/p2p_net_deadlock.py
+++ b/test/functional/p2p_net_deadlock.py
@@ -34,4 +34,4 @@ class NetDeadlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetDeadlockTest().main()
+    NetDeadlockTest(__file__).main()

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -45,4 +45,4 @@ class P2PNoBloomFilterMessages(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PNoBloomFilterMessages().main()
+    P2PNoBloomFilterMessages(__file__).main()

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -119,4 +119,4 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[1]])
 
 if __name__ == '__main__':
-    NodeNetworkLimitedTest().main()
+    NodeNetworkLimitedTest(__file__).main()

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -475,4 +475,4 @@ class OrphanHandlingTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    OrphanHandlingTest().main()
+    OrphanHandlingTest(__file__).main()

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -140,4 +140,4 @@ class P2PPermissionsTests(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    P2PPermissionsTests().main()
+    P2PPermissionsTests(__file__).main()

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -117,4 +117,4 @@ class PingPongTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    PingPongTest().main()
+    PingPongTest(__file__).main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -2019,4 +2019,4 @@ class SegWitTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SegWitTest().main()
+    SegWitTest(__file__).main()

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -589,4 +589,4 @@ class SendHeadersTest(BitcoinTestFramework):
         assert "getdata" not in inv_node.last_message
 
 if __name__ == '__main__':
-    SendHeadersTest().main()
+    SendHeadersTest(__file__).main()

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -230,4 +230,4 @@ class SendTxRcnclTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SendTxRcnclTest().main()
+    SendTxRcnclTest(__file__).main()

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -106,4 +106,4 @@ class TimeoutsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TimeoutsTest().main()
+    TimeoutsTest(__file__).main()

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -271,4 +271,4 @@ class TxDownloadTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxDownloadTest().main()
+    TxDownloadTest(__file__).main()

--- a/test/functional/p2p_tx_privacy.py
+++ b/test/functional/p2p_tx_privacy.py
@@ -74,4 +74,4 @@ class TxPrivacyTest(BitcoinTestFramework):
         spy.wait_for_inv_match(CInv(MSG_WTX, tx2.calc_sha256(True)))
 
 if __name__ == '__main__':
-    TxPrivacyTest().main()
+    TxPrivacyTest(__file__).main()

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -294,4 +294,4 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.log.info("Successfully synced nodes 1 and 0")
 
 if __name__ == '__main__':
-    AcceptBlockTest().main()
+    AcceptBlockTest(__file__).main()

--- a/test/functional/p2p_v2_transport.py
+++ b/test/functional/p2p_v2_transport.py
@@ -163,4 +163,4 @@ class V2TransportTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    V2TransportTest().main()
+    V2TransportTest(__file__).main()

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -124,4 +124,4 @@ class RPCBindTest(BitcoinTestFramework):
         assert_raises_rpc_error(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], self.non_loopback_ip, self.defaultport)
 
 if __name__ == '__main__':
-    RPCBindTest().main()
+    RPCBindTest(__file__).main()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -647,4 +647,4 @@ class BlockchainTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    BlockchainTest().main()
+    BlockchainTest(__file__).main()

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -205,4 +205,4 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RpcCreateMultiSigTest().main()
+    RpcCreateMultiSigTest(__file__).main()

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -289,4 +289,4 @@ class DecodeScriptTest(BitcoinTestFramework):
         self.decodescript_miniscript()
 
 if __name__ == '__main__':
-    DecodeScriptTest().main()
+    DecodeScriptTest(__file__).main()

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -26,4 +26,4 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         self.log.info("No tested deprecated RPC methods")
 
 if __name__ == '__main__':
-    DeprecatedRpcTest().main()
+    DeprecatedRpcTest(__file__).main()

--- a/test/functional/rpc_deriveaddresses.py
+++ b/test/functional/rpc_deriveaddresses.py
@@ -61,4 +61,4 @@ class DeriveaddressesTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, "Descriptor does not have a corresponding address", self.nodes[0].deriveaddresses, bare_multisig_descriptor)
 
 if __name__ == '__main__':
-    DeriveaddressesTest().main()
+    DeriveaddressesTest(__file__).main()

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -58,4 +58,4 @@ class DumptxoutsetTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DumptxoutsetTest().main()
+    DumptxoutsetTest(__file__).main()

--- a/test/functional/rpc_estimatefee.py
+++ b/test/functional/rpc_estimatefee.py
@@ -52,4 +52,4 @@ class EstimateFeeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    EstimateFeeTest().main()
+    EstimateFeeTest(__file__).main()

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -128,4 +128,4 @@ class RPCGenerateTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    RPCGenerateTest().main()
+    RPCGenerateTest(__file__).main()

--- a/test/functional/rpc_getblockfilter.py
+++ b/test/functional/rpc_getblockfilter.py
@@ -61,4 +61,4 @@ class GetBlockFilterTest(BitcoinTestFramework):
                                     self.nodes[0].getblockfilter, genesis_hash, filter_type)
 
 if __name__ == '__main__':
-    GetBlockFilterTest().main()
+    GetBlockFilterTest(__file__).main()

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -154,4 +154,4 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    GetBlockFromPeerTest().main()
+    GetBlockFromPeerTest(__file__).main()

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -200,4 +200,4 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(tip_stats["utxo_size_inc_actual"], 469)
 
 if __name__ == '__main__':
-    GetblockstatsTest().main()
+    GetblockstatsTest(__file__).main()

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -58,4 +58,4 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (tips[1], shortTip)
 
 if __name__ == '__main__':
-    GetChainTipsTest ().main ()
+    GetChainTipsTest(__file__).main()

--- a/test/functional/rpc_getdescriptorinfo.py
+++ b/test/functional/rpc_getdescriptorinfo.py
@@ -63,4 +63,4 @@ class DescriptorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DescriptorTest().main()
+    DescriptorTest(__file__).main()

--- a/test/functional/rpc_gettxfromoutputhash.py
+++ b/test/functional/rpc_gettxfromoutputhash.py
@@ -82,4 +82,4 @@ class GetTxFromOutputHashTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    GetTxFromOutputHashTest().main()
+    GetTxFromOutputHashTest(__file__).main()

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -138,4 +138,4 @@ class HelpRpcTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HelpRpcTest().main()
+    HelpRpcTest(__file__).main()

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -119,4 +119,4 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidAddressErrorMessageTest().main()
+    InvalidAddressErrorMessageTest(__file__).main()

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -90,4 +90,4 @@ class InvalidateTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    InvalidateTest().main()
+    InvalidateTest(__file__).main()

--- a/test/functional/rpc_mempool_info.py
+++ b/test/functional/rpc_mempool_info.py
@@ -97,4 +97,4 @@ class RPCMempoolInfoTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RPCMempoolInfoTest().main()
+    RPCMempoolInfoTest(__file__).main()

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -102,4 +102,4 @@ class RpcMiscTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RpcMiscTest().main()
+    RpcMiscTest(__file__).main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -35,4 +35,4 @@ class NamedArgumentTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Parameter arg1 specified twice both as positional and named argument", node.echo, 0, None, 2, arg1=1)
 
 if __name__ == '__main__':
-    NamedArgumentTest().main()
+    NamedArgumentTest(__file__).main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -510,4 +510,4 @@ class NetTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    NetTest().main()
+    NetTest(__file__).main()

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -359,4 +359,4 @@ class RPCPackagesTest(BitcoinTestFramework):
         peer.wait_for_broadcast([first_wtxid])
 
 if __name__ == "__main__":
-    RPCPackagesTest().main()
+    RPCPackagesTest(__file__).main()

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -109,4 +109,4 @@ class PreciousTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getbestblockhash(), hashH)
 
 if __name__ == '__main__':
-    PreciousTest().main()
+    PreciousTest(__file__).main()

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -593,4 +593,4 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    RawTransactionsTest().main()
+    RawTransactionsTest(__file__).main()

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -174,4 +174,4 @@ class ScanblocksTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ScanblocksTest().main()
+    ScanblocksTest(__file__).main()

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -131,4 +131,4 @@ class ScantxoutsetTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ScantxoutsetTest().main()
+    ScantxoutsetTest(__file__).main()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -78,4 +78,4 @@ class SetBanTests(BitcoinTestFramework):
         assert_equal(banned['ban_duration'], 1234)
 
 if __name__ == '__main__':
-    SetBanTests().main()
+    SetBanTests(__file__).main()

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -77,4 +77,4 @@ class RPCSignerTest(BitcoinTestFramework):
         assert_equal({'fingerprint': '00000001', 'name': 'trezor_t'} in self.nodes[1].enumeratesigners()['signers'], True)
 
 if __name__ == '__main__':
-    RPCSignerTest().main()
+    RPCSignerTest(__file__).main()

--- a/test/functional/rpc_signmessagewithprivkey.py
+++ b/test/functional/rpc_signmessagewithprivkey.py
@@ -60,4 +60,4 @@ class SignMessagesWithPrivTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignMessagesWithPrivTest().main()
+    SignMessagesWithPrivTest(__file__).main()

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -134,4 +134,4 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignRawTransactionWithKeyTest().main()
+    SignRawTransactionWithKeyTest(__file__).main()

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -117,4 +117,4 @@ class MerkleBlockTest(BitcoinTestFramework):
         # verify that the proofs are invalid
 
 if __name__ == '__main__':
-    MerkleBlockTest().main()
+    MerkleBlockTest(__file__).main()

--- a/test/functional/rpc_uptime.py
+++ b/test/functional/rpc_uptime.py
@@ -32,4 +32,4 @@ class UptimeTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    UptimeTest().main()
+    UptimeTest(__file__).main()

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -117,4 +117,4 @@ class HTTPBasicsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    HTTPBasicsTest().main()
+    HTTPBasicsTest(__file__).main()

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -200,4 +200,4 @@ class ValidateAddressMainTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    ValidateAddressMainTest().main()
+    ValidateAddressMainTest(__file__).main()

--- a/test/functional/rpc_whitelist.py
+++ b/test/functional/rpc_whitelist.py
@@ -93,4 +93,4 @@ class RPCWhitelistTest(BitcoinTestFramework):
         assert_equal(200, rpccall(self.nodes[0], self.strange_users[4], "getblockcount").status)
 
 if __name__ == "__main__":
-    RPCWhitelistTest().main()
+    RPCWhitelistTest(__file__).main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -92,8 +92,15 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     This class also contains various public and private helper methods."""
 
-    def __init__(self) -> None:
-        """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
+    def __init__(self, test_file) -> None:
+        """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method.
+
+        test_file is the entry script's __file__. It is used to anchor default
+        paths (config.ini, cache dir) to the build tree. Resolving paths via
+        the framework module's own __file__ does not work because CPython
+        realpath()s sys.path[0] for symlinked scripts, which would point at
+        the source tree instead of the build tree.
+        """
         self.chain: str = 'regtest'
         self.setup_clean_chain: bool = False
         self.nodes: list[TestNode] = []
@@ -102,7 +109,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
         self.supports_cli = True
         self.bind_to_localhost_only = True
-        self.parse_args()
+        self.parse_args(test_file)
         self.default_wallet_name = "default_wallet" if self.options.descriptors else ""
         self.wallet_data_filename = "wallet.dat"
         # Optional list of wallet names that can be set in set_test_params to
@@ -154,14 +161,14 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             exit_code = self.shutdown()
             sys.exit(exit_code)
 
-    def parse_args(self):
+    def parse_args(self, test_file):
         previous_releases_path = os.getenv("PREVIOUS_RELEASES_DIR") or os.getcwd() + "/releases"
         parser = argparse.ArgumentParser(usage="%(prog)s [options]")
         parser.add_argument("--nocleanup", dest="nocleanup", default=False, action="store_true",
                             help="Leave naviods and test.* datadir on exit or error")
         parser.add_argument("--noshutdown", dest="noshutdown", default=False, action="store_true",
                             help="Don't stop naviods after the test execution")
-        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../cache"),
+        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(test_file) + "/../cache"),
                             help="Directory for caching pregenerated datadirs (default: %(default)s)")
         parser.add_argument("--tmpdir", dest="tmpdir", help="Root directory for datadirs")
         parser.add_argument("-l", "--loglevel", dest="loglevel", default="INFO",
@@ -176,7 +183,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         parser.add_argument("--coveragedir", dest="coveragedir",
                             help="Write tested RPC commands into this directory")
         parser.add_argument("--configfile", dest="configfile",
-                            default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../config.ini"),
+                            default=os.path.abspath(os.path.dirname(test_file) + "/../config.ini"),
                             help="Location of the test framework config file (default: %(default)s)")
         parser.add_argument("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
                             help="Attach a python debugger if test fails")
@@ -237,7 +244,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         for binary, [attribute_name, env_variable_name] in binaries.items():
             default_filename = os.path.join(
                 self.config["environment"]["BUILDDIR"],
-                "src",
+                self.config["environment"]["EXEDIR_REL"],
                 binary + self.config["environment"]["EXEEXT"],
             )
             setattr(self.options, attribute_name, os.getenv(env_variable_name, default=default_filename))
@@ -254,8 +261,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.set_binary_paths()
 
         os.environ['PATH'] = os.pathsep.join([
-            os.path.join(config['environment']['BUILDDIR'], 'src'),
-            os.path.join(config['environment']['BUILDDIR'], 'src', 'qt'), os.environ['PATH']
+            os.path.join(config['environment']['BUILDDIR'], config['environment']['EXEDIR_REL']),
+            os.environ['PATH'],
         ])
 
         # Set up temp directory and start logging

--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import pathlib
 
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -59,7 +60,8 @@ class TestShell:
                 print("Shutdown TestShell before resetting!")
             else:
                 self.num_nodes = None
-                super().__init__()
+                dummy_testshell_file = pathlib.Path(__file__).absolute().parent.parent / "testshell_dummy.py"
+                super().__init__(dummy_testshell_file)
 
     instance = None
 
@@ -67,7 +69,13 @@ class TestShell:
         # This implementation enforces singleton pattern, and will return the
         # previously initialized instance if available
         if not TestShell.instance:
-            TestShell.instance = TestShell.__TestShell()
+            # BitcoinTestFramework instances are supposed to be constructed with the path
+            # of the calling test in order to find shared data like configuration and the
+            # cache. Since TestShell is meant for interactive use, there is no concrete
+            # test; passing a dummy name is fine though, as only the containing directory
+            # is relevant for successful initialization.
+            dummy_testshell_file = pathlib.Path(__file__).absolute().parent.parent / "testshell_dummy.py"
+            TestShell.instance = TestShell.__TestShell(dummy_testshell_file)
             TestShell.instance.running = False
         return TestShell.instance
 

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -467,4 +467,4 @@ class ToolWalletTest(BitcoinTestFramework):
         self.test_chainless_conflicts()
 
 if __name__ == '__main__':
-    ToolWalletTest().main()
+    ToolWalletTest(__file__).main()

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -241,4 +241,4 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_equal(newbalance, balance - Decimal("20"))
 
 if __name__ == '__main__':
-    AbandonConflictTest().main()
+    AbandonConflictTest(__file__).main()

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -391,4 +391,4 @@ class AddressTypeTest(BitcoinTestFramework):
             assert_raises_rpc_error(-8, "Legacy wallets cannot provide bech32m addresses", self.nodes[0].getrawchangeaddress, "bech32m")
 
 if __name__ == '__main__':
-    AddressTypeTest().main()
+    AddressTypeTest(__file__).main()

--- a/test/functional/wallet_assumeutxo.py
+++ b/test/functional/wallet_assumeutxo.py
@@ -161,4 +161,4 @@ class AssumeutxoTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AssumeutxoTest().main()
+    AssumeutxoTest(__file__).main()

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -178,4 +178,4 @@ class AddressInputTypeGrouping(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AddressInputTypeGrouping().main()
+    AddressInputTypeGrouping(__file__).main()

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -382,4 +382,4 @@ class AvoidReuseTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    AvoidReuseTest().main()
+    AvoidReuseTest(__file__).main()

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -243,4 +243,4 @@ class WalletBackupTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletBackupTest().main()
+    WalletBackupTest(__file__).main()

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -341,4 +341,4 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                 assert_equal(info, addr_info)
 
 if __name__ == '__main__':
-    BackwardsCompatibilityTest().main()
+    BackwardsCompatibilityTest(__file__).main()

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -343,4 +343,4 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(tx_info['lastprocessedblock']['hash'], prev_hash)
 
 if __name__ == '__main__':
-    WalletTest().main()
+    WalletTest(__file__).main()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -806,4 +806,4 @@ class WalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletTest().main()
+    WalletTest(__file__).main()

--- a/test/functional/wallet_blank.py
+++ b/test/functional/wallet_blank.py
@@ -161,4 +161,4 @@ class WalletBlankTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletBlankTest().main()
+    WalletBlankTest(__file__).main()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -836,4 +836,4 @@ def test_feerate_checks_replaced_outputs(self, rbf_node, peer_node):
 
 
 if __name__ == "__main__":
-    BumpFeeTest().main()
+    BumpFeeTest(__file__).main()

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -130,4 +130,4 @@ class WalletChangeAddressTest(BitcoinTestFramework):
         self.assert_change_pos(w1, tx, 0)
 
 if __name__ == '__main__':
-    WalletChangeAddressTest().main()
+    WalletChangeAddressTest(__file__).main()

--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -65,4 +65,4 @@ class CoinbaseCategoryTest(BitcoinTestFramework):
         self.assert_category("orphan", address, txid, 100, True)
 
 if __name__ == '__main__':
-    CoinbaseCategoryTest().main()
+    CoinbaseCategoryTest(__file__).main()

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -125,4 +125,4 @@ class TxConflicts(BitcoinTestFramework):
         assert_equal(former_conflicted["blockheight"], 217)
 
 if __name__ == '__main__':
-    TxConflicts().main()
+    TxConflicts(__file__).main()

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -76,4 +76,4 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CreateTxWalletTest().main()
+    CreateTxWalletTest(__file__).main()

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -178,4 +178,4 @@ class CreateWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    CreateWalletTest().main()
+    CreateWalletTest(__file__).main()

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -62,4 +62,4 @@ class WalletCrossChain(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletCrossChain().main()
+    WalletCrossChain(__file__).main()

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -233,4 +233,4 @@ class WalletDescriptorTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletDescriptorTest().main ()
+    WalletDescriptorTest(__file__).main()

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -28,4 +28,4 @@ class DisableWalletTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    DisableWalletTest().main()
+    DisableWalletTest(__file__).main()

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -102,4 +102,4 @@ class WalletEncryptionTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletEncryptionTest().main()
+    WalletEncryptionTest(__file__).main()

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -32,4 +32,4 @@ class WalletRBFTest(BitcoinTestFramework):
         assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendmany("", {self.nodes[0].getnewaddress(): 1}))
 
 if __name__ == '__main__':
-    WalletRBFTest().main()
+    WalletRBFTest(__file__).main()

--- a/test/functional/wallet_fast_rescan.py
+++ b/test/functional/wallet_fast_rescan.py
@@ -99,4 +99,4 @@ class WalletFastRescanTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletFastRescanTest().main()
+    WalletFastRescanTest(__file__).main()

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -1459,4 +1459,4 @@ class RawTransactionsTest(BitcoinTestFramework):
         wallet.unloadwallet()
 
 if __name__ == '__main__':
-    RawTransactionsTest().main()
+    RawTransactionsTest(__file__).main()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -184,4 +184,4 @@ class WalletGroupTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletGroupTest().main()
+    WalletGroupTest(__file__).main()

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -281,4 +281,4 @@ class WalletHDTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletHDTest().main()
+    WalletHDTest(__file__).main()

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -134,4 +134,4 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ImportPrunedFundsTest().main()
+    ImportPrunedFundsTest(__file__).main()

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -213,4 +213,4 @@ class KeyPoolTest(BitcoinTestFramework):
             assert_raises_rpc_error(-4, msg, w2.keypoolrefill, 100)
 
 if __name__ == '__main__':
-    KeyPoolTest().main()
+    KeyPoolTest(__file__).main()

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -92,4 +92,4 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    KeypoolRestoreTest().main()
+    KeypoolRestoreTest(__file__).main()

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -256,4 +256,4 @@ def change_label(node, address, old_label, new_label):
     new_label.verify(node)
 
 if __name__ == '__main__':
-    WalletLabelsTest().main()
+    WalletLabelsTest(__file__).main()

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -131,4 +131,4 @@ class ListDescriptorsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListDescriptorsTest().main()
+    ListDescriptorsTest(__file__).main()

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -263,4 +263,4 @@ class ReceivedByTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ReceivedByTest().main()
+    ReceivedByTest(__file__).main()

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -477,4 +477,4 @@ class ListSinceBlockTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListSinceBlockTest().main()
+    ListSinceBlockTest(__file__).main()

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -344,4 +344,4 @@ class ListTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListTransactionsTest().main()
+    ListTransactionsTest(__file__).main()

--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -408,4 +408,4 @@ class WalletMiniscriptTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletMiniscriptTest().main()
+    WalletMiniscriptTest(__file__).main()

--- a/test/functional/wallet_mnemonic.py
+++ b/test/functional/wallet_mnemonic.py
@@ -313,4 +313,4 @@ class WalletMnemonicTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletMnemonicTest().main()
+    WalletMnemonicTest(__file__).main()

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -162,4 +162,4 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletMultisigDescriptorPSBTTest().main()
+    WalletMultisigDescriptorPSBTTest(__file__).main()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -423,4 +423,4 @@ class MultiWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MultiWalletTest().main()
+    MultiWalletTest(__file__).main()

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -88,4 +88,4 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    OrphanedBlockRewardTest().main()
+    OrphanedBlockRewardTest(__file__).main()

--- a/test/functional/wallet_reindex.py
+++ b/test/functional/wallet_reindex.py
@@ -92,4 +92,4 @@ class WalletReindexTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    WalletReindexTest().main()
+    WalletReindexTest(__file__).main()

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -101,4 +101,4 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         assert conflicting["blockhash"] != conflicted_after_reorg["blockhash"]
 
 if __name__ == '__main__':
-    ReorgsRestoreTest().main()
+    ReorgsRestoreTest(__file__).main()

--- a/test/functional/wallet_rescan_unconfirmed.py
+++ b/test/functional/wallet_rescan_unconfirmed.py
@@ -93,4 +93,4 @@ class WalletRescanUnconfirmed(BitcoinTestFramework):
         assert_equal(w1.gettransaction(tx_child_unconfirmed_sweep["txid"])["confirmations"], 0)
 
 if __name__ == '__main__':
-    WalletRescanUnconfirmed().main()
+    WalletRescanUnconfirmed(__file__).main()

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -150,4 +150,4 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ResendWalletTransactionsTest().main()
+    ResendWalletTransactionsTest(__file__).main()

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -580,4 +580,4 @@ class WalletSendTest(BitcoinTestFramework):
         assert_fee_amount(testres["fees"]["base"], testres["vsize"], Decimal(0.0001))
 
 if __name__ == '__main__':
-    WalletSendTest().main()
+    WalletSendTest(__file__).main()

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -466,4 +466,4 @@ class SendallTest(BitcoinTestFramework):
         self.sendall_fails_with_transaction_too_large()
 
 if __name__ == '__main__':
-    SendallTest().main()
+    SendallTest(__file__).main()

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -255,4 +255,4 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "GetExternalSigner: More than one external signer found", self.nodes[1].createwallet, wallet_name='multi_hww', disable_private_keys=True, descriptors=True, external_signer=True)
 
 if __name__ == '__main__':
-    WalletSignerTest().main()
+    WalletSignerTest(__file__).main()

--- a/test/functional/wallet_signmessagewithaddress.py
+++ b/test/functional/wallet_signmessagewithaddress.py
@@ -45,4 +45,4 @@ class SignMessagesWithAddressTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignMessagesWithAddressTest().main()
+    SignMessagesWithAddressTest(__file__).main()

--- a/test/functional/wallet_signrawtransactionwithwallet.py
+++ b/test/functional/wallet_signrawtransactionwithwallet.py
@@ -294,4 +294,4 @@ class SignRawTransactionWithWalletTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    SignRawTransactionWithWalletTest().main()
+    SignRawTransactionWithWalletTest(__file__).main()

--- a/test/functional/wallet_simulaterawtx.py
+++ b/test/functional/wallet_simulaterawtx.py
@@ -129,4 +129,4 @@ class SimulateTxTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "One or more transaction inputs are missing or have been spent already", w2.simulaterawtransaction, [tx1, tx2])
 
 if __name__ == '__main__':
-    SimulateTxTest().main()
+    SimulateTxTest(__file__).main()

--- a/test/functional/wallet_spend_unconfirmed.py
+++ b/test/functional/wallet_spend_unconfirmed.py
@@ -514,4 +514,4 @@ class UnconfirmedInputTest(BitcoinTestFramework):
             self.test_external_input_unconfirmed_low()
 
 if __name__ == '__main__':
-    UnconfirmedInputTest().main()
+    UnconfirmedInputTest(__file__).main()

--- a/test/functional/wallet_startup.py
+++ b/test/functional/wallet_startup.py
@@ -58,4 +58,4 @@ class WalletStartupTest(BitcoinTestFramework):
         assert_equal(set(self.nodes[0].listwallets()), set(('w2', 'w3')))
 
 if __name__ == '__main__':
-    WalletStartupTest().main()
+    WalletStartupTest(__file__).main()

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -510,4 +510,4 @@ class WalletTaprootTest(BitcoinTestFramework):
         )
 
 if __name__ == '__main__':
-    WalletTaprootTest().main()
+    WalletTaprootTest(__file__).main()

--- a/test/functional/wallet_timelock.py
+++ b/test/functional/wallet_timelock.py
@@ -50,4 +50,4 @@ class WalletLocktimeTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    WalletLocktimeTest().main()
+    WalletLocktimeTest(__file__).main()

--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -180,4 +180,4 @@ class TransactionTimeRescanTest(BitcoinTestFramework):
             return
 
 if __name__ == '__main__':
-    TransactionTimeRescanTest().main()
+    TransactionTimeRescanTest(__file__).main()

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -149,4 +149,4 @@ class TxnMallTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnMallTest(__file__).main()

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -138,4 +138,4 @@ class TxnMallTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnMallTest(__file__).main()

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -103,7 +103,8 @@ def main():
         sys.exit(1)
 
     # Build list of tests
-    test_list_all = parse_test_list(fuzz_bin=os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'))
+    fuzz_bin = os.path.join(config["environment"]["BUILDDIR"], config["environment"]["FUZZ_BIN_REL"])
+    test_list_all = parse_test_list(fuzz_bin=fuzz_bin)
 
     if not test_list_all:
         logging.error("No fuzz targets found")
@@ -146,7 +147,7 @@ def main():
     try:
         help_output = subprocess.run(
             args=[
-                os.path.join(config["environment"]["BUILDDIR"], 'src', 'test', 'fuzz', 'fuzz'),
+                fuzz_bin,
                 '-help=1',
             ],
             env=get_fuzz_env(target=test_list_selection[0], source_dir=config['environment']['SRCDIR']),
@@ -168,7 +169,7 @@ def main():
             return generate_corpus(
                 fuzz_pool=fuzz_pool,
                 src_dir=config['environment']['SRCDIR'],
-                build_dir=config["environment"]["BUILDDIR"],
+                fuzz_bin=fuzz_bin,
                 corpus_dir=args.corpus_dir,
                 targets=test_list_selection,
             )
@@ -179,7 +180,7 @@ def main():
                 corpus=args.corpus_dir,
                 test_list=test_list_selection,
                 src_dir=config['environment']['SRCDIR'],
-                build_dir=config["environment"]["BUILDDIR"],
+                fuzz_bin=fuzz_bin,
                 merge_dirs=[Path(m_dir) for m_dir in args.m_dir],
             )
             return
@@ -189,7 +190,7 @@ def main():
             corpus=args.corpus_dir,
             test_list=test_list_selection,
             src_dir=config['environment']['SRCDIR'],
-            build_dir=config["environment"]["BUILDDIR"],
+            fuzz_bin=fuzz_bin,
             using_libfuzzer=using_libfuzzer,
             use_valgrind=args.valgrind,
             empty_min_time=args.empty_min_time,
@@ -232,7 +233,7 @@ def transform_rpc_target(targets, src_dir):
     return targets
 
 
-def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
+def generate_corpus(*, fuzz_pool, src_dir, fuzz_bin, corpus_dir, targets):
     """Generates new corpus.
 
     Run {targets} without input, and outputs the generated corpus to
@@ -264,7 +265,7 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
         target_corpus_dir = corpus_dir / target
         os.makedirs(target_corpus_dir, exist_ok=True)
         command = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
             "-runs=100000",
             target_corpus_dir,
         ]
@@ -274,12 +275,12 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
         future.result()
 
 
-def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dirs):
+def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, merge_dirs):
     logging.info(f"Merge the inputs from the passed dir into the corpus_dir. Passed dirs {merge_dirs}")
     jobs = []
     for t in test_list:
         args = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
             '-rss_limit_mb=8000',
             '-set_cover_merge=1',
             # set_cover_merge is used instead of -merge=1 to reduce the overall
@@ -316,13 +317,13 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dirs
         future.result()
 
 
-def run_once(*, fuzz_pool, corpus, test_list, src_dir, build_dir, using_libfuzzer, use_valgrind, empty_min_time):
+def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, using_libfuzzer, use_valgrind, empty_min_time):
     jobs = []
     for t in test_list:
         corpus_path = corpus / t
         os.makedirs(corpus_path, exist_ok=True)
         args = [
-            os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            fuzz_bin,
         ]
         empty_dir = not any(corpus_path.iterdir())
         if using_libfuzzer:

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -73,7 +73,7 @@ def bctest(testDir, testObj, buildenv):
     are not as expected. Error is caught by bctester() and reported.
     """
     # Get the exec names and arguments
-    execprog = os.path.join(buildenv["BUILDDIR"], "src", testObj["exec"] + buildenv["EXEEXT"])
+    execprog = os.path.join(buildenv["BUILDDIR"], buildenv["EXEDIR_REL"], testObj["exec"] + buildenv["EXEEXT"])
     if testObj["exec"] == "./navio-util":
         execprog = os.getenv("BITCOINUTIL", default=execprog)
     elif testObj["exec"] == "./navio-tx":


### PR DESCRIPTION
## Summary

Follow-up to #210. Migrates CI pipelines off the autotools/docker matrix onto the native CMake matrix introduced in #210.

Pipelines migrated in this PR:
- [x] linux/tidy → `[tidy] Ubuntu 24.04, clang-17 (CMake)`
- [x] linux/no-wallet-libblsct → `Ubuntu 24.04, no wallet, libblsct only (CMake)`

The remaining pipelines (test-each-commit, macos-native-arm64, linux/arm, linux/mac-cross, linux/win64-cross, linux/fuzz, linux/tsan, linux/msan, linux/i686-centos, linux/i686-multiprocess, win64-native) are **deferred to follow-up PRs**. Most need depends-based or cross-compile infrastructure on the CMake side, which is a larger pivot than the native-build matrix this PR extends.

`macos-native-arm64` was attempted as a CMake migration in this PR but reverted — see the comment thread below for the libevent SIGSEGV that surfaces on arm64-native builds (the old autotools job forces x86_64 under Rosetta and dodges it). The autotools job remains until that crash is fixed separately.

## Collateral fixes to the CMake port (#210)

Bringing up `BUILD_LIBBLSCT_ONLY=ON` and the rest of the matrix for the first time in CMake CI surfaced several gaps in the upstream cmake-port that this PR also addresses:

- **USE_ASM ported.** `AC_DEFINE([USE_ASM], [1], ...)` from `configure.ac` was missing from the cmake port. Without it, `crypto/sha256.cpp` never assigned `Transform = sha256_sse4::Transform` and the SIMD object files were unreachable in `libblsct.a` (the symbol check fails). Added `USE_ASM` option (default `ON`) wired through `cmake/navio-build-config.h.in`. Restores SIMD SHA-256 acceleration for every consumer, not just libblsct.
- **SIMD intrinsic detection gated on `USE_ASM`** in `cmake/introspection.cmake`. Previously `HAVE_SSE41/AVX2/X86_SHANI/ARM_SHANI` were probed unconditionally, so `-DUSE_ASM=OFF` configures still enabled SIMD code paths. Wrapped the detection block in `if(NOT MSVC AND USE_ASM)` to match autotools' `--disable-asm`.
- **libblsct `blsct` target source list rewritten** to mirror autotools `libblsct_a_SOURCES + BLSCT_EXTERNAL_CPP` (`src/Makefile.am` ~L251, ~L1524). Previous list pulled in `wallet/rpc.cpp`, `wallet/wallet.cpp`, full BLSCT_SOURCES/BLSCT_WALLET_SOURCES variables, and other sources that reference declarations not satisfied in the libblsct build. Also removed `dummy_impl.cpp` (untracked file, never existed in this fork).
- **SIMD SHA-256 variants gated** on existing `HAVE_*` introspection with matching `-m` compile flags and `ENABLE_*` compile definitions — mirrors `src/crypto/CMakeLists.txt` and autotools `libblsct_a_CXXFLAGS`/`CPPFLAGS` gating.
- **Boost gating ported.** `add_boost_if_needed()` ran unconditionally even with `BUILD_LIBBLSCT_ONLY=ON`; autotools' `configure.ac` skips Boost detection when no boost consumer is being built. Gated `add_boost_if_needed()` and the Boost.Process v1 feature test on `if(NOT BUILD_LIBBLSCT_ONLY)`. Wrapped the navio_blsct_core / navio_blsct_wallet / navio_consensus / navio_common / navio_node / executables / wallet / `test/util` targets in the same condition so they're not defined under libblsct-only (CMake validates `target_link_libraries` references at generate time even for EXCLUDE_FROM_ALL targets).
- **`bls12_381_keygen.cpp`**: replaced `std::ceil(static_cast<float>(L) / DigestSize)` with integer ceil-division `(L + DigestSize - 1) / DigestSize`. The float version emits a `ceilf` libm dependency under clang-14+libc++-14 (clang-13+libc++-13 happened to fold the call away), which the libblsct symbol check treats as an unsatisfied external dep. Integer ceil-division avoids the libm dep on every toolchain.
- **`libblsct-symbol-check.py`** updated to accept both naming conventions for the API entry-point object (autotools `libblsct_a-blsct.o` vs CMake `blsct.cpp.o`), broaden the libm allow-list (`ceil/ceilf/floor/floorf/fmod/fmodf/pow/powf`) for compiler-emitted libcalls in `lockedpool.cpp.o`, and print the referencing member object when reporting unsatisfied symbols.
- **`test_navio` link** fixed by moving `blsct/external_api/blsct.cpp` from `BLSCT_SOURCES` into `BLSCT_WALLET_SOURCES`. `blsct_clientversion.cpp` stays libblsct-only (collides with `FormatFullVersion` in clientversion.cpp).
- **`MAC_OSX` → `__APPLE__`**: navio's autotools defined `MAC_OSX` for Darwin builds; upstream Bitcoin Core's cmake port uses the compiler-builtin `__APPLE__`. Migrated 7 sources (`compat/byteswap.h`, `util/threadnames.cpp`, `util/fs_helpers.cpp`, `crypto/sha256.cpp`, `random.cpp`, `common/args.cpp`, `common/system.cpp`) and removed `-DMAC_OSX` from `configure.ac` to align both build systems on `__APPLE__`.

## Functional test framework: build-tree-agnostic binary paths

CMake's bin layout (`build/bin/`) differs from autotools (`build/src/`). The functional test framework hardcoded `src/` in two places. Replaced with build-system-driven substitutions:

- **`@EXEDIR_REL@` / `@FUZZ_BIN_REL@`** placeholders added to `test/config.ini.in`. Substituted by autotools (`AC_SUBST` → `src` / `src/test/fuzz/fuzz`), CMake (`configure_file` → `bin` / `bin/fuzz${CMAKE_EXECUTABLE_SUFFIX}`), and MSVC vcxproj (`ReplaceInFile` → `src` / `src\test\fuzz\fuzz.exe`).
- **`test_framework.test_framework.BitcoinTestFramework`** now reads `EXEDIR_REL` from the resolved config.ini instead of literal `"src"`. `test/util/test_runner.py` and `test/fuzz/test_runner.py` updated similarly.
- **`__file__` → `test_file` parameter**: ported upstream Bitcoin Core's pattern where each test passes `__file__` into `BitcoinTestFramework(test_file)` for symlink-resilient config.ini path resolution. Mechanical rename across 238 functional test scripts (`XxxTest().main()` → `XxxTest(__file__).main()`), plus the `test_shell.py` dummy-file pattern. `test_runner.py` keeps `__file__` since it's the entry script.

## Notes

- Based on top of `build/cmake-port` (#210). Will rebase onto `master` once #210 lands.
- Shared `linux-cmake` steps gated on optional matrix fields (`smoke_test`, `tidy`, `check_libblsct_symbols`) so other entries skip them cleanly.

## Test plan

- [x] `[tidy]` and `Ubuntu 24.04, no wallet, libblsct only (CMake)` jobs pass green on this PR
- [x] Each removed autotools entry has an equivalent CMake entry covering the same scenario
- [x] `libblsct-symbol-check.py` passes against the CMake-built `libblsct.a` (reachability + undefined-symbols)
- [x] Other existing CI jobs (still autotools) unaffected
- [ ] macos-native-arm64 stays on autotools (Rosetta x86_64) until the libevent arm64-native crash is fixed in a follow-up
