### PR TITLE
ci: smoke-test naviod / navio-cli / navio-tx / navio-util / navio-wallet / navio-staker -version on every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             -DWITH_ZMQ=ON \
             -DWITH_USDT=ON
           cmake --build build -j"$(nproc)"
+          ci/smoke_test_binaries.sh build
           ctest --test-dir build -j"$(nproc)" --output-on-failure
           build/test/functional/test_runner.py -j "$(( $(nproc) * 2 ))" \
             --ci --quiet --tmpdirprefix="${RUNNER_TEMP}" \
@@ -196,6 +197,13 @@ jobs:
 
       - name: Build
         run: cmake --build build -j"$(sysctl -n hw.ncpu)"
+
+      - name: Smoke test binaries
+        # Reproduces aguycalled's macOS rpath regression class: catches
+        # dyld load failures (`@rpath/libevent_pthreads-*.dylib not loaded`,
+        # missing LC_RPATH) that ctest masks because it only execs
+        # test_navio, not the production binaries.
+        run: ci/smoke_test_binaries.sh build
 
       - name: Run unit tests
         working-directory: build
@@ -294,6 +302,10 @@ jobs:
       - name: Build
         shell: cmd
         run: cmake --build build --config Release
+
+      - name: Smoke test binaries
+        shell: bash
+        run: ci/smoke_test_binaries.sh build
 
       - name: Save vcpkg binary cache
         uses: actions/cache/save@v5
@@ -404,6 +416,7 @@ jobs:
               -DAPPEND_CPPFLAGS=-I/usr/lib/llvm-17/lib/clang/17/include
               "-DAPPEND_CXXFLAGS=-O0 -g0"
             tidy: true
+            smoke_test_binaries: true
 
           # Replaces the autotools `no-wallet-libblsct` matrix entry.
           # clang-13 (Bullseye default) is not packaged for Ubuntu 24.04 apt;
@@ -457,6 +470,7 @@ jobs:
               -DWITH_MULTIPROCESS=ON
               "-DAPPEND_CPPFLAGS=-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
             run_unit_tests: true
+            smoke_test_binaries: true
 
           # Replaces the autotools `win64` matrix entry.
           # MinGW cross via depends. Gap 1 (ZeroMQ pkg-config path) was
@@ -488,6 +502,7 @@ jobs:
               -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine
               "-DAPPEND_CXXFLAGS=-Wno-return-type"
             run_unit_tests: true
+            smoke_test_binaries: true
             # system_tests/run_command expects a specific Win32 error code
             # for a non-existent command (6), but wine returns 2 instead —
             # this is a known wine-version-sensitive expectation. Skip the
@@ -515,6 +530,10 @@ jobs:
             cmake_flags: >-
               -DCMAKE_BUILD_TYPE=Release
               -DREDUCE_EXPORTS=ON
+            # mac-cross produces Mach-O binaries on a Linux runner; no
+            # emulator is wired so the smoke step falls back to `file`
+            # shape probes (see ci/smoke_test_binaries.sh).
+            smoke_test_binaries: true
 
           # Replaces the autotools `arm` matrix entry (00_setup_env_arm.sh).
           # 32-bit ARM hard-float cross via depends (arm-linux-gnueabihf).
@@ -543,6 +562,7 @@ jobs:
               -DREDUCE_EXPORTS=ON
               "-DAPPEND_CXXFLAGS=-Wno-psabi"
             run_unit_tests: true
+            smoke_test_binaries: true
 
           # Replaces the `no-wallet-libnaviokernel` autotools matrix entry.
           # -stdlib=libc++ is passed via CMAKE_{CXX,EXE_LINKER}_FLAGS rather
@@ -624,6 +644,7 @@ jobs:
               -DCMAKE_CXX_FLAGS=-stdlib=libc++
               -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
               -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++
+            smoke_test_binaries: true
 
           # Replaces the autotools `msan` matrix entry (removed from linux: above).
           # MSan requires that *every* memory operation — including the C++ standard
