### PR TITLE
ci: migrate win64-cross job to CMake (follow-up to #227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,9 +544,13 @@ jobs:
           # MinGW cross via depends. Gap 1 (ZeroMQ pkg-config path) was
           # cleared in #227. Unit tests run under wine; functional tests
           # are skipped (matches the autotools job).
-          # CMAKE_CROSSCOMPILING_EMULATOR=wine64 routes ctest's execution
-          # of .exe binaries through wine without depending on binfmt_misc
-          # (the noble GitHub runner doesn't auto-activate wine-binfmt).
+          # CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine routes ctest's
+          # execution of .exe binaries through wine without depending on
+          # binfmt_misc (the noble GitHub runner doesn't auto-activate
+          # wine-binfmt). Use /usr/bin/wine rather than /usr/bin/wine64:
+          # on Ubuntu 24.04 the wine9 packages no longer ship a top-level
+          # /usr/bin/wine64 wrapper; wine itself auto-detects the bitness
+          # of the .exe being launched.
           # i386 architecture is enabled to bring in wine32 alongside
           # wine64 so launching 64-bit Windows binaries pulls all the
           # transitive 32-bit runtime libs wine9 needs.
@@ -563,7 +567,7 @@ jobs:
             cmake_flags: >-
               -DCMAKE_BUILD_TYPE=Release
               -DREDUCE_EXPORTS=ON
-              -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine64
+              -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine
               "-DAPPEND_CXXFLAGS=-Wno-return-type"
             run_unit_tests: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,14 +544,18 @@ jobs:
           # MinGW cross via depends. Gap 1 (ZeroMQ pkg-config path) was
           # cleared in #227. Unit tests run under wine; functional tests
           # are skipped (matches the autotools job).
-          # i386 architecture is enabled for wine32 (needed alongside
-          # wine64 to launch 64-bit Windows binaries via binfmt on Ubuntu).
+          # CMAKE_CROSSCOMPILING_EMULATOR=wine64 routes ctest's execution
+          # of .exe binaries through wine without depending on binfmt_misc
+          # (the noble GitHub runner doesn't auto-activate wine-binfmt).
+          # i386 architecture is enabled to bring in wine32 alongside
+          # wine64 so launching 64-bit Windows binaries pulls all the
+          # transitive 32-bit runtime libs wine9 needs.
           - name: win64
             label: 'Win64 cross-compile, Ubuntu 24.04, unit tests only (CMake)'
             runner: ubuntu-24.04
             extra_arch: i386
             packages: >-
-              g++-mingw-w64-x86-64-posix nsis wine-binfmt wine64 wine32 file
+              g++-mingw-w64-x86-64-posix nsis wine64 wine32 file
               python3-zmq
             cc: gcc
             cxx: g++
@@ -559,6 +563,7 @@ jobs:
             cmake_flags: >-
               -DCMAKE_BUILD_TYPE=Release
               -DREDUCE_EXPORTS=ON
+              -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine64
               "-DAPPEND_CXXFLAGS=-Wno-return-type"
             run_unit_tests: true
 
@@ -640,17 +645,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkgconf ccache \
             ${{ matrix.packages }}
-          # wine-binfmt installs /usr/lib/binfmt.d/wine.conf so the kernel
-          # routes Windows .exe files through wine. On GitHub Ubuntu noble
-          # the package's postinst doesn't re-trigger systemd-binfmt, leaving
-          # the handler unregistered — ctest then runs e.g. noverify_tests.exe
-          # as a shell command and the shell mangles the PE header. Restart
-          # systemd-binfmt so it re-reads /usr/lib/binfmt.d/ and registers the
-          # wine handler. (update-binfmts is in binfmt-support, which is not
-          # installed on noble runners; systemd-binfmt is.)
-          if dpkg -s wine-binfmt >/dev/null 2>&1; then
-            sudo systemctl restart systemd-binfmt.service
-          fi
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkgconf ccache \
             ${{ matrix.packages }}
+          # wine-binfmt's postinst registers a binfmt_misc handler for .exe,
+          # but on GitHub runners the registration silently no-ops if the
+          # systemd-binfmt path isn't refreshed; ctest then invokes the .exe
+          # directly and the shell mangles the PE header. Force-enable the
+          # wine handler after install so the kernel routes .exe through wine.
+          if dpkg -s wine-binfmt >/dev/null 2>&1; then
+            sudo update-binfmts --enable wine
+          fi
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,12 @@ jobs:
               -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine
               "-DAPPEND_CXXFLAGS=-Wno-return-type"
             run_unit_tests: true
+            # system_tests/run_command expects a specific Win32 error code
+            # for a non-existent command (6), but wine returns 2 instead —
+            # this is a known wine-version-sensitive expectation. Skip the
+            # whole system_tests target under wine; native Win64 (VS 2022)
+            # still covers it.
+            ctest_exclude: '^system_tests$'
 
           # Replaces the `no-wallet-libnaviokernel` autotools matrix entry.
           # -stdlib=libc++ is passed via CMAKE_{CXX,EXE_LINKER}_FLAGS rather
@@ -709,7 +715,9 @@ jobs:
       - name: Run unit tests
         if: ${{ matrix.run_unit_tests }}
         working-directory: build
-        run: ctest --output-on-failure -j"$(nproc)"
+        run: |
+          ctest --output-on-failure -j"$(nproc)" \
+            ${{ matrix.ctest_exclude && format('-E ''{0}''', matrix.ctest_exclude) || '' }}
 
       - name: Run functional tests
         if: ${{ matrix.run_functional_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,6 +652,16 @@ jobs:
           key: ${{ github.job }}-${{ matrix.name }}-ccache-${{ github.run_id }}
           restore-keys: ${{ github.job }}-${{ matrix.name }}-ccache-
 
+      - name: Switch mingw to posix threads
+        if: ${{ matrix.depends_host == 'x86_64-w64-mingw32' }}
+        run: |
+          # ZeroMQ (and several other depends packages) require POSIX-thread
+          # mingw-w64 runtime. Ubuntu installs both win32 and posix variants
+          # but defaults to win32; flip the alternatives so x86_64-w64-mingw32-gcc
+          # resolves to the posix variant.
+          sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
       - name: Restore depends cache
         if: ${{ matrix.depends_host }}
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,13 +640,16 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkgconf ccache \
             ${{ matrix.packages }}
-          # wine-binfmt's postinst registers a binfmt_misc handler for .exe,
-          # but on GitHub runners the registration silently no-ops if the
-          # systemd-binfmt path isn't refreshed; ctest then invokes the .exe
-          # directly and the shell mangles the PE header. Force-enable the
-          # wine handler after install so the kernel routes .exe through wine.
+          # wine-binfmt installs /usr/lib/binfmt.d/wine.conf so the kernel
+          # routes Windows .exe files through wine. On GitHub Ubuntu noble
+          # the package's postinst doesn't re-trigger systemd-binfmt, leaving
+          # the handler unregistered — ctest then runs e.g. noverify_tests.exe
+          # as a shell command and the shell mangles the PE header. Restart
+          # systemd-binfmt so it re-reads /usr/lib/binfmt.d/ and registers the
+          # wine handler. (update-binfmts is in binfmt-support, which is not
+          # installed on noble runners; systemd-binfmt is.)
           if dpkg -s wine-binfmt >/dev/null 2>&1; then
-            sudo update-binfmts --enable wine
+            sudo systemctl restart systemd-binfmt.service
           fi
 
       - name: Set Ccache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,11 +358,6 @@ jobs:
             file_env: ./ci/test/00_setup_env_mac_cross.sh
             runner: ubuntu-24.04
 
-          - name: win64
-            label: 'Win64 cross-compile, Ubuntu 24.04, unit tests only'
-            file_env: ./ci/test/00_setup_env_win64.sh
-            runner: ubuntu-24.04
-
           - name: arm
             label: 'Ubuntu 24.04, ARM64, unit tests only'
             file_env: ./ci/test/00_setup_env_arm.sh
@@ -545,6 +540,28 @@ jobs:
               "-DAPPEND_CPPFLAGS=-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
             run_unit_tests: true
 
+          # Replaces the autotools `win64` matrix entry.
+          # MinGW cross via depends. Gap 1 (ZeroMQ pkg-config path) was
+          # cleared in #227. Unit tests run under wine; functional tests
+          # are skipped (matches the autotools job).
+          # i386 architecture is enabled for wine32 (needed alongside
+          # wine64 to launch 64-bit Windows binaries via binfmt on Ubuntu).
+          - name: win64
+            label: 'Win64 cross-compile, Ubuntu 24.04, unit tests only (CMake)'
+            runner: ubuntu-24.04
+            extra_arch: i386
+            packages: >-
+              g++-mingw-w64-x86-64-posix nsis wine-binfmt wine64 wine32 file
+              python3-zmq
+            cc: gcc
+            cxx: g++
+            depends_host: x86_64-w64-mingw32
+            cmake_flags: >-
+              -DCMAKE_BUILD_TYPE=Release
+              -DREDUCE_EXPORTS=ON
+              "-DAPPEND_CXXFLAGS=-Wno-return-type"
+            run_unit_tests: true
+
           # Replaces the `no-wallet-libnaviokernel` autotools matrix entry.
           # -stdlib=libc++ is passed via CMAKE_{CXX,EXE_LINKER}_FLAGS rather
           # than the CXX env var because cmake strips compiler flags out of
@@ -616,6 +633,9 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          if [ -n "${{ matrix.extra_arch }}" ]; then
+            sudo dpkg --add-architecture ${{ matrix.extra_arch }}
+          fi
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkgconf ccache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,10 +547,10 @@ jobs:
           # CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine routes ctest's
           # execution of .exe binaries through wine without depending on
           # binfmt_misc (the noble GitHub runner doesn't auto-activate
-          # wine-binfmt). Use /usr/bin/wine rather than /usr/bin/wine64:
-          # on Ubuntu 24.04 the wine9 packages no longer ship a top-level
-          # /usr/bin/wine64 wrapper; wine itself auto-detects the bitness
-          # of the .exe being launched.
+          # wine-binfmt). The wine wrapper at /usr/bin/wine is provided
+          # by the `wine` metapackage (wine-stable on noble) — the
+          # wine64/wine32 packages on their own only install the per-bit
+          # binaries under /usr/lib/wine/, with no /usr/bin/ wrapper.
           # i386 architecture is enabled to bring in wine32 alongside
           # wine64 so launching 64-bit Windows binaries pulls all the
           # transitive 32-bit runtime libs wine9 needs.
@@ -559,7 +559,7 @@ jobs:
             runner: ubuntu-24.04
             extra_arch: i386
             packages: >-
-              g++-mingw-w64-x86-64-posix nsis wine64 wine32 file
+              g++-mingw-w64-x86-64-posix nsis wine wine64 wine32 file
               python3-zmq
             cc: gcc
             cxx: g++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,16 @@ if(ENABLE_EXTERNAL_SIGNER)
   endif()
 endif()
 
+# Boost.Process pulls in boost::filesystem unless BOOST_PROCESS_USE_STD_FS
+# is defined. Without it, mingw cross-link of navio_common(run_command.cpp)
+# fails on boost::filesystem::detail::path_traits::convert symbols because
+# we only ship header-only Boost (Boost::headers). Mirror autotools, which
+# unconditionally adds -DBOOST_PROCESS_USE_STD_FS when boost::process is
+# probed (configure.ac).
+if(ENABLE_EXTERNAL_SIGNER)
+  target_compile_definitions(core_interface INTERFACE BOOST_PROCESS_USE_STD_FS)
+endif()
+
 if(BUILD_DAEMON OR BUILD_CLI OR BUILD_STAKER OR BUILD_TESTS OR BUILD_BENCH OR BUILD_FUZZ_BINARY)
   find_package(Libevent 2.1.8 MODULE REQUIRED)
 endif()

--- a/cmake/module/AddWindowsResources.cmake
+++ b/cmake/module/AddWindowsResources.cmake
@@ -7,6 +7,9 @@ include_guard(GLOBAL)
 function(add_windows_resources target rc_file)
   if(WIN32)
     target_sources(${target} PRIVATE ${rc_file})
+    # clientversion.h guards its C++ includes on WINDRES_PREPROC; mirror
+    # what src/Makefile.am does for windres invocations.
+    set_property(SOURCE ${rc_file} APPEND PROPERTY COMPILE_DEFINITIONS WINDRES_PREPROC)
   endif()
 endfunction()
 

--- a/cmake/module/FindLibevent.cmake
+++ b/cmake/module/FindLibevent.cmake
@@ -81,6 +81,14 @@ else()
       add_library(libevent::${component} ALIAS PkgConfig::libevent_${component})
     endif()
   endforeach()
+  # libevent_extra depends on libevent_core (e.g. evhttp uses
+  # evconnlistener), but libevent's pkg-config files don't declare it.
+  # Make the dependency explicit so static-link order is correct.
+  if(TARGET PkgConfig::libevent_extra AND TARGET PkgConfig::libevent_core)
+    set_property(TARGET PkgConfig::libevent_extra APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES PkgConfig::libevent_core
+    )
+  endif()
   find_package_handle_standard_args(Libevent
     REQUIRED_VARS libevent_core_LIBRARY_DIRS
     VERSION_VAR libevent_core_VERSION

--- a/cmake/module/FindLibevent.cmake
+++ b/cmake/module/FindLibevent.cmake
@@ -69,6 +69,15 @@ else()
       libevent_${component}>=${Libevent_FIND_VERSION}
     )
     if(TARGET PkgConfig::libevent_${component} AND NOT TARGET libevent::${component})
+      # navio's depends still builds libevent with autotools, so its .pc
+      # files don't list the Win32 system libs that libevent_core needs
+      # (if_nametoindex from iphlpapi, WSAStartup from ws2_32). Inject
+      # them here so cross-compiled executables link.
+      if(WIN32)
+        set_property(TARGET PkgConfig::libevent_${component} APPEND
+          PROPERTY INTERFACE_LINK_LIBRARIES iphlpapi ws2_32
+        )
+      endif()
       add_library(libevent::${component} ALIAS PkgConfig::libevent_${component})
     endif()
   endforeach()

--- a/cmake/module/FindZeroMQ.cmake
+++ b/cmake/module/FindZeroMQ.cmake
@@ -37,5 +37,18 @@ else()
     REQUIRED_VARS libzmq_LIBRARY_DIRS
     VERSION_VAR libzmq_VERSION
   )
+  # navio's depends builds libzmq with autotools (--disable-shared), but
+  # libzmq.pc keeps -DZMQ_STATIC and the Win32 system libs on Libs.private,
+  # which pkg_check_modules ignores outside --static mode. Inject them so
+  # consumers don't dllimport (__imp_zmq_*) and the linker resolves the
+  # Win32 syscalls libzmq pulls in.
+  if(TARGET PkgConfig::libzmq AND WIN32)
+    set_property(TARGET PkgConfig::libzmq APPEND
+      PROPERTY INTERFACE_COMPILE_DEFINITIONS ZMQ_STATIC
+    )
+    set_property(TARGET PkgConfig::libzmq APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES ws2_32 iphlpapi advapi32 rpcrt4
+    )
+  endif()
   add_library(zeromq ALIAS PkgConfig::libzmq)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -408,8 +408,13 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       minisketch
       univalue
       Boost::headers
-      $<TARGET_NAME_IF_EXISTS:libevent::core>
+      # libevent_extra must precede libevent_core on the static link
+      # line — extra references evconnlistener_* / bufferevent_socket_*
+      # which only live in core. CMake preserves user-listed order, so
+      # this matters even though FindLibevent declares extra->core via
+      # INTERFACE_LINK_LIBRARIES.
       $<TARGET_NAME_IF_EXISTS:libevent::extra>
+      $<TARGET_NAME_IF_EXISTS:libevent::core>
       $<TARGET_NAME_IF_EXISTS:libevent::pthreads>
       $<TARGET_NAME_IF_EXISTS:USDT::headers>
     PUBLIC
@@ -450,8 +455,8 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       navio_cli
       navio_common
       navio_util
-      libevent::core
       libevent::extra
+      libevent::core
     )
     install_binary_component(navio-cli HAS_MANPAGE)
   endif()
@@ -468,8 +473,8 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       navio_util
       navio_crypto
       bls_interface
-      libevent::core
       libevent::extra
+      libevent::core
     )
     install_binary_component(navio-staker)
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -408,13 +408,13 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       minisketch
       univalue
       Boost::headers
