### PR TITLE
test: fix feature_index_prune + feature_pruning for navio (extended suite)

### DIFF
--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -22,7 +22,12 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
             []
         ]
 
-    def sync_index(self, height):
+    def sync_index(self, height=None):
+        # Every call here waits for the indices to catch up to the chain tip.
+        # Deriving the target from the tip (instead of hard-coding it) keeps
+        # the test independent of navio's exact block heights.
+        if height is None:
+            height = self.nodes[0].getblockcount()
         expected_filter = {
             'basic block filter index': {'synced': True, 'best_block_height': height},
         }
@@ -58,7 +63,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         stats_nodes = [self.nodes[1], self.nodes[2]]
 
         self.log.info("check if we can access blockfilters and coinstats when pruning is enabled but no blocks are actually pruned")
-        self.sync_index(height=200)
+        self.sync_index()
         tip = self.nodes[0].getbestblockhash()
         for node in filter_nodes:
             assert_greater_than(len(node.getblockfilter(tip)['filter']), 0)
@@ -66,15 +71,22 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
             assert node.gettxoutsetinfo(hash_type="muhash", hash_or_height=tip)['muhash']
 
         self.mine_batches(500)
-        self.sync_index(height=700)
+        self.sync_index()
 
         self.log.info("prune some blocks")
         for node in self.nodes[:2]:
-            with node.assert_debug_log(['limited pruning to height 689']):
+            # Match the log message without the trailing height: the exact
+            # "limited pruning" height is another block-file-wrap magic number
+            # that differs in navio, and the returned pruneheight asserted just
+            # below already pins the behaviour.
+            with node.assert_debug_log(['limited pruning to height ']):
                 pruneheight_new = node.pruneblockchain(400)
-                # the prune heights used here and below are magic numbers that are determined by the
-                # thresholds at which block files wrap, so they depend on disk serialization and default block file size.
-                assert_equal(pruneheight_new, 248)
+                # The prune heights asserted here and below are magic numbers
+                # determined by the thresholds at which block files wrap, so
+                # they depend on disk serialization and the default block file
+                # size. They differ from upstream Bitcoin Core because navio's
+                # BLSCT blocks serialize to different sizes.
+                assert_equal(pruneheight_new, 228)
 
         self.log.info("check if we can access the tips blockfilter and coinstats when we have pruned some blocks")
         tip = self.nodes[0].getbestblockhash()
@@ -90,9 +102,11 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         for node in stats_nodes:
             assert node.gettxoutsetinfo(hash_type="muhash", hash_or_height=height_hash)['muhash']
 
-        # mine and sync index up to a height that will later be the pruneheight
-        self.generate(self.nodes[0], 51)
-        self.sync_index(height=751)
+        # mine and sync index up to a height above the pruneblockchain(1000)
+        # boundary, so the later prune (with indices disabled) stays at or
+        # below the index best block and the index can resume.
+        self.generate(self.nodes[0], 301)
+        self.sync_index()
 
         self.restart_without_indices()
 
@@ -109,12 +123,12 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
         self.log.info("prune exactly up to the indices best blocks while the indices are disabled")
         for i in range(3):
             pruneheight_2 = self.nodes[i].pruneblockchain(1000)
-            assert_equal(pruneheight_2, 750)
+            assert_equal(pruneheight_2, 918)
             # Restart the nodes again with the indices activated
             self.restart_node(i, extra_args=self.extra_args[i])
 
         self.log.info("make sure that we can continue with the partially synced indices after having pruned up to the index height")
-        self.sync_index(height=1500)
+        self.sync_index()
 
         self.log.info("prune further than the indices best blocks while the indices are disabled")
         self.restart_without_indices()
@@ -140,17 +154,24 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
             self.connect_nodes(i, 3)
 
         self.sync_blocks(timeout=300)
-        self.sync_index(height=2500)
+        self.sync_index()
 
         for node in self.nodes[:2]:
-            with node.assert_debug_log(['limited pruning to height 2489']):
+            with node.assert_debug_log(['limited pruning to height ']):
                 pruneheight_new = node.pruneblockchain(2500)
-                assert_equal(pruneheight_new, 2005)
+                assert_equal(pruneheight_new, 2298)
 
         self.log.info("ensure that prune locks don't prevent indices from failing in a reorg scenario")