@@ -700,6 +721,7 @@ jobs:
               "-DCMAKE_SHARED_LINKER_FLAGS=-L/msan/cxx_build/lib -Wl,-rpath,/msan/cxx_build/lib -lc++ -lc++abi -fsanitize=memory"
             msan: true
             run_unit_tests: true
+            smoke_test_binaries: true
 
           - name: nowallet-libnaviokernel
             label: 'Ubuntu 22.04, no wallet, libnaviokernel (CMake)'
@@ -722,11 +744,11 @@ jobs:
               -DBUILD_TX=ON
               -DBUILD_UTIL=ON
               -DENABLE_EXTERNAL_SIGNER=OFF
+            smoke_test_binaries: true
+            # Binary -version smoke is covered by smoke_test_binaries above;
+            # the per-job smoke_test command stays focused on the
+            # libnaviokernel-specific artifacts unique to this matrix entry.
             smoke_test: |
-              ./build/bin/naviod -version
-              ./build/bin/navio-cli --help | head -5
-              ./build/bin/navio-tx -help | head -5
-              ./build/bin/navio-util -help | head -5
               test -f ./build/lib/libnaviokernel.so
               file ./build/lib/libnaviokernel.so
               test -x ./build/bin/navio-chainstate
@@ -981,6 +1003,21 @@ jobs:
 
       - name: Build
         run: cmake --build build
+
+      - name: Smoke test binaries
+        # Runs `-version` on each built navio binary (or `file` for cross
+        # builds with no emulator) to catch load-time failures (rpath,
+        # ABI, runtime dep) that ctest can miss since it only execs
+        # test_navio. The matrix.win64 entry sets CMAKE_CROSSCOMPILING_EMULATOR
+        # so wine is used automatically; mac-cross sets NAVIO_SMOKE_NO_EXEC
+        # so the script does a `file` shape probe instead of trying to
+        # exec a Mach-O on Linux (where +x is set but the kernel returns
+        # ENOEXEC).
+        if: ${{ matrix.smoke_test_binaries }}
+        env:
+          CMAKE_CROSSCOMPILING_EMULATOR: ${{ matrix.depends_host == 'x86_64-w64-mingw32' && '/usr/bin/wine' || '' }}
+          NAVIO_SMOKE_NO_EXEC: ${{ contains(matrix.depends_host, 'darwin') && '1' || '' }}
+        run: ci/smoke_test_binaries.sh build
 
       - name: Run unit tests
         if: ${{ matrix.run_unit_tests }}
@@ -1268,6 +1305,9 @@ jobs:
 
       - name: Build (in container)
         run: docker exec "${CONTAINER_NAME}" cmake --build build
+
+      - name: Smoke test binaries (in container)
+        run: docker exec "${CONTAINER_NAME}" ci/smoke_test_binaries.sh build
 
       - name: Run unit tests (in container)
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,27 @@ if(NOT DEFINED CMAKE_OPTIMIZE_DEPENDENCIES)
 endif()
 
 #=============================
+# RPATH handling
+#=============================
+# Homebrew dylibs (libevent, zeromq, ...) on macOS ship with
+# LC_ID_DYLIB=@rpath/<soname>, so the consuming binary must carry an
+# LC_RPATH that resolves to the directory containing the dylib.
+# CMake's default build-tree RPATH logic only fires when an imported
+# target's location is a concrete path; some Config-package exports use
+# bare -l<name> link flags or generator expressions that miss the
+# default, and binaries are then shipped with no LC_RPATH at all
+# (dyld: "Reason: no LC_RPATH's found"). Force CMake to embed each
+# link-time library directory in the install rpath, and on macOS embed
+# @loader_path/../lib too so binaries stay relocatable next to bundled
+# dylibs. Harmless on Linux/Windows (no LC_RPATH section, ld ignores
+# the @loader_path entry as just another DT_RUNPATH string).
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+if(APPLE)
+  list(APPEND CMAKE_BUILD_RPATH "@loader_path/../lib")
+  list(APPEND CMAKE_INSTALL_RPATH "@loader_path/../lib")
+endif()
+
+#=============================
 # Configurable options
 #=============================
 include(CMakeDependentOption)

