### PR TITLE
ci: migrate i686-centos job to CMake (follow-up to #234)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1202,6 +1202,11 @@ jobs:
             dnf config-manager --set-enabled crb
             # CentOS Stream 9 ships Python 3.9; navio CMakeLists requires >=3.10.
             # Install python3.11 from AppStream and shadow /usr/bin/python3.
+            # e2fsprogs (chattr/lsattr) needed by feature_reindex_readonly.py.
+            # centos9 default image ships without it; test framework's
+            # `subprocess.run(['chattr'])` probe raises FileNotFoundError,
+            # falls through without setting the immutable bit, naviod runs
+            # unconstrained and the test times out at --timeout-factor x 60.
             dnf install -y \
               cmake ninja-build pkgconf-pkg-config ccache \
               python3.11 python3.11-pip python3.11-devel \
@@ -1210,41 +1215,12 @@ jobs:
               gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 \
               glibc-devel.i686 libstdc++-devel.i686 \
               git which patch bison perl rsync \
-              xz lbzip2 procps-ng make
+              xz lbzip2 procps-ng make \
+              e2fsprogs
             ln -sf /usr/bin/python3.11 /usr/local/bin/python3
             ln -sf /usr/bin/pip3.11 /usr/local/bin/pip3
             python3.11 -m pip install --break-system-packages pyzmq 2>/dev/null \
               || python3.11 -m pip install pyzmq
-          '
-
-      - name: Probe chattr +i on /tmp/navio_test_runner (debug)
-        # feature_reindex_readonly.py relies on chattr +i being honored by
-        # the filesystem hosting the test_runner scratch dir. Even with
-        # --tmpfs /tmp/navio_test_runner:exec, naviod runs as if the block
-        # file were writable. Verify here whether the kernel actually sets
-        # and enforces EXT4_IMMUTABLE_FL on tmpfs inside this container.
-        run: |
-          docker exec "${CONTAINER_NAME}" bash -c '
-            set +e
-            dnf install -y e2fsprogs >/dev/null
-            cd /tmp/navio_test_runner
-            mountpoint /tmp/navio_test_runner || true
-            findmnt /tmp/navio_test_runner || true
-            touch probe
-            echo "--- lsattr (pre): ---"
-            lsattr probe
-            chattr +i probe
-            echo "chattr +i exit: $?"
-            echo "--- lsattr (post): ---"
-            lsattr probe
-            echo "--- try rm (should fail with EPERM if immutable): ---"
-            rm -f probe
-            echo "rm exit: $?  | still present: $(test -e probe && echo yes || echo no)"
-            echo "--- try write (should fail if immutable): ---"
-            echo hello > probe
-            echo "write exit: $?  | content: $(cat probe 2>/dev/null || true)"
-            chattr -i probe 2>/dev/null
-            rm -f probe
           '
 
       - name: Restore Ccache cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -863,6 +863,11 @@ jobs:
         run: |
           if [ -n "${{ matrix.container }}" ]; then
             # Running inside a CentOS/RHEL container: use dnf, no sudo.
+            # ninja-build, ccache, and lbzip2 live in EPEL (not in the
+            # CentOS Stream 9 base repos), so enable EPEL + CRB first.
+            # CRB (CodeReady Builder) provides some EPEL build deps.
+            dnf install -y epel-release dnf-plugins-core
+            dnf config-manager --set-enabled crb
             # The container image ships Python 3 and pip; install pyzmq
             # (needed by the functional-test runner) via pip after dnf.
             dnf install -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1203,10 +1203,10 @@ jobs:
             # CentOS Stream 9 ships Python 3.9; navio CMakeLists requires >=3.10.
             # Install python3.11 from AppStream and shadow /usr/bin/python3.
             # e2fsprogs (chattr/lsattr) needed by feature_reindex_readonly.py.
-            # centos9 default image ships without it; test framework's
-            # `subprocess.run(['chattr'])` probe raises FileNotFoundError,
-            # falls through without setting the immutable bit, naviod runs
-            # unconstrained and the test times out at --timeout-factor x 60.
+            # centos9 default image ships without it; test framework probes
+            # for the chattr binary, falls through silently when missing,
+            # leaves undo_immutable as a no-op, and naviod runs unconstrained
+            # until --timeout-factor x 60 s elapses.
             dnf install -y \
               cmake ninja-build pkgconf-pkg-config ccache \
               python3.11 python3.11-pip python3.11-devel \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,17 +868,21 @@ jobs:
             # CRB (CodeReady Builder) provides some EPEL build deps.
             dnf install -y epel-release dnf-plugins-core
             dnf config-manager --set-enabled crb
-            # The container image ships Python 3 and pip; install pyzmq
-            # (needed by the functional-test runner) via pip after dnf.
+            # CentOS Stream 9 ships Python 3.9 by default but navio's
+            # CMakeLists requires Python 3.10+ for the functional-test
+            # runner. Install python3.11 from AppStream and shadow the
+            # default /usr/bin/python3 via /usr/local/bin so both cmake
+            # find_package(Python3) and the test runner pick it up.
             dnf install -y \
               cmake ninja-build pkgconf-pkg-config ccache \
-              python3-pip \
+              python3.11 python3.11-pip python3.11-devel \
               libtool automake autoconf \
               libatomic.i686 libatomic.x86_64 \
-              python3-devel \
               ${{ matrix.packages }}
-            pip3 install --break-system-packages pyzmq 2>/dev/null \
-              || pip3 install pyzmq
+            ln -sf /usr/bin/python3.11 /usr/local/bin/python3
+            ln -sf /usr/bin/pip3.11 /usr/local/bin/pip3
+            python3.11 -m pip install --break-system-packages pyzmq 2>/dev/null \
+              || python3.11 -m pip install pyzmq
           else
             if [ -n "${{ matrix.extra_arch }}" ]; then
               sudo dpkg --add-architecture ${{ matrix.extra_arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,6 +873,7 @@ jobs:
             dnf install -y \
               cmake ninja-build pkgconf-pkg-config ccache \
               python3-pip \
+              libtool automake autoconf \
               ${{ matrix.packages }}
             pip3 install --break-system-packages pyzmq 2>/dev/null \
               || pip3 install pyzmq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1227,6 +1227,16 @@ jobs:
         #                 bind ::1.
         # --cap-add=LINUX_IMMUTABLE: feature_reindex_readonly.py runs
         #                 `chattr +i` on a block file.
+        # --tmpfs /tmp/navio_test_runner:exec: the functional test runner
+        #                 places per-test scratch dirs here. On docker's
+        #                 default overlay2 storage the immutable inode
+        #                 attribute from chattr +i is not honored across
+        #                 copy-up boundaries, so feature_reindex_readonly
+        #                 expects naviod to fail-on-write but naviod runs
+        #                 normally and the test times out. tmpfs supports
+        #                 the immutable attribute natively; size left at
+        #                 docker's default (half of total RAM) which is
+        #                 plenty for the test_runner scratch dirs.
         # Mount the workspace and ccache dir bidirectionally so depends/
         # build/ artifacts and the ccache survive across steps as if we
         # were running natively.
@@ -1235,6 +1245,7 @@ jobs:
           docker run -d --name "${CONTAINER_NAME}" \
             --network=host \
             --cap-add=LINUX_IMMUTABLE \
+            --tmpfs /tmp/navio_test_runner:exec \
             -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             -v "${RUNNER_TEMP}/ccache_dir:${RUNNER_TEMP}/ccache_dir" \
             -w "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,17 +425,12 @@ jobs:
     # i686-centos). When the field is absent the expression evaluates to an
     # empty string which GitHub Actions treats as "no container", so all
     # other entries keep running on the bare ubuntu runner unchanged.
-    # When matrix.container_opts or matrix.container_network is set we
-    # resolve to an object form so the extra docker run flags
-    # (--cap-add=LINUX_IMMUTABLE) and network mode (host) reach the
-    # container. fromJSON is used because GHA doesn't allow conditionally
-    # adding object keys via expression interpolation; we build the JSON
-    # by concatenating optional ",key":"value" fragments and parsing.
-    # `network` is undocumented on jobs.<id>.container but the Actions
-    # Runner accepts it and substitutes the value for the otherwise
-    # auto-created github_network_<id> bridge. Required for i686-centos
-    # so the container can use the runner's working IPv6 stack (::1).
-    container: ${{ (matrix.container_opts || matrix.container_network) && fromJSON(format('{{"image":"{0}"{1}{2}}}', matrix.container, matrix.container_opts && format(',"options":"{0}"', matrix.container_opts) || '', matrix.container_network && format(',"network":"{0}"', matrix.container_network) || '')) || matrix.container || '' }}
+    # With i686-centos extracted to its own job (see linux-cmake-centos
+    # below), no remaining linux-cmake matrix entry uses matrix.container,
+    # so the container: directive is back to its original "no container
+    # for any of these jobs" form. Left present (always-empty string) in
+    # case a future matrix entry needs containerised setup again.
+    container: ''
     # 180 min matches the autotools `linux:` job above. The fuzz matrix
     # entry (#233) regularly takes 45-70 min wall-clock between build and
     # harness run, which overruns a 60 min budget; every other matrix
@@ -835,56 +830,19 @@ jobs:
           # host gcc/g++ (no multilib cross-compiler package needed on RHEL —
           # the native gcc accepts -m32 when glibc-devel.i686 is present).
           #
-          # Both unit tests and functional tests run, matching the autotools job.
-          - name: i686-centos
-            label: 'CentOS Stream 9, 32-bit, unit + functional tests (CMake)'
-            runner: ubuntu-24.04
-            container: quay.io/centos/amd64:stream9
-            # Mirrors autotools ci/test/02_run_container.sh:
-            #   --cap-add LINUX_IMMUTABLE: feature_reindex_readonly.py uses
-            #     chattr +i on the block file to simulate a read-only FS.
-            #   net.ipv6.conf.{all,default,lo}.disable_ipv6=0: rpc_bind.py
-            #     --ipv6 and feature_proxy.py (which configures [::1] proxies)
-            #     need IPv6 enabled inside the container. GHA's container:
-            #     directive attaches to a user-defined bridge where Docker
-            #     disables IPv6 on lo (so ::1 vanishes). The `lo` sysctl is
-            #     what restores ::1; the all/default sysctls are belt-and-
-            #     suspenders for any other ifaces.
-            # LINUX_IMMUTABLE is needed for feature_reindex_readonly.py's
-            # chattr +i. Other options were tried (IPv6 sysctls) but only
-            # --network=host (set via container_network below, not via
-            # options) actually fixes rpc_bind --ipv6 / feature_proxy [::1]:
-            # GHA's default github_network_<id> bridge has no IPv6 wired,
-            # so even with disable_ipv6=0 the namespace has no working ::1.
-            container_opts: "--cap-add=LINUX_IMMUTABLE"
-            # `network: host` on jobs.<id>.container replaces the otherwise
-            # auto-created bridge with the host's network namespace, so the
-            # container reuses the runner's IPv6 stack. Cannot be passed via
-            # container_opts because GHA appends its own --network flag and
-            # docker rejects two network modes on one container.
-            container_network: "host"
-            packages: >-
-              gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
-              glibc-devel.i686 libstdc++-devel.i686
-              git which patch bison perl rsync
-              xz lbzip2 procps-ng make
-            cc: gcc
-            cxx: g++
-            depends_host: i686-pc-linux-gnu
-            depends_opts: CC='gcc -m32' CXX='g++ -m32'
-            cmake_flags: >-
-              -DCMAKE_BUILD_TYPE=Release
-              -DWITH_ZMQ=ON
-              -DREDUCE_EXPORTS=ON
-            run_unit_tests: true
-            run_functional_tests: true
-            # ${RUNNER_TEMP} (/__w/_temp) is a bind mount from the host
-            # runner's ext4. chattr +i set on bind-mounted files is not
-            # honored as the test framework expects (naviod still writes to
-            # the "immutable" block file), so feature_reindex_readonly.py
-            # times out. Put the test scratch dir on the container's native
-            # rootfs instead.
-            tmpdirprefix: /tmp/navio_test_runner
+          # NB: i686-centos was historically a linux-cmake matrix entry that
+          # used GHA's container: directive. It is now its own top-level
+          # job (linux-cmake-centos) below because the centos functional
+          # tests need:
+          #   - --network=host (for working ::1 — GHA's auto-created
+          #     github_network_<id> bridge has no IPv6 wired, so [::1]
+          #     binds fail; `network: host` is not accepted on
+          #     jobs.<id>.container by GHA's workflow schema).
+          #   - --cap-add LINUX_IMMUTABLE (for chattr +i in
+          #     feature_reindex_readonly.py).
+          # Both require manual `docker run` so the centos job runs on a
+          # bare ubuntu-24.04 runner and spawns its own container in steps,
+          # mirroring autotools' ci/test/02_run_container.sh.
 
     env:
       CC: ${{ matrix.cc }}
@@ -1231,4 +1189,157 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
+
+  # i686-centos lives in its own job because the centos container needs:
+  #   1) --network=host  (for working ::1; GHA's auto github_network_<id>
+  #      bridge has no IPv6 wired, and `network` is not accepted on
+  #      jobs.<id>.container by GHA's workflow schema);
+  #   2) --cap-add=LINUX_IMMUTABLE  (for chattr +i in
+  #      feature_reindex_readonly.py).
+  # Both are only achievable with a manual `docker run` inside an ubuntu
+  # runner, mirroring autotools' ci/test/02_run_container.sh.
+  linux-cmake-centos:
+    name: 'CentOS Stream 9, 32-bit, unit + functional tests (CMake)'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    env:
+      CC: gcc
+      CXX: g++
+      CCACHE_MAXSIZE: '2G'
+      CONTAINER_IMAGE: quay.io/centos/amd64:stream9
+      CONTAINER_NAME: navio-ci-centos
+      DEPENDS_HOST: i686-pc-linux-gnu
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Pull container image
+        run: docker pull "${CONTAINER_IMAGE}"
+
+      - name: Start container
+        # --network=host: container reuses runner's working IPv6 stack so
+        #                 rpc_bind --ipv6 / feature_proxy [::1] tests can
+        #                 bind ::1.
+        # --cap-add=LINUX_IMMUTABLE: feature_reindex_readonly.py runs
+        #                 `chattr +i` on a block file.
+        # Mount the workspace and ccache dir bidirectionally so depends/
+        # build/ artifacts and the ccache survive across steps as if we
+        # were running natively.
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ccache_dir"
+          docker run -d --name "${CONTAINER_NAME}" \
+            --network=host \
+            --cap-add=LINUX_IMMUTABLE \
+            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            -v "${RUNNER_TEMP}/ccache_dir:${RUNNER_TEMP}/ccache_dir" \
+            -w "${GITHUB_WORKSPACE}" \
+            -e CCACHE_DIR="${RUNNER_TEMP}/ccache_dir" \
+            -e CCACHE_MAXSIZE="${CCACHE_MAXSIZE}" \
+            -e CC="${CC}" \
+            -e CXX="${CXX}" \
+            "${CONTAINER_IMAGE}" \
+            tail -f /dev/null
+
+      - name: Install build dependencies (in container)
+        run: |
+          docker exec "${CONTAINER_NAME}" bash -eu -c '
+            # EPEL + CRB needed for ninja-build, ccache, lbzip2 (not in base).
+            dnf install -y epel-release dnf-plugins-core
+            dnf config-manager --set-enabled crb
+            # CentOS Stream 9 ships Python 3.9; navio CMakeLists requires >=3.10.
+            # Install python3.11 from AppStream and shadow /usr/bin/python3.
+            dnf install -y \
+              cmake ninja-build pkgconf-pkg-config ccache \
+              python3.11 python3.11-pip python3.11-devel \
+              libtool automake autoconf \
+              libatomic.i686 libatomic.x86_64 \
+              gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 \
+              glibc-devel.i686 libstdc++-devel.i686 \
+              git which patch bison perl rsync \
+              xz lbzip2 procps-ng make
+            ln -sf /usr/bin/python3.11 /usr/local/bin/python3
+            ln -sf /usr/bin/pip3.11 /usr/local/bin/pip3
+            python3.11 -m pip install --break-system-packages pyzmq 2>/dev/null \
+              || python3.11 -m pip install pyzmq
+          '
+
+      - name: Restore Ccache cache
+        id: ccache-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.RUNNER_TEMP }}/ccache_dir
+          key: ${{ github.job }}-ccache-${{ github.run_id }}
+          restore-keys: ${{ github.job }}-ccache-
+
+      - name: Restore depends cache
+        uses: actions/cache/restore@v5
+        with:
+          path: depends/${{ env.DEPENDS_HOST }}
+          key: depends-${{ env.DEPENDS_HOST }}-${{ hashFiles('depends/**') }}
+          restore-keys: depends-${{ env.DEPENDS_HOST }}-
+
+      - name: Build depends (in container)
+        run: |
+          docker exec "${CONTAINER_NAME}" bash -eu -c '
+            env -u CC -u CXX make -C depends \
+              HOST='"${DEPENDS_HOST}"' \
+              CC="gcc -m32" CXX="g++ -m32"
+          '
+
+      - name: Save depends cache
+        uses: actions/cache/save@v5
+        with:
+          path: depends/${{ env.DEPENDS_HOST }}
+          key: depends-${{ env.DEPENDS_HOST }}-${{ hashFiles('depends/**') }}
+
+      - name: Configure (in container)
+        run: |
+          docker exec "${CONTAINER_NAME}" bash -eu -c '
+            cmake -B build -G Ninja \
+              -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/depends/'"${DEPENDS_HOST}"'/toolchain.cmake" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DWITH_ZMQ=ON \
+              -DREDUCE_EXPORTS=ON
+          '
+
+      - name: Build (in container)
+        run: docker exec "${CONTAINER_NAME}" cmake --build build
+
+      - name: Run unit tests (in container)
+        run: |
+          docker exec --workdir "${GITHUB_WORKSPACE}/build" "${CONTAINER_NAME}" \
+            ctest --output-on-failure -j"$(nproc)"
+
+      - name: Run functional tests (in container)
+        # --timeout-factor=40 mirrors TEST_RUNNER_TIMEOUT_FACTOR in autotools
+        # ci/test/00_setup_env.sh; slow 32-bit jobs (blsct_htlc, etc.) need it.
+        # tmpdirprefix points at /tmp inside the container (overlayfs) rather
+        # than the bind-mounted workspace, so feature_reindex_readonly's
+        # chattr +i lands on a filesystem that honours immutability.
+        run: |
+          docker exec "${CONTAINER_NAME}" bash -eu -c '
+            mkdir -p /tmp/navio_test_runner
+            build/test/functional/test_runner.py -j"$(nproc)" \
+              --ci --quiet --tmpdirprefix=/tmp/navio_test_runner \
+              --combinedlogslen=99999999 \
+              --timeout-factor=40 \
+              --exclude mempool_limit
+          '
+
+      - name: Stop container
+        if: always()
+        run: |
+          docker stop "${CONTAINER_NAME}" || true
+          docker rm "${CONTAINER_NAME}" || true
+
+      - name: Save Ccache cache
+        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.RUNNER_TEMP }}/ccache_dir
           key: ${{ steps.ccache-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,11 +837,14 @@ jobs:
             # Mirrors autotools ci/test/02_run_container.sh:
             #   --cap-add LINUX_IMMUTABLE: feature_reindex_readonly.py uses
             #     chattr +i on the block file to simulate a read-only FS.
-            #   net.ipv6.conf.all.disable_ipv6=0: rpc_bind.py --ipv6 and
-            #     feature_proxy.py (which configures [::1] proxies) need
-            #     IPv6 enabled inside the container. GHA disables IPv6 by
-            #     default on its container runs.
-            container_opts: "--cap-add=LINUX_IMMUTABLE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0"
+            #   net.ipv6.conf.{all,default,lo}.disable_ipv6=0: rpc_bind.py
+            #     --ipv6 and feature_proxy.py (which configures [::1] proxies)
+            #     need IPv6 enabled inside the container. GHA's container:
+            #     directive attaches to a user-defined bridge where Docker
+            #     disables IPv6 on lo (so ::1 vanishes). The `lo` sysctl is
+            #     what restores ::1; the all/default sysctls are belt-and-
+            #     suspenders for any other ifaces.
+            container_opts: "--cap-add=LINUX_IMMUTABLE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --sysctl net.ipv6.conf.lo.disable_ipv6=0"
             packages: >-
               gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
               glibc-devel.i686 libstdc++-devel.i686
@@ -857,6 +860,13 @@ jobs:
               -DREDUCE_EXPORTS=ON
             run_unit_tests: true
             run_functional_tests: true
+            # ${RUNNER_TEMP} (/__w/_temp) is a bind mount from the host
+            # runner's ext4. chattr +i set on bind-mounted files is not
+            # honored as the test framework expects (naviod still writes to
+            # the "immutable" block file), so feature_reindex_readonly.py
+            # times out. Put the test scratch dir on the container's native
+            # rootfs instead.
+            tmpdirprefix: /tmp/navio_test_runner
 
     env:
       CC: ${{ matrix.cc }}
@@ -1067,11 +1077,25 @@ jobs:
 
       - name: Run functional tests
         if: ${{ matrix.run_functional_tests }}
+        # matrix.tmpdirprefix overrides ${RUNNER_TEMP} for entries that need
+        # an in-container tmpdir. The i686-centos job runs in a container
+        # whose ${RUNNER_TEMP} is a bind mount from the host runner's ext4;
+        # chattr +i on bind-mounted files is not honored as expected by
+        # feature_reindex_readonly.py, so that job points tmpdirprefix at a
+        # native container path (/tmp) where the inode immutability bit
+        # behaves consistently.
+        # --timeout-factor=40 mirrors TEST_RUNNER_TIMEOUT_FACTOR in the
+        # autotools `ci/test/00_setup_env.sh` baseline; slow 32-bit jobs
+        # (e.g. blsct_htlc on i686-centos) need it.
         run: |
+          TMPDIRPREFIX="${{ matrix.tmpdirprefix }}"
+          TMPDIRPREFIX="${TMPDIRPREFIX:-${RUNNER_TEMP}}"
+          mkdir -p "${TMPDIRPREFIX}"
           ${{ matrix.functional_tests_env }} \
             build/test/functional/test_runner.py -j"$(nproc)" \
-            --ci --quiet --tmpdirprefix="${RUNNER_TEMP}" \
+            --ci --quiet --tmpdirprefix="${TMPDIRPREFIX}" \
             --combinedlogslen=99999999 \
+            --timeout-factor=40 \
             --exclude mempool_limit
 
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1217,6 +1217,36 @@ jobs:
               || python3.11 -m pip install pyzmq
           '
 
+      - name: Probe chattr +i on /tmp/navio_test_runner (debug)
+        # feature_reindex_readonly.py relies on chattr +i being honored by
+        # the filesystem hosting the test_runner scratch dir. Even with
+        # --tmpfs /tmp/navio_test_runner:exec, naviod runs as if the block
+        # file were writable. Verify here whether the kernel actually sets
+        # and enforces EXT4_IMMUTABLE_FL on tmpfs inside this container.
+        run: |
+          docker exec "${CONTAINER_NAME}" bash -c '
+            set +e
+            dnf install -y e2fsprogs >/dev/null
+            cd /tmp/navio_test_runner
+            mountpoint /tmp/navio_test_runner || true
+            findmnt /tmp/navio_test_runner || true
+            touch probe
+            echo "--- lsattr (pre): ---"
+            lsattr probe
+            chattr +i probe
+            echo "chattr +i exit: $?"
+            echo "--- lsattr (post): ---"
+            lsattr probe
+            echo "--- try rm (should fail with EPERM if immutable): ---"
+            rm -f probe
+            echo "rm exit: $?  | still present: $(test -e probe && echo yes || echo no)"
+            echo "--- try write (should fail if immutable): ---"
+            echo hello > probe
+            echo "write exit: $?  | content: $(cat probe 2>/dev/null || true)"
+            chattr -i probe 2>/dev/null
+            rm -f probe
+          '
+
       - name: Restore Ccache cache
         id: ccache-cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,73 +344,11 @@ jobs:
           --combinedlogslen=99999999
           --timeout-factor=$env:TEST_RUNNER_TIMEOUT_FACTOR
           $env:TEST_RUNNER_EXTRA --exclude mempool_limit
-  linux:
-    name: ${{ matrix.label }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 180
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Disabled: previous-releases job needs further setup before enabling.
-          # - name: previous-releases
-          #   label: 'Ubuntu 24.04, previous releases, depends, DEBUG'
-          #   file_env: ./ci/test/00_setup_env_native_previous_releases.sh
-          #   runner: ubuntu-24.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Enable IPv6 in Docker daemon
-        run: |
-          echo '{"ipv6":true,"fixed-cidr-v6":"fd00::/80"}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Set MAKEJOBS
-        run: echo "MAKEJOBS=-j$(nproc)" >> "$GITHUB_ENV"
-
-      - name: Restore cache
-        uses: actions/cache/restore@v5
-        with:
-          path: /tmp/ci-cache/${{ matrix.name }}
-          # Narrow the depends hash to the files that actually drive a
-          # rebuild: package recipes, the framework Makefile/funcs.mk,
-          # builders/hosts/patches. Editing depends/README.md or any
-          # uninstalled/staging .stamp would otherwise invalidate every
-          # triplet cache for every job. See issue #217.
-          key:
-            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
-            'depends/funcs.mk', 'depends/packages/**',
-            'depends/builders/**', 'depends/hosts/**',
-            'depends/patches/**') }}-${{ github.sha }}
-          restore-keys: |
-            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
-            'depends/funcs.mk', 'depends/packages/**',
-            'depends/builders/**', 'depends/hosts/**',
-            'depends/patches/**') }}-
-            ci-${{ matrix.name }}-
-
-      - name: Run CI
-        env:
-          FILE_ENV: ${{ matrix.file_env }}
-          CI_HOST_CACHE_DIR: /tmp/ci-cache/${{ matrix.name }}
-        run: ./ci/test_run_all.sh
-
-      - name: Save cache
-        if: always()
-        uses: actions/cache/save@v5
-        with:
-          path: /tmp/ci-cache/${{ matrix.name }}
-          # Same narrowed key as Restore cache above; see comment there.
-          key:
-            ci-${{ matrix.name }}-${{ hashFiles('depends/Makefile',
-            'depends/funcs.mk', 'depends/packages/**',
-            'depends/builders/**', 'depends/hosts/**',
-            'depends/patches/**') }}-${{ github.sha }}
+  # Autotools `linux:` matrix job removed: with arm/tsan/msan/i686-centos
+  # all migrated to CMake (#250, #251, #252, #253), no autotools matrix
+  # entries remain. The `previous-releases` stub was commented out and
+  # never enabled. Restore from git history if a non-CMake linux scenario
+  # ever needs to come back.
 
   # CMake-driven matrix. Mirrors the structure of the autotools `linux:` matrix
   # so scenarios can be added by appending one entry. Each entry supplies its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,7 @@ jobs:
               cmake ninja-build pkgconf-pkg-config ccache \
               python3-pip \
               libtool automake autoconf \
