### PR TITLE
build: clear -Wundef warnings in cmake-generated build config

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -9,6 +9,10 @@ include(CheckIncludeFileCXX)
 check_include_file_cxx(endian.h HAVE_ENDIAN_H)
 check_include_file_cxx(sys/endian.h HAVE_SYS_ENDIAN_H)
 check_include_file_cxx(ifaddrs.h HAVE_IFADDRS)
+if(HAVE_IFADDRS)
+  check_cxx_symbol_exists(getifaddrs "ifaddrs.h" HAVE_DECL_GETIFADDRS)
+  check_cxx_symbol_exists(freeifaddrs "ifaddrs.h" HAVE_DECL_FREEIFADDRS)
+endif()
 
 check_cxx_symbol_exists(htobe16 "endian.h" HAVE_DECL_HTOBE16)
 check_cxx_symbol_exists(htole16 "endian.h" HAVE_DECL_HTOLE16)
@@ -24,6 +28,32 @@ check_cxx_symbol_exists(be64toh "endian.h" HAVE_DECL_BE64TOH)
 check_cxx_symbol_exists(le64toh "endian.h" HAVE_DECL_LE64TOH)
 
 check_cxx_symbol_exists(gmtime_r "time.h" HAVE_GMTIME_R)
+
+# Check for byteswap declarations (Linux byteswap.h).
+check_include_file_cxx(byteswap.h HAVE_BYTESWAP_H)
+if(HAVE_BYTESWAP_H)
+  check_cxx_symbol_exists(bswap_16 "byteswap.h" HAVE_DECL_BSWAP_16)
+  check_cxx_symbol_exists(bswap_32 "byteswap.h" HAVE_DECL_BSWAP_32)
+  check_cxx_symbol_exists(bswap_64 "byteswap.h" HAVE_DECL_BSWAP_64)
+endif()
+
+# Check for __builtin_clzl and __builtin_clzll.
+check_cxx_source_compiles("
+  int main()
+  {
+    unsigned long x = 1;
+    return __builtin_clzl(x);
+  }
+  " HAVE_BUILTIN_CLZL
+)
+check_cxx_source_compiles("
+  int main()
+  {
+    unsigned long long x = 1;
+    return __builtin_clzll(x);
+  }
+  " HAVE_BUILTIN_CLZLL
+)
 
 check_cxx_symbol_exists(O_CLOEXEC "fcntl.h" HAVE_O_CLOEXEC)
 check_cxx_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
@@ -45,6 +75,8 @@ check_cxx_symbol_exists(std::system "cstdlib" HAVE_STD_SYSTEM)
 check_cxx_symbol_exists(::_wsystem "stdlib.h" HAVE__WSYSTEM)
 if(HAVE_STD_SYSTEM OR HAVE__WSYSTEM)
   set(HAVE_SYSTEM 1)
+else()
+  set(HAVE_SYSTEM 0)
 endif()
 
 check_cxx_source_compiles("

--- a/cmake/navio-build-config.h.in
+++ b/cmake/navio-build-config.h.in
@@ -42,10 +42,24 @@
 #cmakedefine USE_SQLITE 1
 
 /* Define to 1 to enable ZMQ notifications. */
-#cmakedefine ENABLE_ZMQ 1
+#cmakedefine01 ENABLE_ZMQ
 
 /* Define to 1 if you have the declaration of `fork', and to 0 if you don't. */
 #cmakedefine01 HAVE_DECL_FORK
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#cmakedefine HAVE_BYTESWAP_H 1
+
+/* Byteswap function declarations */
+#cmakedefine01 HAVE_DECL_BSWAP_16
+#cmakedefine01 HAVE_DECL_BSWAP_32
+#cmakedefine01 HAVE_DECL_BSWAP_64
+
+/* Define to 1 if you have __builtin_clzl */
+#cmakedefine01 HAVE_BUILTIN_CLZL
+
+/* Define to 1 if you have __builtin_clzll */
+#cmakedefine01 HAVE_BUILTIN_CLZLL
 
 /* Endian conversion function declarations */
 #cmakedefine01 HAVE_DECL_HTOBE16
@@ -69,6 +83,12 @@
 
 /* Define to 1 if '*ifaddrs' are available. */
 #cmakedefine HAVE_IFADDRS 1
+
+/* Define to 1 if you have the declaration of 'getifaddrs', and to 0 if you don't. */
+#cmakedefine01 HAVE_DECL_GETIFADDRS
+
+/* Define to 1 if you have the declaration of 'freeifaddrs', and to 0 if you don't. */
+#cmakedefine01 HAVE_DECL_FREEIFADDRS
 
 /* Define to 1 if you have the declaration of `pipe2', and to 0 if you don't. */
 #cmakedefine01 HAVE_DECL_PIPE2
@@ -106,14 +126,14 @@
 /* Define this symbol to build code that uses getauxval */
 #cmakedefine HAVE_STRONG_GETAUXVAL 1
 
-/* Define this symbol if the BSD sysctl() is available */
-#cmakedefine HAVE_SYSCTL 1
+/* Define to 1 if the BSD sysctl() is available */
+#cmakedefine01 HAVE_SYSCTL
 
 /* Define this symbol if the BSD sysctl(KERN_ARND) is available */
 #cmakedefine HAVE_SYSCTL_ARND 1
 
 /* Define to 1 if std::system or ::wsystem is available. */
-#cmakedefine HAVE_SYSTEM 1
+#cmakedefine01 HAVE_SYSTEM
 
 /* Define to the version of this package. */
 #define CLIENT_VERSION_STRING "@CLIENT_VERSION_STRING@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 # Wire ENABLE_ZMQ from the WITH_ZMQ option.
 if(WITH_ZMQ)
   set(ENABLE_ZMQ 1)
+else()
+  set(ENABLE_ZMQ 0)
 endif()
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/navio-build-config.h.in config/bitcoin-config.h USE_SOURCE_PERMISSIONS @ONLY)


