### PR TITLE
depends: bump native_libmultiprocess to current master (3c69d125)

### DIFF
--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=414542f81e0997354b45b8ade13ca144a3e35ff1
-$(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
+$(package)_version=3c69d125a175084e4056ec9db8badb625e5f31d8
+$(package)_download_path=https://github.com/bitcoin-core/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=8542dbaf8c4fce8fd7af6929f5dc9b34dffa51c43e9ee360e93ee0f34b180bc2
+$(package)_sha256_hash=456c176eedffd1692f9b3a43bb5fe75b271d313e9d6e7a7eb82fee756763b397
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds


### PR DESCRIPTION
## What

Bump `native_libmultiprocess` from `414542f8` (2023-11, capnproto-1.0.1 era) to current master `3c69d125` (2026-04), and switch the download path to the canonical `bitcoin-core/libmultiprocess` (chaincodelabs now redirects there). `libmultiprocess.mk` inherits all fields from the native package, so only `native_libmultiprocess.mk` changes.

## Why

It was the only remaining out-of-date depends package — all others (boost 1.90, libevent 2.1.12, sqlite 3500400, zeromq 4.3.5, capnp 1.4.0, systemtap 5.3) already match upstream. navio keeps the tarball-download model rather than upstream's in-tree subtree vendoring.

## Risk / validation

A 2.5-year jump could surface libmultiprocess API changes that navio's `src/ipc` code (also ~2023-era) doesn't match. So this is validated by the **guix build** (compiles depends + multiprocess) and the **`multiprocess` ci.yml job** before being marked ready — not assumed.

_Draft pending a green fork guix build on this branch._