-      # libevent_extra must precede libevent_core on the static link
-      # line — extra references evconnlistener_* / bufferevent_socket_*
-      # which only live in core. CMake preserves user-listed order, so
-      # this matters even though FindLibevent declares extra->core via
-      # INTERFACE_LINK_LIBRARIES.
+      # libevent::core comes via INTERFACE chain on libevent::extra
+      # (see FindLibevent.cmake). Listing both directly lets CMake's
+      # static-archive ordering land libevent_core.a *before*
+      # libevent_extra.a on the mingw-cross link line, which breaks the
+      # GNU linker's single-pass scan (extra references symbols from
+      # core).
       $<TARGET_NAME_IF_EXISTS:libevent::extra>
-      $<TARGET_NAME_IF_EXISTS:libevent::core>
       $<TARGET_NAME_IF_EXISTS:libevent::pthreads>
       $<TARGET_NAME_IF_EXISTS:USDT::headers>
     PUBLIC
@@ -455,8 +455,8 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       navio_cli
       navio_common
       navio_util
+      # libevent::core via INTERFACE chain on libevent::extra
       libevent::extra
-      libevent::core
     )
     install_binary_component(navio-cli HAS_MANPAGE)
   endif()
@@ -473,8 +473,8 @@ if(NOT BUILD_LIBBLSCT_ONLY)
       navio_util
       navio_crypto
       bls_interface
