### PR TITLE
fix(mempool): find children via mapNextTx in UpdateTransactionsFromBlock

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -164,11 +164,16 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256>& vHashes
         WITH_FRESH_EPOCH(m_epoch);
         for (const auto& out : it->GetTx().vout) {
             const auto outHash = out.GetHash();
-            // Find children by looking up the output hash in mapOutputToTx
-            auto output_iter = mapOutputToTx.find(outHash);
-            if (output_iter != mapOutputToTx.end()) {
+            // Find the child that SPENDS this output via mapNextTx (prevout ->
+            // spending tx), matching addUnchecked()/CalculateDescendants().
+            // mapOutputToTx maps an output hash to the tx that PRODUCED it
+            // (i.e. `it` itself), so it must not be used here -- using it meant
+            // the real child links were never established on reorg, leaving the
+            // child with empty m_parents and stale ancestor state.
+            auto output_iter = mapNextTx.find(COutPoint(outHash));
+            if (output_iter != mapNextTx.end()) {
                 // Found a transaction that spends this output
-                const uint256& childHash = output_iter->second;
+                const uint256 childHash = output_iter->second->GetHash();
                 txiter childIter = mapTx.find(childHash);
                 if (childIter != mapTx.end()) {
                     // We can skip updating entries we've encountered before or that


### PR DESCRIPTION
## Problem

`feature_dbcrash.py` fails **deterministically** on the Win64-native job (debug build) — it has been red on every master run for weeks. node3 aborts with:

```
Assertion failed: !inBlock.contains(iter->GetSharedTx()->GetHash()), src/node/miner.cpp:509
```

This is an *extended* test (`--extended`), which runs only on push to master, not on PRs — so it doesn't show up on PR CI.

## Root cause

`CTxMemPool::UpdateTransactionsFromBlock()` rebuilds parent/child links for transactions re-added to the mempool during a reorg. It located each re-added tx's children by looking the tx's **own output hashes** up in `mapOutputToTx`:

```cpp
auto output_iter = mapOutputToTx.find(outHash);   // output -> PRODUCER (i.e. `it` itself)
```

But `mapOutputToTx` maps an output hash to the tx that **produced** it, not the tx that **spends** it. So it never found the real children, and never called `UpdateParent(child, it)` or refreshed the child's ancestor state.

After a reorg, a child could be left with **empty `m_parents` and a stale `m_count_with_ancestors`**, while its parent still listed it in `m_children`. The block assembler (`addPackageTxs`) then re-added that child to `mapModifiedTx` via `UpdatePackagesForAdded` (still reachable as a descendant) even though it was already in the block — tripping the `inBlock` assert in `miner.cpp`. The Win64 job is the only debug build that runs the extended functional suite, so it's the only place the (compiled-in) assert is exercised.

## Fix

Find children via `mapNextTx.find(COutPoint(outHash))` (prevout -> spending tx), matching `addUnchecked()`, `CalculateDescendants()` and `UpdateChildrenForRemoval()` — the rest of the mempool already uses this mapping.

## Validation

Reproduced locally on a Linux debug build with an always-reorg variant of `feature_dbcrash` (instrumented `miner.cpp` confirmed the offending entry had `ancCount=3` but zero `m_parents`). With the fix: **40/40 iterations clean, 30 crash-recoveries, no violations**; before the fix it tripped within ~2 iterations. The extended Win64 CI will confirm on master post-merge.
