### PR TITLE
ci(cmake): bump linux-cmake timeout to 180 min for fuzz job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,12 @@ jobs:
   linux-cmake:
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    # 180 min matches the autotools `linux:` job above. The fuzz matrix
+    # entry (#233) regularly takes 45-70 min wall-clock between build and
+    # harness run, which overruns a 60 min budget; every other matrix
+    # entry finishes well under 60 min, so the higher ceiling only costs
+    # us in pathological hangs.
+    timeout-minutes: 180
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

PR #233 migrated the `fuzz` matrix entry from the autotools `linux:` job (timeout-minutes: 180) to the new `linux-cmake:` job (timeout-minutes: 60). The autotools fuzz runs historically took 43–67 minutes wall-clock, so the migration silently squeezed the budget below typical runtime. Every fuzz run on master since the merge has been cancelled at the 60 min mark.

| run | sha | fuzz duration | result |
| --- | --- | --- | --- |
| 24957598174 | ffa8557 | 65.5 min | ✓ |
| 25374840884 | be676ee | 60.0 min | ✓ |
| 25625502401 | a102d9a | 67.0 min | ✓ |
| 25825806956 | 5c424d9 | 43.9 min | ✓ |
| 25962703695 | c047c48 | 67.0 min | ✓ (last pre-migration) |
| 25992593980 | 2decaa1 | 60.0 min | cancelled (post-migration, #233 merged) |
| 25992626365 | e43772c | 60.0 min | cancelled |
| 25992652530 | 215e080 | 60.0 min | cancelled |

This restores the previous timeout. Every other `linux-cmake` matrix entry finishes in under 30 min, so the higher ceiling only matters for pathological hangs.

## Test plan

- [ ] Wait for `linux-cmake / Ubuntu 24.04, fuzzer, ASan + UBSan + integer, no depends (CMake)` job to complete (not cancelled) on this PR.
- [ ] Confirm wall-clock duration falls in the historical 43–70 min window.