+              libatomic.i686 libatomic.x86_64 \
               ${{ matrix.packages }}
             pip3 install --break-system-packages pyzmq 2>/dev/null \
               || pip3 install pyzmq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,7 +844,15 @@ jobs:
             #     disables IPv6 on lo (so ::1 vanishes). The `lo` sysctl is
             #     what restores ::1; the all/default sysctls are belt-and-
             #     suspenders for any other ifaces.
-            container_opts: "--cap-add=LINUX_IMMUTABLE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --sysctl net.ipv6.conf.lo.disable_ipv6=0"
+            # --network host: the IPv6 sysctls alone do not bring ::1 up on
+            # GHA's user-defined `github_network_<id>` bridge (the network
+            # itself has no IPv6 configured, so the container netns starts
+            # without working ::1 even with disable_ipv6=0). Sharing the
+            # host's network namespace inherits the runner's working IPv6
+            # stack, mirroring what autotools' `docker run` (default bridge
+            # + host inheritance) gets. Resolves rpc_bind --ipv6 and
+            # feature_proxy [::1] tests.
+            container_opts: "--cap-add=LINUX_IMMUTABLE --network=host"
             packages: >-
               gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
               glibc-devel.i686 libstdc++-devel.i686

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,6 +875,7 @@ jobs:
               python3-pip \
               libtool automake autoconf \
               libatomic.i686 libatomic.x86_64 \
