### PR TITLE
ci: migrate mac-cross job to CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,11 +353,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: mac-cross
-            label: 'macOS cross-compile, Ubuntu 24.04, no tests'
-            file_env: ./ci/test/00_setup_env_mac_cross.sh
-            runner: ubuntu-24.04
-
           - name: arm
             label: 'Ubuntu 24.04, ARM64, unit tests only'
             file_env: ./ci/test/00_setup_env_arm.sh
@@ -572,6 +567,27 @@ jobs:
             # still covers it.
             ctest_exclude: '^system_tests$'
 
+          # Replaces the autotools `mac-cross` matrix entry.
+          # Cross-compile to x86_64-apple-darwin via depends. Build only —
+          # no unit/functional tests (matches autotools RUN_UNIT_TESTS=false
+          # RUN_FUNCTIONAL_TESTS=false). The autotools job's GOAL=deploy is
+          # a no-op in navio (no Qt/macOS bundle target); the CMake job
+          # mirrors that by stopping at build.
+          # The Xcode SDK is fetched from bitcoincore.org's mirror, matching
+          # ci/test/01_base_install.sh's OSX_SDK_BASENAME logic.
+          - name: mac-cross
+            label: 'macOS cross-compile, Ubuntu 24.04, no tests (CMake)'
+            runner: ubuntu-24.04
+            packages: zip
+            cc: gcc
+            cxx: g++
+            depends_host: x86_64-apple-darwin
+            xcode_version: '15.0'
+            xcode_build_id: '15A240d'
+            cmake_flags: >-
+              -DCMAKE_BUILD_TYPE=Release
+              -DREDUCE_EXPORTS=ON
+
           # Replaces the `no-wallet-libnaviokernel` autotools matrix entry.
           # -stdlib=libc++ is passed via CMAKE_{CXX,EXE_LINKER}_FLAGS rather
           # than the CXX env var because cmake strips compiler flags out of