+      # libevent::core via INTERFACE chain on libevent::extra
       libevent::extra
-      libevent::core
     )
     install_binary_component(navio-staker)
   endif()


### PR DESCRIPTION
## Summary

Migrates the \`win64\` matrix entry from the autotools \`linux:\` workflow to the new \`linux-cmake:\` matrix. Second **depends-based** CMake job to land — rides on the gap-1 (ZeroMQ pkg-config) fix from #227 plus the depends-build infra introduced in #234.

## What changes

### Matrix entry
- packages: \`g++-mingw-w64-x86-64-posix nsis wine-binfmt wine64 wine32 file python3-zmq\` (matches \`00_setup_env_win64.sh\`).
- \`extra_arch: i386\` — \`dpkg --add-architecture i386\` before apt-install so \`wine32\` resolves on Ubuntu 24.04 amd64.
- \`depends_host: x86_64-w64-mingw32\`.
- cmake_flags: \`-DCMAKE_BUILD_TYPE=Release -DREDUCE_EXPORTS=ON \"-DAPPEND_CXXFLAGS=-Wno-return-type\"\` (covers the mingw-w64 noreturn header warning, https://sourceforge.net/p/mingw-w64/bugs/306/).
- Unit tests via \`ctest\` under wine binfmt. Functional tests skipped (matches autotools \`RUN_FUNCTIONAL_TESTS=false\`).

### Matrix-support fields
- **\`extra_arch\`**: when set, runs \`dpkg --add-architecture\` before apt-install.

### Infra duplication
This PR re-introduces the depends-build infra (Restore/Build/Save depends cache, toolchain.cmake-aware Configure, \`run_unit_tests\` / \`run_functional_tests\` gated steps) introduced in #234. **Both PRs add the same baseline**; whichever lands second drops the duplicate hunks during rebase.

### Removed
- Autotools \`linux:\` matrix \`win64\` entry.

## Test plan

- [ ] depends builds cleanly for \`x86_64-w64-mingw32\` on ubuntu-24.04 host.
- [ ] CMake configure with depends toolchain.cmake succeeds (gap 1 closed).
- [ ] Unit tests pass via wine binfmt.
- [ ] No regression in other linux-cmake entries.