### PR TITLE
ci: narrow depends/** hash to files that drive a rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,11 +428,21 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/ci-cache/${{ matrix.name }}
+          # Narrow the depends hash to the files that actually drive a
+          # rebuild: package recipes, the framework Makefile/funcs.mk,
+          # builders/hosts/patches. Editing depends/README.md or any
+          # uninstalled/staging .stamp would otherwise invalidate every
+          # triplet cache for every job. See issue #217.
           key:
-            ci-${{ matrix.name }}-${{ hashFiles('depends/**') }}-${{ github.sha
-            }}
+            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
+            'depends/funcs.mk', 'depends/packages/**',
+            'depends/builders/**', 'depends/hosts/**',
+            'depends/patches/**') }}-${{ github.sha }}
           restore-keys: |
-            ci-${{ matrix.name }}-${{ hashFiles('depends/**') }}-
+            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
+            'depends/funcs.mk', 'depends/packages/**',
+            'depends/builders/**', 'depends/hosts/**',
+            'depends/patches/**') }}-
             ci-${{ matrix.name }}-
 
       - name: Run CI
@@ -446,9 +456,12 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /tmp/ci-cache/${{ matrix.name }}
+          # Same narrowed key as Restore cache above; see comment there.
           key:
-            ci-${{ matrix.name }}-${{ hashFiles('depends/**') }}-${{ github.sha
-            }}
+            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
+            'depends/funcs.mk', 'depends/packages/**',
+            'depends/builders/**', 'depends/hosts/**',
+            'depends/patches/**') }}-${{ github.sha }}
 
   # CMake-driven matrix. Mirrors the structure of the autotools `linux:` matrix
   # so scenarios can be added by appending one entry. Each entry supplies its


### PR DESCRIPTION
Item from #217's remaining-work list.

## Problem

The `linux:` autotools matrix's `Restore cache` / `Save cache` steps key the per-triplet depends cache on `hashFiles('depends/**')`. That hash flips on **any** change anywhere under `depends/` — including:

- `depends/README.md`, `description.md`, `gen_id`
- `depends/built/`, `sources/`, `work/` output dirs (if present in the checkout)
- host-specific output trees like `depends/x86_64-w64-mingw32/`

So touching a single package patch list, fixing a typo in a doc, or even completing a build (which writes to `built/` / output trees) invalidates **every** triplet cache for **every** linux job.

## Fix

Narrow the hash to just the files that actually drive a depends rebuild:

```yaml
hashFiles(
  'depends/Makefile',
  'depends/funcs.mk',
  'depends/packages/**',
  'depends/builders/**',
  'depends/hosts/**',
  'depends/patches/**',
)
```

Applied to all 3 `hashFiles('depends/**')` sites (Restore-key, restore-keys fallback, Save-key).

## Scope

This PR only touches the **autotools** `linux:` matrix because that's what's on master right now. The `linux-cmake` matrix will gain a depends cache step via PR #234 (`i686-multiprocess`); the narrowed key should be applied there in the same PR (or a follow-up if #234 is close to merging).

## Validation

First post-merge run will cold-miss (new key). Subsequent runs see fewer false invalidations — e.g. editing a `boost.mk` comment or `README.md` no longer evicts the win64-cross / arm / etc. caches.

Refs #217.