### PR DESCRIPTION
## Summary

Configuring the CMake build with `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON`
surfaced **311 `-Wundef` errors** in non-vendored navio sources. None
were code bugs; the landmines all came from
`cmake/navio-build-config.h.in` defining capability-test macros with

```c
#cmakedefine FOO 1
```

which leaves `FOO` undefined when the feature is absent, while the
consuming source treats it with

```c
#if FOO
```

which then trips `-Wundef`.

## Change

Convert the affected macros to `#cmakedefine01` so they expand to either
`0` or `1`, matching the autotools `AC_DEFINE` / `HAVE_DECL_` contract
the consumer code was written against. Wire up the missing
capability-detection probes in `cmake/introspection.cmake`:

| Macro | Used in | Probe |
|---|---|---|
| `HAVE_BUILTIN_CLZL`, `HAVE_BUILTIN_CLZLL` | `crypto/common.h` | `check_cxx_source_compiles` |
| `HAVE_DECL_BSWAP_16/32/64` | `compat/byteswap.h` | `check_cxx_symbol_exists`, gated on `HAVE_BYTESWAP_H` |
| `HAVE_DECL_GETIFADDRS`, `HAVE_DECL_FREEIFADDRS` | `net.cpp` | `check_cxx_symbol_exists`, gated on `HAVE_IFADDRS` |
| `HAVE_SYSCTL` | `randomenv.cpp` | already probed; flipped to `#cmakedefine01` |
| `HAVE_SYSTEM` | `init.cpp`, `common/system.cpp` | already probed; flipped to `#cmakedefine01` with explicit `else()` |
| `ENABLE_ZMQ` | `init.cpp` | already opt-controlled in `src/CMakeLists.txt`; flipped to `#cmakedefine01` with explicit `else()` |

`HAVE_SYSCTL_ARND` keeps its `#cmakedefine` / `#ifdef` shape because
`random.cpp` guards `<sys/sysctl.h>` with `#ifdef`, not `#if`. Converting
it would force the include on Linux where the header does not exist.

## Verification

After this change, a `Release` build with `WaaE` on produces **zero
`-W` errors in non-vendored navio code**. Remaining errors are confined
to:

- Vendored subtrees (`src/secp256k1`, `src/minisketch`, `src/leveldb`) —
  forbidden to edit by lint-subtree.
- One GCC 16 false positive in `<bits/stl_construct.h>` that does not
  appear on CI's GCC versions.

## Impact

No-op for source code (only the build template + introspection probes
change). Unblocks gap #5 in tracking issue #223 and clears the path to
flip on WaaE for the `linux/fuzz` and `macos-native-arm64` CMake jobs.

Refs #223. Follow-up to #210 (CMake build system port). Independent of #222, #227, #228.

## Test plan

- [ ] Existing CMake CI matrix stays green.
- [ ] Local: `cmake -B build -S . -DCMAKE_COMPILE_WARNING_AS_ERROR=ON && cmake --build build` succeeds with the only remaining errors in vendored subtrees.
- [ ] Follow-up PR that flips `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON` on for fuzz/macos jobs exercises this end-to-end.