### PR TITLE
build(depends): emit minimal BoostConfig.cmake for header-only install

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -12,5 +12,27 @@ endef
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \
-  cp -r boost $($(package)_staging_prefix_dir)/include
+  cp -r boost $($(package)_staging_prefix_dir)/include && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/cmake/Boost-$($(package)_version) && \
+  printf '%s\n' \
+    'set(Boost_FOUND TRUE)' \
+    'set(Boost_VERSION $($(package)_version))' \
+    'set(Boost_VERSION_STRING $($(package)_version))' \
+    'get_filename_component(_boost_prefix "$$$${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)' \
+    'if(NOT TARGET Boost::headers)' \
+    '  add_library(Boost::headers INTERFACE IMPORTED)' \
+    '  set_target_properties(Boost::headers PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "$$$${_boost_prefix}/include")' \
+    'endif()' \
+    'unset(_boost_prefix)' \
+    'set(boost_headers_DIR "$$$${CMAKE_CURRENT_LIST_DIR}")' \
+    > $($(package)_staging_prefix_dir)/lib/cmake/Boost-$($(package)_version)/BoostConfig.cmake && \
+  printf '%s\n' \
+    'set(PACKAGE_VERSION $($(package)_version))' \
+    'if(PACKAGE_FIND_VERSION VERSION_LESS_EQUAL PACKAGE_VERSION)' \
+    '  set(PACKAGE_VERSION_COMPATIBLE TRUE)' \
+    '  if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)' \
+    '    set(PACKAGE_VERSION_EXACT TRUE)' \
+    '  endif()' \
+    'endif()' \
+    > $($(package)_staging_prefix_dir)/lib/cmake/Boost-$($(package)_version)/BoostConfigVersion.cmake
 endef


### PR DESCRIPTION
## Summary

`cmake/module/AddBoostIfNeeded.cmake` calls
`find_package(Boost 1.74.0 REQUIRED CONFIG)`. The `CONFIG` mode forces
CMake to look for a `BoostConfig.cmake` / `BoostConfigVersion.cmake`
pair. Our depends installs Boost 1.81.0 as header-only
(`cp -r boost \$prefix/include/`) and never writes a CMake config
file, so the find fails with:

```
CMake Error: Could not find a package configuration file provided by
"Boost" (requested version 1.74.0) with any of the following names:
  BoostConfig.cmake / boost-config.cmake
```

This blocks any CMake build that consumes the depends toolchain —
**gap #4 in tracking issue #223**, blocking `linux/i686-centos`
migration.

## Why not bump Boost like upstream

Upstream Bitcoin Core fixed the same gap by bumping to Boost 1.90.0
(CMake-built tarball that ships `BoostConfig.cmake` natively). That
path is **not** viable for navio because upstream only needs the
`multi_index` + `test` Boost components, while navio still uses:

- `boost/process.hpp` (Boost.Process)
- `boost/signals2/...` (Boost.Signals2)
- `boost/date_time/posix_time/...` (Boost.DateTime)
- `boost/tuple/tuple.hpp` (Boost.Tuple)
- `boost/unordered_map.hpp` (Boost.UnorderedMap)
- `boost/operators.hpp`
- `boost/multi_index/...` + `boost/test/...`

Cherry-picking upstream's restricted `BOOST_INCLUDE_LIBRARIES` would
silently miss those headers and break the build at compile time.

## Fix

Stay on Boost 1.81.0 (header-only) and have the depends stage step
emit a hand-rolled minimal `BoostConfig.cmake` + `BoostConfigVersion.cmake`
that:

- Declare the `Boost::headers` `IMPORTED INTERFACE` target with
  `INTERFACE_INCLUDE_DIRECTORIES` pointing at the depends prefix's
  `include/` directory.
- Implement the standard `PACKAGE_VERSION_COMPATIBLE` /
  `PACKAGE_VERSION_EXACT` contract for version matching.

The minimum surface that satisfies `AddBoostIfNeeded.cmake`'s
expectations (Boost_FOUND, `Boost::headers` target, version checks)
without changing the actual Boost headers, version, or library set
that consumers compile against.

The `\$\$\$\$` escaping on `\${CMAKE_CURRENT_LIST_DIR}` /
`\${_boost_prefix}` is required because `depends/funcs.mk` wraps the
package's `stage_cmds` in `\$(eval ...)`, which consumes one `\$` pass
before the recipe's `\$\$ -> \$` shell substitution.

## Verification

- Cached boost tarball under `depends/built/\$HOST/boost/` now contains
  `lib/cmake/Boost-1.81.0/BoostConfig.cmake` with the expected literal
  `\${CMAKE_CURRENT_LIST_DIR}` references (no premature shell expansion).
- `cmake -DCMAKE_TOOLCHAIN_FILE=depends/x86_64-pc-linux-gnu/toolchain.cmake`
  now passes the `AddBoostIfNeeded.cmake` step ("HAVE_BOOST_PROCESS_V1 -
  Success", build files written).
- `cmake --build build --target navio_common` succeeds end-to-end,
  confirming the Boost.Process / multi_index / etc. headers resolve
  at compile time through the generated config.

## Impact

Closes gap #4 in #223 and the tracking issue overall (gaps 1, 2, 3, 5
already addressed via #227, #222, #228, #229 respectively).

Refs #223. Independent of #222, #227, #228, #229.

## Test plan

- [ ] Existing CMake CI matrix stays green.
- [ ] Follow-up PR that migrates `linux/i686-centos` to a CMake matrix
      entry exercises this end-to-end.