### PR TITLE
ci(macos-native-arm64): migrate to CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           #" ${{ env.TEST_BASE }}
 
   macos-native-arm64:
-    name: 'macOS 15 native, arm64, no depends, sqlite only'
+    name: 'macOS 15 native, arm64, no depends, sqlite only (CMake)'
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
     runs-on: macos-15
@@ -124,15 +124,13 @@ jobs:
     timeout-minutes: 120
 
     env:
-      DANGER_RUN_CI_ON_HOST: 1
-      FILE_ENV: './ci/test/00_setup_env_mac_native.sh'
-      BASE_ROOT_DIR: ${{ github.workspace }}
+      CCACHE_MAXSIZE: '2G'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Clang version
+      - name: Select Xcode
         run: |
           sudo xcode-select --switch /Applications/Xcode_16.4.app
           clang --version
@@ -140,9 +138,10 @@ jobs:
       - name: Install Homebrew packages
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-        run:
-          brew install automake libtool pkg-config gnu-getopt ccache boost
-          libevent zeromq
+        # Drop autotools toolchain (automake/libtool). Add cmake + ninja.
+        run: |
+          brew install cmake ninja pkg-config gnu-getopt ccache boost \
+            libevent zeromq
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"
@@ -155,8 +154,19 @@ jobs:
           key: ${{ github.job }}-ccache-${{ github.run_id }}
           restore-keys: ${{ github.job }}-ccache-
 
-      - name: CI script
-        run: ./ci/test_run_all.sh
+      - name: Configure
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DREDUCE_EXPORTS=ON \
+            -DWITH_ZMQ=ON
+
+      - name: Build
+        run: cmake --build build -j"$(sysctl -n hw.ncpu)"
+
+      - name: Run unit tests
+        working-directory: build
+        run: ctest -j"$(sysctl -n hw.ncpu)" --output-on-failure
 
       - name: Save Ccache cache
         uses: actions/cache/save@v5


### PR DESCRIPTION
## Summary

Migrates the macOS-native apple-silicon job from \`ci/test_run_all.sh\` (autotools) to a direct CMake invocation. Independent of any #223 gap — no depends, host-only.

## Pipeline

Before:
\`\`\`yaml
- name: CI script
  run: ./ci/test_run_all.sh
# (drives ci/test/00_setup_env_mac_native.sh + autotools)
\`\`\`

After:
\`\`\`yaml
- name: Configure
  run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DREDUCE_EXPORTS=ON -DWITH_ZMQ=ON
- name: Build
  run: cmake --build build -j"$(sysctl -n hw.ncpu)"
- name: Run unit tests
  working-directory: build
  run: ctest -j"$(sysctl -n hw.ncpu)" --output-on-failure
\`\`\`

## Brew packages

- **drop**: \`automake libtool\` (autotools toolchain), \`libnatpmp\` (replaced by in-tree PCP/NAT-PMP in #226).
- **add**: \`cmake ninja\`.

## Env

- **drop**: \`DANGER_RUN_CI_ON_HOST\`, \`FILE_ENV\`, \`BASE_ROOT_DIR\` (no longer needed without the \`test_run_all.sh\` wrapper).
- **set**: \`CCACHE_MAXSIZE=2G\` (matches upstream + linux-cmake matrix).

## Coverage parity

- \`-DREDUCE_EXPORTS=ON\` mirrors \`--enable-reduce-exports\` from \`00_setup_env_mac_native.sh:12\`.
- \`-DWITH_ZMQ=ON\` keeps ZMQ linked (zeromq still in brew install).
- \`ctest\` replaces \`make check\` for unit tests.

**Note**: the prior env set \`RUN_FUZZ_TESTS=true\` but never passed \`--enable-fuzz\` to autotools configure, so no fuzz binary was actually built and the fuzz harness step would have no-op'd or silently failed. Not preserving that env flag — coverage was nominal, not real. If we want a true macOS fuzz job, that's a follow-up (mirror \`upstream/master:ci/test/00_setup_env_mac_native_fuzz.sh\`).

## Test plan

- [ ] Brew install resolves cleanly on macos-15.
- [ ] CMake configure picks up Homebrew Boost/libevent/zmq.
- [ ] Build produces naviod / navio-cli / navio-tx / navio-util / test_navio binaries.
- [ ] Unit tests pass via ctest.