--- a/ci/smoke_test_binaries.sh
+++ b/ci/smoke_test_binaries.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026-present The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Smoke test: run -version on every built navio binary.
+#
+# Catches load-time failures (missing rpath, unresolved runtime deps, ABI
+# mismatches) that the unit / functional test suites can miss, because
+# ctest only exercises test_navio — not the production naviod / navio-cli
+# / navio-wallet / navio-staker / navio-tx / navio-util binaries.
+#
+# Cross-compile aware:
+#   - If CMAKE_CROSSCOMPILING_EMULATOR is set (e.g. wine for the Win64
+#     cross matrix entry), invoke each binary through it.
+#   - If NAVIO_SMOKE_NO_EXEC is set (e.g. for the mac-cross matrix
+#     entry on a Linux runner) or the target binary's format does not
+#     match the host kernel, fall back to a `file` shape check so the
+#     smoke step still asserts something useful without tripping
+#     "Exec format error".
+#   - Otherwise execute the binary directly.
+
+export LC_ALL=C
+
+set -euo pipefail
+
+BUILD_DIR="${1:-build}"
+BIN_DIR="${BUILD_DIR}/bin"
+EMULATOR="${CMAKE_CROSSCOMPILING_EMULATOR:-}"
+NO_EXEC="${NAVIO_SMOKE_NO_EXEC:-}"
+
+if [ ! -d "${BIN_DIR}" ]; then
+  echo "::error::No ${BIN_DIR} directory — did the build run?"
+  exit 1
+fi
+
+# Match a binary's format (via `file -b`) against the host kernel so we
+# don't try to exec a Mach-O on Linux (the +x bit is set but the kernel
+# returns ENOEXEC). Returns 0 if exec is safe, 1 otherwise.
+host_kernel="$(uname -s)"
+is_native_format() {
+  local probe
+  probe="$(file -b "$1" 2>/dev/null || true)"
+  case "${host_kernel}" in
+    Linux)        [[ "${probe}" == ELF* ]] ;;
+    Darwin)       [[ "${probe}" == Mach-O* ]] ;;
+    MINGW*|MSYS*|CYGWIN*) [[ "${probe}" == PE32* ]] ;;
+    *) return 1 ;;
+  esac
+}
+
+# Detect output suffix (.exe on mingw / MSVC builds, empty otherwise) by
+# probing for naviod first since every navio config produces it (except
+# libblsct-only / fuzz-only builds, which this script is not wired into).
+suffix=""
+for cand in naviod naviod.exe; do
+  if [ -e "${BIN_DIR}/${cand}" ]; then
+    case "${cand}" in *.exe) suffix=".exe" ;; esac
+    break
+  fi
+done
+
+binaries=(naviod navio-cli navio-tx navio-util navio-wallet navio-staker)
+fail=0
+ran=0
+
+for base in "${binaries[@]}"; do
+  bin="${BIN_DIR}/${base}${suffix}"
+  if [ ! -e "${bin}" ]; then
+    echo "skip: ${bin} not built"
+    continue
+  fi
+  ran=$((ran + 1))
+  echo "::group::${base}${suffix} -version"
+  if [ -n "${EMULATOR}" ]; then
+    if ! ${EMULATOR} "${bin}" -version; then
+      echo "::error::${base}${suffix} -version failed under ${EMULATOR}"
+      fail=1
+    fi
+  elif [ -z "${NO_EXEC}" ] && [ -x "${bin}" ] && is_native_format "${bin}"; then
+    if ! "${bin}" -version; then
+      echo "::error::${base}${suffix} -version failed"
+      fail=1
+    fi
+  else
+    # Non-runnable on this host (cross-compiled darwin Mach-O on Linux
+    # with no emulator, or NAVIO_SMOKE_NO_EXEC set). Drop to a shape
+    # check so the binary at least exists in a recognizable format.
+    if ! file -b "${bin}"; then
+      echo "::error::file probe failed for ${bin}"
+      fail=1
+    fi
+  fi
+  echo "::endgroup::"
+done
+
+if [ "${ran}" -eq 0 ]; then
+  echo "::error::No navio binaries found in ${BIN_DIR}; nothing to smoke-test"
+  exit 1
+fi
+
+exit "${fail}"


