### PR TITLE
ci: migrate fuzz job to CMake (follow-up to #219)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,11 +370,6 @@ jobs:
             file_env: ./ci/test/00_setup_env_i686_multiprocess.sh
             runner: ubuntu-24.04
 
-          - name: fuzz
-            label: 'Ubuntu 24.04, fuzzer, ASan + UBSan + integer, no depends'
-            file_env: ./ci/test/00_setup_env_native_fuzz.sh
-            runner: ubuntu-24.04
-
           - name: tsan
             label: 'Ubuntu 24.04, ThreadSanitizer, depends'
             file_env: ./ci/test/00_setup_env_native_tsan.sh
@@ -500,6 +495,27 @@ jobs:
           # than the CXX env var because cmake strips compiler flags out of
           # CXX when detecting the compiler, which would mean libstdc++/libc++
           # mixing in the bls/mcl subprojects.
+          # Replaces the autotools `fuzz` matrix entry.
+          # BUILD_FOR_FUZZING=ON enables fuzz binary and disables non-fuzz targets,
+          # matching --enable-fuzz. SANITIZERS mirrors the autotools value.
+          # -ftrivial-auto-var-init=pattern is added via APPEND_CXXFLAGS/CFLAGS.
+          # Fuzz harness runs against the nav-io/qa-assets corpus with
+          # --empty_min_time=60, matching ci/test/03_test_script.sh.
+          - name: fuzz
+            label: 'Ubuntu 24.04, fuzzer, ASan + UBSan + integer, no depends (CMake)'
+            runner: ubuntu-24.04
+            packages: >-
+              clang-17 llvm-17 libclang-rt-17-dev libevent-dev libboost-dev
+              libsqlite3-dev python3
+            cc: clang-17
+            cxx: clang++-17
+            cmake_flags: >-
+              -DBUILD_FOR_FUZZING=ON
+              -DSANITIZERS=fuzzer,address,undefined,float-divide-by-zero,integer
+              "-DAPPEND_CFLAGS=-ftrivial-auto-var-init=pattern"
+              "-DAPPEND_CXXFLAGS=-ftrivial-auto-var-init=pattern"
+            fuzz: true
+
           - name: nowallet-libnaviokernel
             label: 'Ubuntu 22.04, no wallet, libnaviokernel (CMake)'
             runner: ubuntu-22.04
@@ -659,6 +675,20 @@ jobs:
           # surface the IWYU-suggested diff for visibility but do not fail
           # the job — the codebase has not been cleaned for strict IWYU.
           git --no-pager diff || true
+
+      - name: Fetch qa-assets fuzz corpus
+        if: ${{ matrix.fuzz }}
+        run: |
+          git clone --depth=1 https://github.com/nav-io/qa-assets "${RUNNER_TEMP}/qa-assets"
+          echo "DIR_FUZZ_IN=${RUNNER_TEMP}/qa-assets/fuzz_seed_corpus/" >> "$GITHUB_ENV"
+
+      - name: Run fuzz harness
+        if: ${{ matrix.fuzz }}
+        env:
+          LLVM_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-17
+        run: |
+          build/test/fuzz/test_runner.py -j"$(nproc)" -l DEBUG \
+            "${DIR_FUZZ_IN}" --empty_min_time=60
 
       - name: Save Ccache cache
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,9 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
+      # Match upstream bitcoin/master which sets CCACHE_MAXSIZE=2G as the
+      # default across every ci/test/00_setup_env_*.sh env file.
+      CCACHE_MAXSIZE: '2G'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Migrates the \`fuzz\` matrix entry from the autotools \`linux:\` workflow to the new \`linux-cmake:\` matrix added in #219. fuzz is the first depends-free job to land on CMake, riding on the gap-5 (-Wundef WaaE) cleanup already merged via #229.

## What changes

- Removes the fuzz row from the autotools \`linux:\` matrix (\`ci/test/00_setup_env_native_fuzz.sh\` no longer driven by CI).
- Adds a fuzz row to \`linux-cmake:\` with:
  - packages mirroring 00_setup_env_native_fuzz.sh (clang-17, llvm-17, libclang-rt-17-dev, libevent-dev, libboost-dev, libsqlite3-dev).
  - \`-DBUILD_FOR_FUZZING=ON\` → enables fuzz binary, disables others (≡ \`--enable-fuzz\`).
  - \`-DSANITIZERS=fuzzer,address,undefined,float-divide-by-zero,integer\` (≡ \`--with-sanitizers=...\`).
  - \`APPEND_CFLAGS\`/\`APPEND_CXXFLAGS=-ftrivial-auto-var-init=pattern\`.
- Adds two gated steps (run only when \`matrix.fuzz\`):
  - clone \`nav-io/qa-assets\` into \`\${RUNNER_TEMP}/qa-assets\`
  - invoke \`build/test/fuzz/test_runner.py … --empty_min_time=60\` with \`LLVM_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-17\`, matching \`ci/test/03_test_script.sh:215\`.

## Test plan

- [ ] \`fuzz\` row in \`linux-cmake\` matrix turns green (config → build → corpus clone → run).
- [ ] No regression in other \`linux-cmake\` entries (tidy, no-wallet-libblsct, nowallet-libnaviokernel).
- [ ] Autotools \`linux:\` no longer contains a fuzz row.