+              python3-devel \
               ${{ matrix.packages }}
             pip3 install --break-system-packages pyzmq 2>/dev/null \
               || pip3 install pyzmq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,11 +425,17 @@ jobs:
     # i686-centos). When the field is absent the expression evaluates to an
     # empty string which GitHub Actions treats as "no container", so all
     # other entries keep running on the bare ubuntu runner unchanged.
-    # When matrix.container_opts is set we resolve to an object form so the
-    # extra docker run flags (e.g. --cap-add=LINUX_IMMUTABLE, IPv6 sysctl)
-    # reach the container. fromJSON is used because GHA doesn't allow
-    # conditionally adding object keys via expression interpolation.
-    container: ${{ matrix.container_opts && fromJSON(format('{{"image":"{0}","options":"{1}"}}', matrix.container, matrix.container_opts)) || matrix.container || '' }}
+    # When matrix.container_opts or matrix.container_network is set we
+    # resolve to an object form so the extra docker run flags
+    # (--cap-add=LINUX_IMMUTABLE) and network mode (host) reach the
+    # container. fromJSON is used because GHA doesn't allow conditionally
+    # adding object keys via expression interpolation; we build the JSON
+    # by concatenating optional ",key":"value" fragments and parsing.
+    # `network` is undocumented on jobs.<id>.container but the Actions
+    # Runner accepts it and substitutes the value for the otherwise
+    # auto-created github_network_<id> bridge. Required for i686-centos
+    # so the container can use the runner's working IPv6 stack (::1).
+    container: ${{ (matrix.container_opts || matrix.container_network) && fromJSON(format('{{"image":"{0}"{1}{2}}}', matrix.container, matrix.container_opts && format(',"options":"{0}"', matrix.container_opts) || '', matrix.container_network && format(',"network":"{0}"', matrix.container_network) || '')) || matrix.container || '' }}
     # 180 min matches the autotools `linux:` job above. The fuzz matrix
     # entry (#233) regularly takes 45-70 min wall-clock between build and
     # harness run, which overruns a 60 min budget; every other matrix
