### PR TITLE
ci: migrate tsan job to CMake (follow-up to #233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,11 +363,6 @@ jobs:
             file_env: ./ci/test/00_setup_env_i686_centos.sh
             runner: ubuntu-24.04
 
-          - name: tsan
-            label: 'Ubuntu 24.04, ThreadSanitizer, depends'
-            file_env: ./ci/test/00_setup_env_native_tsan.sh
-            runner: ubuntu-24.04
-
           - name: msan
             label: 'Ubuntu 22.04, MemorySanitizer, depends'
             file_env: ./ci/test/00_setup_env_native_msan.sh
@@ -613,6 +608,62 @@ jobs:
               "-DAPPEND_CFLAGS=-ftrivial-auto-var-init=pattern"
               "-DAPPEND_CXXFLAGS=-ftrivial-auto-var-init=pattern"
             fuzz: true
+
+          # Replaces the autotools `tsan` matrix entry
+          # (ci/test/00_setup_env_native_tsan.sh).
+          #
+          # Uses depends with HOST=x86_64-pc-linux-gnu (native). Because host ==
+          # build, toolchain.cmake sets crosscompiling=FALSE and does NOT set
+          # CMAKE_SYSTEM_NAME, so CMake does not enter cross-compile mode. The
+          # toolchain still wires up the depends-installed libraries and headers.
+          #
+          # depends_opts passes CC=clang-17 (mirrors DEP_OPTS CC=clang-17) and
+          # NO_OPENMP=1 to skip building depends/libomp — OpenMP inside MCL
+          # (parallel MSM) races with libomp in ways ThreadSanitizer flags as
+          # false-positive data races; the TSan job intentionally runs
+          # single-threaded through the BLSCT crypto path.
+          #
+          # -stdlib=libc++ is passed via CMAKE_CXX_FLAGS / CMAKE_EXE_LINKER_FLAGS
+          # / CMAKE_SHARED_LINKER_FLAGS rather than through the CXX env var or
+          # depends_opts CXX because CMake strips compiler flags out of CXX
+          # during compiler detection (the same reason no-wallet-libblsct and
+          # nowallet-libnaviokernel use this pattern). Passing it through DEP_OPTS
+          # CXX would propagate it into depends package configure scripts, causing
+          # libstdc++/libc++ mixing in the bls/mcl subprojects.
+          #
+          # autotools → CMake flag mapping:
+          #   --with-sanitizers=thread → -DSANITIZERS=thread
+          #   --disable-openmp         → -DWITH_MCL_OPENMP=OFF (also NO_OPENMP=1 in
+          #                              depends_opts to skip the libomp port build)
+          #   --enable-zmq             → -DWITH_ZMQ=ON
+          #   CPPFLAGS=-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION
+          #                            → "-DAPPEND_CPPFLAGS=-DARENA_DEBUG
+          #                               -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"
+          #   CXXFLAGS=-g              → "-DAPPEND_CXXFLAGS=-g"
+          #   CXX='clang++-17 -stdlib=libc++' (DEP_OPTS)
+          #                            → -DCMAKE_CXX_FLAGS=-stdlib=libc++
+          #                               -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
+          #                               -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++
+          - name: tsan
+            label: 'Ubuntu 24.04, ThreadSanitizer, depends (CMake)'
+            runner: ubuntu-24.04
+            packages: >-
+              clang-17 llvm-17 libclang-rt-17-dev libc++abi-17-dev libc++-17-dev
+              python3-zmq
+            cc: clang-17
+            cxx: clang++-17
+            depends_host: x86_64-pc-linux-gnu
+            depends_opts: CC=clang-17 NO_OPENMP=1
+            cmake_flags: >-
+              -DSANITIZERS=thread
+              -DWITH_MCL_OPENMP=OFF
+              -DWITH_ZMQ=ON
+              "-DAPPEND_CPPFLAGS=-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"
+              "-DAPPEND_CXXFLAGS=-g"
+              -DCMAKE_CXX_FLAGS=-stdlib=libc++
+              -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
+              -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++
+            run_unit_tests: true
 
           - name: nowallet-libnaviokernel
             label: 'Ubuntu 22.04, no wallet, libnaviokernel (CMake)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,7 +653,7 @@ jobs:
             cc: clang-17
             cxx: clang++-17
             depends_host: x86_64-pc-linux-gnu
-            depends_opts: CC=clang-17 NO_OPENMP=1
+            depends_opts: CC=clang-17 CXX='clang++-17 -stdlib=libc++' NO_OPENMP=1
             cmake_flags: >-
               -DSANITIZERS=thread
               -DWITH_MCL_OPENMP=OFF

--- a/cmake/bls.cmake
+++ b/cmake/bls.cmake
@@ -134,9 +134,12 @@ else()
       # letter, so append " r".
       "AR=${CMAKE_AR} r"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
-      # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
+      # so CMAKE_CXX_FLAGS is passed here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.
-      "CFLAGS_USER=${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+      # CMAKE_C_FLAGS is intentionally NOT merged: depends toolchains can
+      # set -std=c11 in CMAKE_C_FLAGS, which clang++ rejects when the same
+      # string is reused for .cpp compilation.
+      "CFLAGS_USER=${CMAKE_CXX_FLAGS}"
       "LDFLAGS=${CMAKE_EXE_LINKER_FLAGS}"
       -C ${MCL_SRC_DIR}
       lib/libmcl.a
@@ -166,9 +169,12 @@ else()
       # See mcl_build above for why AR must be forwarded explicitly.
       "AR=${CMAKE_AR} r"
       # mcl/bls Makefiles only consult CFLAGS for both C and C++ compilation,
-      # so CMAKE_CXX_FLAGS gets merged in here to propagate things like
+      # so CMAKE_CXX_FLAGS is passed here to propagate things like
       # -stdlib=libc++ that would otherwise be lost between cmake and make.
-      "CFLAGS_USER=${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+      # CMAKE_C_FLAGS is intentionally NOT merged: depends toolchains can
+      # set -std=c11 in CMAKE_C_FLAGS, which clang++ rejects when the same
+      # string is reused for .cpp compilation.
+      "CFLAGS_USER=${CMAKE_CXX_FLAGS}"
       "LDFLAGS=${CMAKE_EXE_LINKER_FLAGS}"
       -C ${BLS_SRC_DIR}
       lib/libbls384_256.a


### PR DESCRIPTION
## Summary

- Removes the `tsan` entry from the autotools `linux:` matrix (`ci/test/00_setup_env_native_tsan.sh`).
- Adds an equivalent `tsan` entry to the CMake `linux-cmake:` matrix.
- Uses `depends` with `HOST=x86_64-pc-linux-gnu` (native build); since host == build, `toolchain.cmake` sets `crosscompiling=FALSE` so CMake does not enter cross-compile mode while still picking up depends-installed libraries and headers.

## What changed

Autotools → CMake flag mapping:

| autotools (`BITCOIN_CONFIG` / `DEP_OPTS`) | CMake equivalent |
|---|---|
| `--with-sanitizers=thread` | `-DSANITIZERS=thread` |
| `--disable-openmp` | `-DWITH_MCL_OPENMP=OFF` + `NO_OPENMP=1` in `depends_opts` |
| `--enable-zmq` | `-DWITH_ZMQ=ON` |
| `CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION'` | `"-DAPPEND_CPPFLAGS=-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION"` |
| `CXXFLAGS='-g'` | `"-DAPPEND_CXXFLAGS=-g"` |
| `CXX='clang++-17 -stdlib=libc++'` (DEP_OPTS) | `-DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++` |

**OpenMP disabled at both layers:** `NO_OPENMP=1` in `depends_opts` skips the `libomp` port build; `-DWITH_MCL_OPENMP=OFF` disables it at the CMake configure level. OpenMP inside MCL (parallel MSM) races with libomp in ways ThreadSanitizer flags as false-positive data races — the TSan job intentionally keeps the BLSCT crypto path single-threaded.

**libc++ flag routing:** `-stdlib=libc++` is passed via `CMAKE_CXX_FLAGS` / `CMAKE_EXE_LINKER_FLAGS` / `CMAKE_SHARED_LINKER_FLAGS` rather than through the `CXX` env var or `depends_opts CXX`. CMake strips compiler flags from `CXX` during compiler detection, which would cause libstdc++/libc++ mixing in the bls/mcl subprojects. This mirrors the pattern from `no-wallet-libblsct` and `nowallet-libnaviokernel`.

Template PRs: #233 (fuzz/sanitizer CMake pattern), #235 (win64 depends path).

## Test plan

- [ ] `linux-cmake / Ubuntu 24.04, ThreadSanitizer, depends (CMake)` job passes in CI.
- [ ] `linux / Ubuntu 24.04, ThreadSanitizer, depends` entry no longer appears in CI (removed from autotools matrix).
- [ ] Unit tests (`run_unit_tests: true`) run and pass under TSan.
- [ ] No functional tests run (not set — matches autotools job behaviour).
- [ ] TSan does not report data races in the BLSCT crypto path (OpenMP disabled).