### PR DESCRIPTION
## Summary

Add a binary-loading smoke step (`-version` on every built navio executable) to every CI job that produces runnable binaries. Catches load-time failures (missing rpath, unresolved runtime deps, ABI mismatch) that ctest can mask because it only execs `test_navio`, not the production binaries.

## Motivation

@aguycalled reported that with the new CMake flow on macOS, `naviod` fails to load without `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`:

```
dyld[57160]: Library not loaded: @rpath/libevent_pthreads-2.1.7.dylib
  Referenced from: /Users/alex/dev/navio-core/build/bin/naviod
  Reason: no LC_RPATH's found
```

The `macos-native-arm64` CI job builds against the exact same Homebrew `libevent` (see `ci.yml`'s `brew install ... libevent ...` step), but it didn't catch the regression because the only thing it runs after `cmake --build` is `ctest` — and `test_navio`'s runtime dep surface differs from `naviod`'s. With this smoke step, the next time a CMake change drops the rpath on a production binary, CI fails on the job that ships that binary, not in a user's terminal.

This PR **does not fix the rpath bug** — it adds the regression detector. The rpath fix lives in a follow-up so it gets the "CI red → fix → CI green" bisect-friendly trail.

## How

New shared script `ci/smoke_test_binaries.sh`:

- Loops over `naviod`, `navio-cli`, `navio-tx`, `navio-util`, `navio-wallet`, `navio-staker` and runs each with `-version`
- Detects `.exe` suffix automatically (mingw / MSVC builds)
- Cross-compile aware:
  - Honors `CMAKE_CROSSCOMPILING_EMULATOR` (wine for the Win64-cross matrix entry)
  - Honors `NAVIO_SMOKE_NO_EXEC=1` for cross builds with no emulator (mac-cross on Linux)
  - Auto-falls-back to `file` shape check if the binary format doesn't match the host kernel (defence-in-depth — `+x` is set on Mach-O files on Linux but exec returns `ENOEXEC`)
- Skips missing binaries silently (no naviod → matrix entry is wallet-only / libblsct-only / fuzz-only)
- Fails the step if zero navio binaries are found in `build/bin/` (probably a build misconfig — surface it loudly)

Wired into every CI job that produces runnable binaries:

| Job | Trigger |
|---|---|
| `test-each-commit` | inline call after `cmake --build` |
| `macos-native-arm64` | dedicated step after Build, before ctest |
| `win64-native` | dedicated step after Build, `shell: bash` |
| `linux-cmake` matrix (tidy, i686-multiprocess, win64, mac-cross, arm, tsan, msan, nowallet-libnaviokernel) | shared step gated on `matrix.smoke_test_binaries` |
| `linux-cmake-centos` | `docker exec` step |

Skipped where no runnable navio binary is produced:

- `no-wallet-libblsct` (`BUILD_LIBBLSCT_ONLY=ON`; static lib only)
- `fuzz` (`BUILD_FOR_FUZZING=ON`; only fuzz harness binaries)

For the existing `nowallet-libnaviokernel` smoke_test field, the redundant per-binary `-version` lines are removed and only the libnaviokernel-specific artifact checks (`libnaviokernel.so`, `navio-chainstate`) remain.

## Test plan

- [x] Confirm CI fails on the `macos-native-arm64` job with the same dyld error the user reported (this PR is built to reproduce that bug in CI; the rpath fix follows in a separate PR).
- [x] Confirm every other matrix entry passes the smoke step.
- [x] Confirm the script's `file` fallback fires only on `mac-cross` and reports a `Mach-O` shape.