@@ -844,15 +850,19 @@ jobs:
             #     disables IPv6 on lo (so ::1 vanishes). The `lo` sysctl is
             #     what restores ::1; the all/default sysctls are belt-and-
             #     suspenders for any other ifaces.
-            # --network host: the IPv6 sysctls alone do not bring ::1 up on
-            # GHA's user-defined `github_network_<id>` bridge (the network
-            # itself has no IPv6 configured, so the container netns starts
-            # without working ::1 even with disable_ipv6=0). Sharing the
-            # host's network namespace inherits the runner's working IPv6
-            # stack, mirroring what autotools' `docker run` (default bridge
-            # + host inheritance) gets. Resolves rpc_bind --ipv6 and
-            # feature_proxy [::1] tests.
-            container_opts: "--cap-add=LINUX_IMMUTABLE --network=host"
+            # LINUX_IMMUTABLE is needed for feature_reindex_readonly.py's
+            # chattr +i. Other options were tried (IPv6 sysctls) but only
+            # --network=host (set via container_network below, not via
+            # options) actually fixes rpc_bind --ipv6 / feature_proxy [::1]:
+            # GHA's default github_network_<id> bridge has no IPv6 wired,
+            # so even with disable_ipv6=0 the namespace has no working ::1.
+            container_opts: "--cap-add=LINUX_IMMUTABLE"
+            # `network: host` on jobs.<id>.container replaces the otherwise
+            # auto-created bridge with the host's network namespace, so the
+            # container reuses the runner's IPv6 stack. Cannot be passed via
+            # container_opts because GHA appends its own --network flag and
+            # docker rejects two network modes on one container.
+            container_network: "host"
             packages: >-
               gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
               glibc-devel.i686 libstdc++-devel.i686

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1298,10 +1298,14 @@ jobs:
           key: depends-${{ env.DEPENDS_HOST }}-${{ hashFiles('depends/**') }}
 
       - name: Configure (in container)
