### PR TITLE
refactor: drop boost::date_time from ParseISO8601DateTime

### DIFF
--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -7,13 +7,16 @@
 #include <common/url.h>
 #include <rpc/util.h>
 #include <util/any.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 
 #include <univalue.h>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
+#include <string_view>
 
 namespace wallet {
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
@@ -21,16 +24,31 @@ const std::string HELP_REQUIRING_PASSPHRASE{"\nRequires wallet passphrase to be 
 
 int64_t ParseISO8601DateTime(const std::string& str)
 {
-    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
-    static const std::locale loc(std::locale::classic(),
-        new boost::posix_time::time_input_facet("%Y-%m-%dT%H:%M:%SZ"));
-    std::istringstream iss(str);
-    iss.imbue(loc);
-    boost::posix_time::ptime ptime(boost::date_time::not_a_date_time);
-    iss >> ptime;
-    if (ptime.is_not_a_date_time() || epoch > ptime)
+    // Parse a strict "YYYY-MM-DDTHH:MM:SSZ" timestamp without Boost.DateTime.
+    // Preserves the historical behaviour of returning 0 for unparseable input
+    // and for timestamps at or before the Unix epoch.
+    constexpr auto FMT_SIZE{std::string_view{"2000-01-01T01:01:01Z"}.size()};
+    const std::string_view sv{str};
+    if (sv.size() != FMT_SIZE || sv[4] != '-' || sv[7] != '-' || sv[10] != 'T' || sv[13] != ':' || sv[16] != ':' || sv[19] != 'Z') {
         return 0;
-    return (ptime - epoch).total_seconds();
+    }
+    const auto year{ToIntegral<uint16_t>(sv.substr(0, 4))};
+    const auto month{ToIntegral<uint8_t>(sv.substr(5, 2))};
+    const auto day{ToIntegral<uint8_t>(sv.substr(8, 2))};
+    const auto hour{ToIntegral<uint8_t>(sv.substr(11, 2))};
+    const auto min{ToIntegral<uint8_t>(sv.substr(14, 2))};
+    const auto sec{ToIntegral<uint8_t>(sv.substr(17, 2))};
+    if (!year || !month || !day || !hour || !min || !sec) {
+        return 0;
+    }
+    const std::chrono::year_month_day ymd{std::chrono::year{*year}, std::chrono::month{*month}, std::chrono::day{*day}};
+    if (!ymd.ok()) {
+        return 0;
+    }
+    const auto time{std::chrono::hours{*hour} + std::chrono::minutes{*min} + std::chrono::seconds{*sec}};
+    const auto tp{std::chrono::sys_days{ymd} + time};
+    const int64_t secs{TicksSinceEpoch<std::chrono::seconds>(tp)};
+    return secs > 0 ? secs : 0;
 }
 
 bool GetAvoidReuseFlag(const CWallet& wallet, const UniValue& param) {

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -23,8 +23,7 @@ EXCLUDED_DIRS = ["contrib/devtools/bitcoin-tidy/",
                  "src/minisketch/",
                 ]
 
-EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",
-                           "boost/multi_index/detail/hash_index_iterator.hpp",
+EXPECTED_BOOST_INCLUDES = ["boost/multi_index/detail/hash_index_iterator.hpp",
                            "boost/multi_index/hashed_index.hpp",
                            "boost/multi_index/identity.hpp",
                            "boost/multi_index/indexed_by.hpp",


### PR DESCRIPTION
Removes the `boost::date_time` (Boost.DateTime) dependency by reimplementing `ParseISO8601DateTime` with `std::chrono`, matching upstream Bitcoin Core's removal of this dependency.

## Change

`src/wallet/rpc/util.cpp` — the strict `YYYY-MM-DDTHH:MM:SSZ` parser now uses `ToIntegral` + `std::chrono::year_month_day` + `TicksSinceEpoch` instead of `boost::posix_time::time_input_facet`.

Behaviour is preserved: unparseable input and timestamps at or before the Unix epoch return `0`. The existing `wallet_util_tests/util_ParseISO8601DateTime` cases pass unchanged:

```
check ParseISO8601DateTime("1970-01-01T00:00:00Z") == 0 ... passed
check ParseISO8601DateTime("1960-01-01T00:00:00Z") == 0 ... passed
check ParseISO8601DateTime("2000-01-01T00:00:01Z") == 946684801 ... passed
check ParseISO8601DateTime("2011-09-30T23:36:17Z") == 1317425777 ... passed
check ParseISO8601DateTime("2100-12-31T23:59:59Z") == 4133980799 ... passed
```

Drops `boost/date_time/...` from `EXPECTED_BOOST_INCLUDES` in `lint-includes.py`.

## Why

One of navio's extra Boost dependencies (beyond upstream's `multi_index` + `test`). Removing it (along with `boost::signals2`, separate PR) lets the depends Boost recipe move to upstream's `BOOST_INCLUDE_LIBRARIES="multi_index;test"` CMake build (#268).