### PR TITLE
depends: bump systemtap to 5.3

### DIFF
--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -1,8 +1,8 @@
 package=systemtap
-$(package)_version=4.8
+$(package)_version=5.3
 $(package)_download_path=https://sourceware.org/ftp/systemtap/releases/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=cbd50a4eba5b261394dc454c12448ddec73e55e6742fda7f508f9fbc1331c223
+$(package)_sha256_hash=966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
 $(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Updates the systemtap (USDT tracing) dependency from **4.8 → 5.3**, matching upstream Bitcoin Core.

## Change

`depends/packages/systemtap.mk` — version + sha256 bump only. Everything else (download path, the `remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check` patch, the stage commands, and navio's `USDT_INCLUDE_DIR` doc comment) is unchanged.

## Verification

- The recipe now matches upstream's `systemtap.mk` exactly (apart from navio's extra doc comment).
- The patch file is byte-identical to upstream's and still applies to 5.3.
- sha256 verified locally against the sourceware.org release tarball:
  ```
  computed: 966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
  expected: 966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
  ```

Only built into depends when `WITH_USDT` is enabled; the USDT CI job exercises it.