+        # ${GITHUB_WORKSPACE} is a runner-side env var that is not set
+        # inside the container; $PWD inside the container resolves to the
+        # workspace because docker run was invoked with -w
+        # "${GITHUB_WORKSPACE}".
         run: |
           docker exec "${CONTAINER_NAME}" bash -eu -c '
             cmake -B build -G Ninja \
-              -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/depends/'"${DEPENDS_HOST}"'/toolchain.cmake" \
+              -DCMAKE_TOOLCHAIN_FILE="$PWD/depends/'"${DEPENDS_HOST}"'/toolchain.cmake" \
               -DCMAKE_BUILD_TYPE=Release \
               -DWITH_ZMQ=ON \
               -DREDUCE_EXPORTS=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -872,6 +872,7 @@ jobs:
             # (needed by the functional-test runner) via pip after dnf.
             dnf install -y \
               cmake ninja-build pkgconf-pkg-config ccache \
+              python3-pip \
               ${{ matrix.packages }}
             pip3 install --break-system-packages pyzmq 2>/dev/null \
               || pip3 install pyzmq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1269,18 +1269,22 @@ jobs:
             ctest --output-on-failure -j"$(nproc)"
 
       - name: Run functional tests (in container)
-        # --timeout-factor=40 mirrors TEST_RUNNER_TIMEOUT_FACTOR in autotools
-        # ci/test/00_setup_env.sh; slow 32-bit jobs (blsct_htlc, etc.) need it.
-        # tmpdirprefix points at /tmp inside the container (overlayfs) rather
-        # than the bind-mounted workspace, so feature_reindex_readonly's
-        # chattr +i lands on a filesystem that honours immutability.
+        # --timeout-factor=80 (doubled from autotools' 40 in
+        # ci/test/00_setup_env.sh) — 32-bit naviod block-generation for
+        # blsct_unconfirmed_spending overruns the 2400 s budget that
+        # factor=40 produces; bump to 4800 s (=80 x 60 s). Other slow
+        # blsct_* tests already pass under factor=40.
+        # tmpdirprefix points at /tmp inside the container (overlayfs)
+        # rather than the bind-mounted workspace, so
+        # feature_reindex_readonly's chattr +i lands on a filesystem that
+        # honours immutability.
         run: |
           docker exec "${CONTAINER_NAME}" bash -eu -c '
             mkdir -p /tmp/navio_test_runner
             build/test/functional/test_runner.py -j"$(nproc)" \
               --ci --quiet --tmpdirprefix=/tmp/navio_test_runner \
               --combinedlogslen=99999999 \
