### PR TITLE
build(depends): set PKG_CONFIG_PATH on all targets in toolchain.cmake.in

### DIFF
--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -104,13 +104,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_APPLE)
   set(CMAKE_FRAMEWORK_PATH "@OSX_SDK@/System/Library/Frameworks")
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
-  cmake_path(APPEND CMAKE_CURRENT_LIST_DIR "lib" "pkgconfig" OUTPUT_VARIABLE pkg_config_path)
-  set(ENV{PKG_CONFIG_PATH} ${pkg_config_path})
-  set(ENV{PKG_CONFIG_LIBDIR} ${pkg_config_path})
-  unset(pkg_config_path)
-  set(PKG_CONFIG_ARGN --static)
-endif()
+cmake_path(APPEND CMAKE_CURRENT_LIST_DIR "lib" "pkgconfig" OUTPUT_VARIABLE pkg_config_path)
+set(ENV{PKG_CONFIG_PATH} ${pkg_config_path})
+set(ENV{PKG_CONFIG_LIBDIR} ${pkg_config_path})
+unset(pkg_config_path)
+set(PKG_CONFIG_ARGN --static)
 
 # Set configuration options based on what depends built.
 if("@zmq_packages@" MATCHES "^[ ]*$")


### PR DESCRIPTION
## Summary

`depends/toolchain.cmake.in` only configured `PKG_CONFIG_PATH` /
`PKG_CONFIG_LIBDIR` / `PKG_CONFIG_ARGN` inside

```cmake
if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
  ...
endif()
```

This is inherited from upstream Bitcoin Core, where it works because
upstream builds ZeroMQ with CMake and ships a `ZeroMQConfig.cmake` —
so cross-compile targets satisfy `find_package(ZeroMQ NO_MODULE)`
without ever going through pkg-config.

navio still builds ZeroMQ via autotools in `depends/packages/zeromq.mk`,
so `cmake/module/FindZeroMQ.cmake`'s `pkg_check_modules(libzmq>=4.0.0)`
is the **only** discovery path on every host, not just Linux/FreeBSD.
With the guard in place, win64-cross and mac-cross configures fail with:

```
Could NOT find ZeroMQ: Found unsuitable version "",
but required is at least '4.0.0'
```

because the depends `pkgconfig` directory is never on the search path.

This PR drops the guard so `PKG_CONFIG_PATH` is set for every target
that consumes `toolchain.cmake.in`.

## Impact

- No-op for currently running CMake CI jobs (tidy, no-wallet-libblsct,
  no-wallet-libnaviokernel — none of them use depends).
- Unblocks gap # 1 in tracking issue #223, clearing the path to migrate
  the win64-cross and mac-cross CI jobs to CMake.

Refs #223. Follow-up to #210 (CMake build system port).

## Test plan

- [ ] Existing CMake CI matrix stays green (no depends consumers today).
- [ ] Local verification: `cmake -S . -DCMAKE_TOOLCHAIN_FILE=depends/x86_64-w64-mingw32/toolchain.cmake -DWITH_ZMQ=ON` now reports `Found ZeroMQ: .../depends/x86_64-w64-mingw32/lib (found suitable version "4.3.5", minimum required is "4.0.0")`.
- [ ] Follow-up PR that migrates win64-cross to CMake exercises this end-to-end.