### PR TITLE
depends: install systemtap headers under $(package)/include/sys/

### DIFF
--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -6,7 +6,12 @@ $(package)_sha256_hash=cbd50a4eba5b261394dc454c12448ddec73e55e6742fda7f508f9fbc1
 $(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch && \
-  mkdir -p $($(package)_staging_prefix_dir)/include/sys && \
-  cp includes/sys/sdt.h $($(package)_staging_prefix_dir)/include/sys/sdt.h
+  patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
+endef
+
+# Install to a unique path to prevent accidental inclusion via other dependencies' -I flags.
+# depends/toolchain.cmake.in points USDT_INCLUDE_DIR at $(staging)/$(package)/include.
+define $(package)_stage_cmds
+  mkdir -p $($(package)_staging_prefix_dir)/$(package)/include/sys && \
+  cp includes/sys/sdt.h $($(package)_staging_prefix_dir)/$(package)/include/sys/sdt.h
 endef


### PR DESCRIPTION
## Summary

Extracts a single-commit standalone fix from #222 (\"depends: sync with upstream Bitcoin Core\") so it can land independently and unblock downstream CMake-migration PRs without waiting for the full depends sync.

## What changes

\`depends/packages/systemtap.mk\` now installs \`sys/sdt.h\` under \`\$(staging)/\$(package)/include/sys/\` instead of the shared \`\$(staging)/include/sys/\`. This matches \`depends/toolchain.cmake.in:132\`, which sets:

\`\`\`cmake
set(USDT_INCLUDE_DIR \${CMAKE_CURRENT_LIST_DIR}/systemtap/include)
\`\`\`

Before this commit, the staging path was \`include/sys/sdt.h\` and the toolchain pointed at \`systemtap/include\` — so \`find_package(USDT)\` in \`CMakeLists.txt:107\` would fail with \`Could NOT find USDT (missing: HAVE_USDT_H)\` on every depends-driven CMake build.

## Why split out

Closes **gap 2** of #223 (CI/depends integration gaps) in isolation.

Unblocks:
- **#234** (i686-multiprocess CMake) — currently fails at \`find_package(USDT)\`.
- Future CMake migrations for **arm**, **tsan**, **msan** — same gap.

#222 itself remains open for the larger \`depends: sync with upstream Bitcoin Core\` work; this PR is the minimal isolable fix.

## Test plan

- [ ] Run a depends build with \`USDT_INCLUDE_DIR\` (linux host).
- [ ] CMake configure with the resulting depends toolchain.cmake succeeds at \`find_package(USDT)\`.