-              --timeout-factor=40 \
+              --timeout-factor=80 \
               --exclude mempool_limit
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,11 @@ jobs:
     # i686-centos). When the field is absent the expression evaluates to an
     # empty string which GitHub Actions treats as "no container", so all
     # other entries keep running on the bare ubuntu runner unchanged.
-    container: ${{ matrix.container || '' }}
+    # When matrix.container_opts is set we resolve to an object form so the
+    # extra docker run flags (e.g. --cap-add=LINUX_IMMUTABLE, IPv6 sysctl)
+    # reach the container. fromJSON is used because GHA doesn't allow
+    # conditionally adding object keys via expression interpolation.
+    container: ${{ matrix.container_opts && fromJSON(format('{{"image":"{0}","options":"{1}"}}', matrix.container, matrix.container_opts)) || matrix.container || '' }}
     # 180 min matches the autotools `linux:` job above. The fuzz matrix
     # entry (#233) regularly takes 45-70 min wall-clock between build and
     # harness run, which overruns a 60 min budget; every other matrix
@@ -830,6 +834,14 @@ jobs:
             label: 'CentOS Stream 9, 32-bit, unit + functional tests (CMake)'
             runner: ubuntu-24.04
             container: quay.io/centos/amd64:stream9
+            # Mirrors autotools ci/test/02_run_container.sh:
+            #   --cap-add LINUX_IMMUTABLE: feature_reindex_readonly.py uses
+            #     chattr +i on the block file to simulate a read-only FS.
+            #   net.ipv6.conf.all.disable_ipv6=0: rpc_bind.py --ipv6 and
+            #     feature_proxy.py (which configures [::1] proxies) need
+            #     IPv6 enabled inside the container. GHA disables IPv6 by
+            #     default on its container runs.
+            container_opts: "--cap-add=LINUX_IMMUTABLE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0"
             packages: >-
               gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
               glibc-devel.i686 libstdc++-devel.i686

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,11 +353,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: i686-centos
-            label: 'CentOS Stream 9, 32-bit, dash, unit + functional tests'
-            file_env: ./ci/test/00_setup_env_i686_centos.sh
-            runner: ubuntu-24.04
-
           # Disabled: previous-releases job needs further setup before enabling.
           # - name: previous-releases
           #   label: 'Ubuntu 24.04, previous releases, depends, DEBUG'