@@ -671,6 +687,21 @@ jobs:
           # resolves to the posix variant.
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+      - name: Fetch macOS SDK
+        if: ${{ matrix.xcode_version }}
+        run: |
+          # Matches ci/test/01_base_install.sh: OSX_SDK_BASENAME =
+          # Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers
+          sdk_basename="Xcode-${{ matrix.xcode_version }}-${{ matrix.xcode_build_id }}-extracted-SDK-with-libcxx-headers"
+          sdk_dir="$PWD/depends/SDKs"
+          mkdir -p "$sdk_dir"
+          if [ ! -d "$sdk_dir/$sdk_basename" ]; then
+            curl --location --fail \
+              "https://bitcoincore.org/depends-sources/sdks/${sdk_basename}.tar.gz" \
+              -o /tmp/osx-sdk.tar.gz
+            tar -C "$sdk_dir" -xf /tmp/osx-sdk.tar.gz
+          fi
 
       - name: Restore depends cache
         if: ${{ matrix.depends_host }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,10 +691,11 @@ jobs:
       - name: Fetch macOS SDK
         if: ${{ matrix.xcode_version }}
         run: |
-          # Matches ci/test/01_base_install.sh: OSX_SDK_BASENAME =
-          # Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers
+          # Extract outside depends/ so hashFiles('depends/**') doesn't
+          # choke on the SDK's broken-on-Linux symlinks. depends/Makefile
+          # honours SDK_PATH, so the build still finds it.
           sdk_basename="Xcode-${{ matrix.xcode_version }}-${{ matrix.xcode_build_id }}-extracted-SDK-with-libcxx-headers"
-          sdk_dir="$PWD/depends/SDKs"
+          sdk_dir="${RUNNER_TEMP}/osx-sdks"
           mkdir -p "$sdk_dir"
           if [ ! -d "$sdk_dir/$sdk_basename" ]; then
             curl --location --fail \
@@ -702,6 +703,7 @@ jobs:
               -o /tmp/osx-sdk.tar.gz
             tar -C "$sdk_dir" -xf /tmp/osx-sdk.tar.gz
           fi
+          echo "SDK_PATH=$sdk_dir" >> "$GITHUB_ENV"
 
       - name: Restore depends cache
         if: ${{ matrix.depends_host }}

--- a/cmake/bls.cmake
+++ b/cmake/bls.cmake
@@ -116,8 +116,14 @@ else()
       ${MCL_USE_GMP_FLAG}
       ${MCL_USE_OMP_FLAG}
       ARCH=${CMAKE_SYSTEM_PROCESSOR}
-      CC=${CMAKE_C_COMPILER}
-      CXX=${CMAKE_CXX_COMPILER}
+      # depends toolchains for mac-cross use a multi-token CC line
+      # ("env -u C_INCLUDE_PATH ... clang --target=... -isysroot..."),
+      # which CMake splits into CMAKE_C_COMPILER (first token = /bin/env)
+      # plus CMAKE_C_COMPILER_ARG1 (everything else). Re-join here so
+      # mcl's Makefile receives the full launcher invocation as a single
+      # CC= value.
+      "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}"
+      "CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
       # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.
@@ -140,8 +146,14 @@ else()
       ${MCL_USE_GMP_FLAG}
       ${MCL_USE_OMP_FLAG}
       ARCH=${CMAKE_SYSTEM_PROCESSOR}
-      CC=${CMAKE_C_COMPILER}
-      CXX=${CMAKE_CXX_COMPILER}
+      # depends toolchains for mac-cross use a multi-token CC line
+      # ("env -u C_INCLUDE_PATH ... clang --target=... -isysroot..."),
+      # which CMake splits into CMAKE_C_COMPILER (first token = /bin/env)
+      # plus CMAKE_C_COMPILER_ARG1 (everything else). Re-join here so
+      # mcl's Makefile receives the full launcher invocation as a single
+      # CC= value.
+      "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}"
+      "CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
       # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.

--- a/cmake/bls.cmake
+++ b/cmake/bls.cmake
@@ -124,6 +124,15 @@ else()
       # CC= value.
       "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}"
       "CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}"
+      # mcl's Makefile detects host OS via `uname -s` and so always reports
+      # Linux on the cross-compile host, even when the target is Darwin.
+      # That keeps the default `AR=ar r` (system GNU ar) in effect, which
+      # produces a SysV-style archive without the per-architecture symbol
+      # table Apple's ld64 expects ("archive has no table of contents file
+      # ... for architecture x86_64"). Forward the depends toolchain's
+      # archiver instead. mcl's Makefile expects AR to include the operation
+      # letter, so append " r".
+      "AR=${CMAKE_AR} r"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
       # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.
@@ -154,6 +163,8 @@ else()
       # CC= value.
       "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}"
       "CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}"
+      # See mcl_build above for why AR must be forwarded explicitly.
+      "AR=${CMAKE_AR} r"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
       # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.

--- a/cmake/bls.cmake
+++ b/cmake/bls.cmake
@@ -106,6 +106,13 @@ else()
     BUILD_COMMAND
       ${GNU_MAKE_EXECUTABLE}
       MCL_USE_LLVM=0
+      # mcl/Makefile runs `expr $(LLVM_OPT_VERSION) \>= 9` at parse
+      # time, where LLVM_OPT_VERSION comes from `opt --version`. On
+      # some hosts the awk extractor leaves a dotted version string
+      # like '4.6.0' that expr can't parse, killing the make run even
+      # though MCL_USE_LLVM=0. Forcing it empty short-circuits the
+      # `ifneq ($(LLVM_OPT_VERSION),)` guard above the expr call.
+      LLVM_OPT_VERSION=
       ${MCL_USE_GMP_FLAG}
       ${MCL_USE_OMP_FLAG}
       ARCH=${CMAKE_SYSTEM_PROCESSOR}
@@ -129,6 +136,7 @@ else()
     BUILD_COMMAND
       ${GNU_MAKE_EXECUTABLE}
       BLS_ETH=1
+      LLVM_OPT_VERSION= # see mcl_build above for why
       ${MCL_USE_GMP_FLAG}
       ${MCL_USE_OMP_FLAG}
       ARCH=${CMAKE_SYSTEM_PROCESSOR}


### PR DESCRIPTION
## Summary

Migrates the \`mac-cross\` matrix entry from the autotools \`linux:\` workflow to the new \`linux-cmake:\` matrix. Last cross-compile target to migrate. No remaining #223 gaps applicable.

## What changes

### Matrix entry
- packages: \`zip\` (matches \`00_setup_env_mac_cross.sh\`).
- \`depends_host: x86_64-apple-darwin\`.
- \`xcode_version: 15.0\`, \`xcode_build_id: 15A240d\` — these drive a new \"Fetch macOS SDK\" step that downloads the SDK tarball from \`bitcoincore.org/depends-sources/sdks/\`, mirroring \`ci/test/01_base_install.sh:79-89\`.
- cmake_flags: \`-DCMAKE_BUILD_TYPE=Release -DREDUCE_EXPORTS=ON\` (mirrors \`--enable-reduce-exports\`).

### Coverage parity
- No unit / functional tests (matches autotools \`RUN_UNIT_TESTS=false RUN_FUNCTIONAL_TESTS=false\`).
- Autotools \`GOAL=deploy\` is a no-op in navio (no Qt/macOS bundle target — \`.PHONY: deploy\` is declared in \`Makefile.am:14\` but has no recipe), so stopping at build is equivalent coverage.

### Infra duplication
Pulls in the depends-build infra (Restore/Build/Save depends cache, toolchain.cmake-aware Configure, env-stripped \`make -C depends\`) that #234 and #235 add. **Whichever PR lands first takes the infra diff**; the rest dedupe on rebase.

### Removed
- Autotools \`linux:\` matrix \`mac-cross\` entry.

## Test plan

- [ ] macOS SDK fetched + extracted.
- [ ] depends builds cleanly for \`x86_64-apple-darwin\`.
- [ ] CMake configure with depends toolchain.cmake succeeds.
- [ ] CMake build produces naviod / navio-cli / navio-tx / navio-util binaries.
- [ ] No regression in other linux-cmake entries.