### PR TITLE
style: fix clang-tidy warnings-as-errors

### DIFF
--- a/src/blsct/set_mem_proof/set_mem_proof_prover.cpp
+++ b/src/blsct/set_mem_proof/set_mem_proof_prover.cpp
@@ -225,7 +225,7 @@ retry: // retrying without generating fiat_shamir again to get different hashes
 
     // Commit 2
     Scalars l0 = bL - (ones * z);
-    Scalars l1 = sL;
+    const Scalars& l1 = sL;
     Scalars r0 = y_to_n * (bR * omega + ones * (omega * z)) + (ones * z_sq);
     Scalars r1 = y_to_n * sR;
     Scalar t1 = (l0 * r1).Sum() + (l1 * r0).Sum();

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -109,7 +109,7 @@ UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransaction
 
     wallet::mapValue_t map_value;
     wallet.CommitTransaction(tx, std::move(map_value), /*orderForm=*/{});
-    const std::string outputHash = tx->vout[0].GetHash().GetHex();
+    std::string outputHash = tx->vout[0].GetHash().GetHex();
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("outputHash", outputHash);
@@ -1943,7 +1943,7 @@ RPCHelpMan fundblsctrawtransaction()
 
                     for (const auto& [type, outputs] : available_outputs.coins) {
                         for (const auto& output : outputs) {
-                            if (existing_inputs.count(output.outpoint) > 0) {
+                            if (existing_inputs.contains(output.outpoint)) {
                                 continue;
                             }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -48,7 +48,6 @@
 #include <univalue.h>
 
 using node::AnalyzePSBT;
-using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
 using node::FindCoins;
 using node::GetTransaction;
 using node::NodeContext;

--- a/src/test/blsct/wallet/output_storage_tests.cpp
+++ b/src/test/blsct/wallet/output_storage_tests.cpp
@@ -51,7 +51,7 @@ BOOST_FIXTURE_TEST_CASE(output_storage_basic, TestingSetup)
     BOOST_CHECK(result != nullptr);
 
     // Find the output in mapOutputs
-    BOOST_CHECK(wallet->mapOutputs.count(outpoint) > 0);
+    BOOST_CHECK(wallet->mapOutputs.contains(outpoint));
 
     const CWalletOutput& wout = wallet->mapOutputs.at(outpoint);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2546,7 +2546,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         pos_kernel_range_proof.emplace(block.posProof.GetKernelRangeProof(min_value_u64, eta_phi));
         pos_verify_future = blsct::GetPosAsyncVerifier().Submit(
-            [staked_commitments = std::move(staked_commitments_snapshot),
+            [staked_commitments = staked_commitments_snapshot,
              eta_fiat_shamir = std::move(eta_fiat_shamir),
              eta_phi = std::move(eta_phi),
              &pos_proof = block.posProof]() -> std::pair<bool, std::string> {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1340,7 +1340,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             }
 
             for (size_t i = 0; i < wtx.tx->vout.size(); ++i) {
-                if (wtx.blsctRecoveryData.count(i) != 0) {
+                if (wtx.blsctRecoveryData.contains(i)) {
                     continue;
                 }
 
@@ -1471,7 +1471,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             if (auto it = mapWallet.find(tx.GetHash()); it != mapWallet.end()) {
                 it->second.m_state = tx_state;
                 it->second.MarkDirty();
-                WalletBatch batch(GetDatabase(), /*flush_on_close=*/false);
+                WalletBatch batch(GetDatabase(), /*_fFlushOnClose=*/false);
                 batch.WriteTx(it->second);
             }
 
@@ -2669,7 +2669,7 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
     }
 
     if (tx->IsBLSCT() && IsWalletFlagSet(WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
-        WalletBatch batch(GetDatabase(), /*flush_on_close=*/false);
+        WalletBatch batch(GetDatabase(), /*_fFlushOnClose=*/false);
         for (const CTxIn& txin : tx->vin) {
             auto it = mapOutputs.find(txin.prevout);
             if (it == mapOutputs.end()) continue;


### PR DESCRIPTION
## Summary

The CI `[tidy]` job is currently red on `master` (run 25625502401) due to clang-tidy diagnostics elevated to `-Werror`. This PR fixes the 9 reported errors with minimal, surgical changes.

- `rpc/rawtransaction.cpp` — drop unused `using node::DEFAULT_MAX_RAW_TX_FEE_RATE` (`misc-unused-using-decls`)
- `blsct/set_mem_proof/set_mem_proof_prover.cpp` — `l1` by const reference instead of copying `sL` (`performance-unnecessary-copy-initialization`)
- `validation.cpp` — drop `std::move()` on `staked_commitments_snapshot` in the lambda capture; `Elements<MclG1Point>` is not move-constructible so the move silently degraded to a copy (`performance-move-const-arg`)
- `blsct/wallet/rpc.cpp`, `wallet/wallet.cpp`, `test/blsct/wallet/output_storage_tests.cpp` — `.count(...) > 0` / `!= 0` → `.contains(...)` (`readability-container-contains`)
- `blsct/wallet/rpc.cpp` — drop `const` on local `outputHash` so NRVO / automatic-move applies on the return (`performance-no-automatic-move`)
- `wallet/wallet.cpp` — update `/*flush_on_close=*/` argument comments to `/*_fFlushOnClose=*/` to match `WalletBatch` parameter name (`bugprone-argument-comment`)

## Test plan

- [x] CI `[tidy]` job passes
- [x] No new lint / build / test regressions across the rest of the matrix