@@ -426,6 +421,11 @@ jobs:
   linux-cmake:
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
+    # container is only set for entries that supply matrix.container (e.g.
+    # i686-centos). When the field is absent the expression evaluates to an
+    # empty string which GitHub Actions treats as "no container", so all
+    # other entries keep running on the bare ubuntu runner unchanged.
+    container: ${{ matrix.container || '' }}
     # 180 min matches the autotools `linux:` job above. The fuzz matrix
     # entry (#233) regularly takes 45-70 min wall-clock between build and
     # harness run, which overruns a 60 min budget; every other matrix
@@ -788,6 +788,64 @@ jobs:
               file ./build/lib/libnaviokernel.so
               test -x ./build/bin/navio-chainstate
 
+          # Replaces the autotools `i686-centos` matrix entry.
+          # Runs inside a CentOS Stream 9 container (quay.io/centos/amd64:stream9)
+          # to preserve the distinct coverage the autotools job provided:
+          #   - older glibc than Ubuntu 24.04 noble (CentOS Stream 9 ≈ glibc 2.34)
+          #   - gcc/g++ from CentOS Stream 9 toolset instead of Ubuntu clang
+          #   - rpm/dnf package universe (different from Debian/apt)
+          # This faithfully ports the autotools job's container rather than
+          # collapsing it into an Ubuntu runner like #234 (i686-multiprocess)
+          # did, because the CentOS-glibc/gcc surface is the unique coverage
+          # value this job was set up to provide.
+          #
+          # apt → dnf package mapping:
+          #   build-essential cmake ninja-build pkgconf ccache →
+          #     gcc-c++ make cmake ninja-build pkgconf-pkg-config ccache
+          #   g++-multilib (32-bit ABI) →
+          #     glibc-devel.i686 libstdc++-devel.i686  (multilib via gcc native)
+          #   python3-zmq → pip3 install pyzmq  (no dnf package)
+          #   other tools: git which patch bison perl rsync xz
+          #                lbzip2 procps-ng (provides nproc)
+          #
+          # Autotools CONFIG_SHELL=/bin/dash forced ./configure to run under
+          # dash. CMake has no configure script, so there is no shell to
+          # override; dash is installed but plays no role in the build.
+          #
+          # Autotools NO_WERROR=1 suppressed "#warning _FORTIFY_SOURCE > 2 is
+          # treated like 2 on this platform [-Werror=cpp]" emitted by CentOS
+          # GCC during ./configure. In CMake, the FORTIFY_SOURCE probe inside
+          # TryAppendCXXFlags.cmake compiles a small test with -Werror; on
+          # CentOS GCC the #warning turns the probe into a compile error, so
+          # cxx_supports_fortify_source is set to false and _FORTIFY_SOURCE=3
+          # is silently not applied to the actual build. No explicit
+          # -Wno-error=cpp flag is needed.
+          #
+          # depends_opts: CC/CXX use -m32 to produce 32-bit objects from the
+          # host gcc/g++ (no multilib cross-compiler package needed on RHEL —
+          # the native gcc accepts -m32 when glibc-devel.i686 is present).
+          #
+          # Both unit tests and functional tests run, matching the autotools job.
+          - name: i686-centos
+            label: 'CentOS Stream 9, 32-bit, unit + functional tests (CMake)'
+            runner: ubuntu-24.04
+            container: quay.io/centos/amd64:stream9
+            packages: >-
+              gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64
+              glibc-devel.i686 libstdc++-devel.i686
+              git which patch bison perl rsync
+              xz lbzip2 procps-ng make
+            cc: gcc
+            cxx: g++
+            depends_host: i686-pc-linux-gnu
+            depends_opts: CC='gcc -m32' CXX='g++ -m32'
+            cmake_flags: >-
+              -DCMAKE_BUILD_TYPE=Release
+              -DWITH_ZMQ=ON
+              -DREDUCE_EXPORTS=ON
+            run_unit_tests: true
+            run_functional_tests: true
+
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
@@ -803,13 +861,24 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          if [ -n "${{ matrix.extra_arch }}" ]; then
-            sudo dpkg --add-architecture ${{ matrix.extra_arch }}
+          if [ -n "${{ matrix.container }}" ]; then
+            # Running inside a CentOS/RHEL container: use dnf, no sudo.
+            # The container image ships Python 3 and pip; install pyzmq
+            # (needed by the functional-test runner) via pip after dnf.
+            dnf install -y \
+              cmake ninja-build pkgconf-pkg-config ccache \
+              ${{ matrix.packages }}
+            pip3 install --break-system-packages pyzmq 2>/dev/null \
+              || pip3 install pyzmq
+          else
+            if [ -n "${{ matrix.extra_arch }}" ]; then
+              sudo dpkg --add-architecture ${{ matrix.extra_arch }}
+            fi
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              build-essential cmake ninja-build pkgconf ccache \
+              ${{ matrix.packages }}
           fi
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkgconf ccache \
-            ${{ matrix.packages }}
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- Removes `i686-centos` from the autotools `linux:` matrix
- Adds `i686-centos` to the `linux-cmake:` matrix, running inside **CentOS Stream 9** (`quay.io/centos/amd64:stream9`)
- Extends `linux-cmake:` with `container: ${{ matrix.container || '' }}` so other entries (tidy, fuzz, win64, etc.) are unaffected
- Updates the "Install build dependencies" step to use `dnf` when inside a container, `apt-get` otherwise

