### PR TITLE
ci(macos-native-arm64): cache Homebrew downloads + skip auto-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,9 +149,28 @@ jobs:
           sudo xcode-select --switch /Applications/Xcode_16.4.app
           clang --version
 
+      # Cache Homebrew's download / metadata directory so 'brew install'
+      # skips the curl step on cache hit. The bottles themselves still get
+      # linked into /opt/homebrew/Cellar each run, but that's seconds, not
+      # the ~3-5min of cold network downloads from cold.
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/downloads
+            ~/Library/Caches/Homebrew/api
+          # Key on the brew install line so a package list change busts
+          # the cache. github.job pins to this job so other macOS jobs
+          # don't collide if they're added later.
+          key: ${{ github.job }}-brew-cmake-ninja-pkg-config-gnu-getopt-ccache-boost-libevent-zeromq-v1
+          restore-keys: ${{ github.job }}-brew-
+
       - name: Install Homebrew packages
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          # Skip the auto-update on every invocation; we trust the bottle
+          # versions the runner image ships with.
+          HOMEBREW_NO_AUTO_UPDATE: 1
         # Drop autotools toolchain (automake/libtool). Add cmake + ninja.
         run: |
           brew install cmake ninja pkg-config gnu-getopt ccache boost \


### PR DESCRIPTION
First item from #217's remaining-work list.

## What this does

`macos-native-arm64` cold-installs cmake, ninja, pkg-config, gnu-getopt, ccache, boost, libevent, zeromq on every run. On the macos-15 arm runner that's roughly 3-5 min of curl + untar + link, repeated for every PR push and every master push.

Two small tweaks:

1. **Cache Homebrew's download cache** (`~/Library/Caches/Homebrew/downloads` + `api`) — skips the curl half of `brew install` on cache hit.
2. **`HOMEBREW_NO_AUTO_UPDATE=1`** — `brew install` defaults to a silent `brew update` first; the runner image's bottle versions are pinned, so the update is wasted work.

The bottles themselves still get linked into `/opt/homebrew/Cellar` each run, which is seconds rather than minutes.

## Cache key

```
${{ github.job }}-brew-cmake-ninja-pkg-config-gnu-getopt-ccache-boost-libevent-zeromq-v1
```

- Encodes the package list verbatim so a formula list edit busts the cache (no stale partial downloads).
- `github.job` prefix isolates this from any future macOS jobs.
- `-v1` lets us bump on demand if we ever need to invalidate without changing the package list.
- `restore-keys: ${{ github.job }}-brew-` falls back to the most recent cache when the exact key misses (the first run after this PR merges).

## Validation

First post-merge run on master will be a cold miss (saves the cache). Subsequent PR runs should drop the install step from ~3-5 min to ~10-30s.

Refs #217.