-        with self.nodes[0].assert_debug_log(['basic block filter index prune lock moved back to 2480']):
-            self.nodes[3].invalidateblock(self.nodes[0].getblockhash(2480))
-            self.generate(self.nodes[3], 30)
+        # Reorg point: a height above the pruned data so the block to
+        # invalidate is still available, and below the tip.
+        reorg_height = 2480
+        tip_height = self.nodes[0].getblockcount()
+        with self.nodes[0].assert_debug_log(['basic block filter index prune lock moved back to ']):
+            self.nodes[3].invalidateblock(self.nodes[0].getblockhash(reorg_height))
+            # node3 (unpruned) must out-mine the other nodes' tip so they reorg
+            # onto its branch. Derive the count from the current tip instead of
+            # hard-coding it, since navio's block heights differ from upstream.
+            self.generate(self.nodes[3], tip_height - reorg_height + 2)
             self.sync_blocks()
 
 

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -486,13 +486,21 @@ class PruneTest(BitcoinTestFramework):
     def test_scanblocks_pruned(self):
         node = self.nodes[5]
         genesis_blockhash = node.getblockhash(0)
-        false_positive_spk = bytes.fromhex("001400000000000000000000000000000000000cadcb")
+        # scanblocks the genesis block by its coinbase output scriptPubKey,
+        # which is present in the genesis block filter. The upstream test used
+        # a hand-picked scriptPubKey crafted to be a false positive against
+        # Bitcoin's genesis filter; that does not match navio's (different)
+        # genesis, so use the genesis coinbase spk directly — a chain
+        # constant. The first call matches via the filter; the second forces a
+        # block fetch to drop false positives, which fails because the genesis
+        # block has been pruned on this node.
+        genesis_spk = "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
 
         assert genesis_blockhash in node.scanblocks(
-            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0)['relevant_blocks']
+            "start", [{"desc": f"raw({genesis_spk})"}], 0, 0)['relevant_blocks']
 
         assert_raises_rpc_error(-1, "Block not available (pruned data)", node.scanblocks,
-            "start", [{"desc": f"raw({false_positive_spk.hex()})"}], 0, 0, "basic", {"filter_false_positives": True})
+            "start", [{"desc": f"raw({genesis_spk})"}], 0, 0, "basic", {"filter_false_positives": True})
 
 if __name__ == '__main__':
     PruneTest(__file__).main()


### PR DESCRIPTION
Fixes two of the three `EXTENDED_SCRIPTS` functional tests that fail in the Win64 `--extended` CI job. Both are upstream Bitcoin Core tests whose hard-coded constants don't match navio. Verified locally against a fresh build.

## feature_index_prune

The prune heights are magic numbers tied to block-file-wrap thresholds, which depend on block serialization + default block file size. navio's BLSCT blocks serialize differently, so they diverge (first prune lands at **228**, not 248; etc.).

- Derive every `sync_index()` target from the chain tip instead of hard-coding it — all calls already targeted the tip, so this removes five magic numbers with no fidelity loss.
- Mine the index above the `pruneblockchain(1000)` boundary before the indices-disabled prune, so the index best block isn't left "beyond pruned data" (which aborted node startup).
- Update asserted prune heights to navio's values (228 / 918 / 2298).
- Match the `limited pruning to height` / `prune lock moved back to` debug logs by prefix (the exact heights are the same kind of magic number; the returned pruneheight already pins behaviour).
- Derive the reorg block count from the tip so node3 reliably out-mines the others.

## feature_pruning

`test_scanblocks_pruned` used a scriptPubKey hand-picked to be a false positive against **Bitcoin's** genesis block filter. navio has a different genesis, so it didn't match navio's genesis filter. Use the genesis coinbase output scriptPubKey (a chain constant) — present in the genesis filter, so the first `scanblocks` matches; the second (`filter_false_positives`) still hits "Block not available (pruned data)" because genesis is pruned.

## Not included: feature_dbcrash

The third Win64 `--extended` failure, `feature_dbcrash`, is **not** a test-port issue — it reproduces deterministically on Linux (`--randomseed=2105098797299165016`, iteration 3) and surfaces a **real navio bug**: after a multi-block reorg, `CreateNewBlock` packs a transaction whose inputs are missing/spent (`bad-txns-inputs-missingorspent`), producing a self-invalid block. The transaction is re-added by `MaybeUpdateMempoolForReorg` and not culled by `filter_final_and_mature`. This points at navio's reorg/mempool-consistency changes (e.g. the BLSCT `DisconnectBlock` handling in `dda8d81a13` and the `mapOutputToTx` short-circuit in `filter_final_and_mature`). It needs a consensus-level fix and is filed separately rather than masked here.