## Container vs Ubuntu decision

Unlike #234 (i686-multiprocess) which dropped the container in favour of `ubuntu-24.04 + g++-multilib`, this entry keeps the CentOS Stream 9 container because its unique coverage value is:

- Older glibc than Ubuntu noble (CentOS Stream 9 ≈ glibc 2.34 vs noble 2.39)
- CentOS gcc toolset rather than Ubuntu clang
- rpm/dnf package universe (exercises a different build environment)

Collapsing to Ubuntu would duplicate the i686-multiprocess entry without adding new coverage. Per `feedback_cmake_port_no_feature_drop` memory: coverage must not be dropped to make migration easier.

## Flag mapping table

| Autotools | CMake | Notes |
|-----------|-------|-------|
| `--enable-zmq` | `-DWITH_ZMQ=ON` | verified in `CMakeLists.txt:100` |
| `--enable-reduce-exports` | `-DREDUCE_EXPORTS=ON` | verified in `CMakeLists.txt:96` |
| `HOST=i686-pc-linux-gnu` | `depends_host: i686-pc-linux-gnu` | direct |
| `CC='gcc -m32' CXX='g++ -m32'` | `depends_opts: CC='gcc -m32' CXX='g++ -m32'` | direct |
| `CI_IMAGE_NAME_TAG=quay.io/centos/amd64:stream9` | `container: quay.io/centos/amd64:stream9` | native GH Actions container |

## What didn't translate

**`CONFIG_SHELL=/bin/dash`**: The autotools `./configure` accepted a shell override. CMake has no configure script, so this setting has no equivalent and is a no-op. Noted in matrix comment.

**`NO_WERROR=1`**: Autotools emitted `#warning _FORTIFY_SOURCE > 2 is treated like 2 [-Werror=cpp]` during `./configure`. In CMake, `TryAppendCXXFlags.cmake` probes `_FORTIFY_SOURCE=3` with `-Werror`; the `#warning` causes the probe to fail on CentOS GCC, so `_FORTIFY_SOURCE=3` is silently omitted from actual compile flags. No explicit `-Wno-error=cpp` flag is needed.

**`PIP_PACKAGES=pyzmq`**: No `python3-zmq` dnf package exists for CentOS Stream 9. Installed via `pip3 install pyzmq` in the dnf branch of the dependency step. The `--break-system-packages` flag is tried first (Python 3.12+) with fallback to bare `pip3 install`.

## apt → dnf package translation

| apt (Ubuntu) | dnf (CentOS Stream 9) |
|---|---|
| `build-essential` | `gcc-c++ make` |
| `cmake ninja-build pkgconf ccache` | `cmake ninja-build pkgconf-pkg-config ccache` |
| `g++-multilib` | `glibc-devel.i686 libstdc++-devel.i686` (native gcc -m32) |
| `python3-zmq` | `pip3 install pyzmq` |
| (implicit) `git patch bison perl rsync xz procps-ng` | same names |
| (implicit) `lbzip2` | `lbzip2` |

## Test plan

- [ ] CI passes for all existing `linux-cmake:` entries (tidy, no-wallet-libblsct, i686-multiprocess, win64, fuzz, nowallet-libnaviokernel) — container line must be a no-op for them
- [ ] New `i686-centos` entry: depends builds clean with `CC='gcc -m32' CXX='g++ -m32'`
- [ ] CMake configure picks up the toolchain; `WITH_ZMQ=ON` and `REDUCE_EXPORTS=ON` appear in configure summary
- [ ] Unit tests (`ctest`) pass
- [ ] Functional tests (`test_runner.py`) pass