### PR TITLE
build(depends): bundled Tor daemon (zlib, openssl, tor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1445,7 +1445,7 @@ jobs:
 
       - name: Verify bundled tor binary
         run: |
-          tor_bin="depends/x86_64-pc-linux-gnu/bin/navio-tor"
+          tor_bin="depends/x86_64-pc-linux-gnu/bin/tor"
           test -x "${tor_bin}" || { echo "bundled tor not built at ${tor_bin}"; exit 1; }
           file "${tor_bin}"
           "${tor_bin}" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1445,7 +1445,7 @@ jobs:
 
       - name: Verify bundled tor binary
         run: |
-          tor_bin="depends/x86_64-pc-linux-gnu/bin/tor"
+          tor_bin="depends/x86_64-pc-linux-gnu/bin/navio-tor"
           test -x "${tor_bin}" || { echo "bundled tor not built at ${tor_bin}"; exit 1; }
           file "${tor_bin}"
           "${tor_bin}" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1018,7 +1018,9 @@ jobs:
           # from HOST instead of inheriting the linux-cmake matrix CC/CXX
           # (which would otherwise leak into per-package configure scripts —
           # e.g. zeromq would probe windows.h with the host gcc and fail).
-          env -u CC -u CXX make -C depends HOST=${{ matrix.depends_host }} ${{ matrix.depends_opts }}
+          # NO_TOR=1: the bundled Tor daemon (OpenSSL+zlib+tor) is heavy and is
+          # only exercised by the dedicated "depends with Tor" job below.
+          env -u CC -u CXX make -C depends HOST=${{ matrix.depends_host }} ${{ matrix.depends_opts }} NO_TOR=1
 
       - name: Dump depends config.log on failure
         if: failure() && matrix.depends_host
@@ -1332,7 +1334,8 @@ jobs:
           docker exec "${CONTAINER_NAME}" bash -eu -c '
             env -u CC -u CXX make -C depends \
               HOST='"${DEPENDS_HOST}"' \
-              CC="gcc -m32" CXX="g++ -m32"
+              CC="gcc -m32" CXX="g++ -m32" \
+              NO_TOR=1
           '
 
       - name: Save depends cache
@@ -1398,3 +1401,51 @@ jobs:
         with:
           path: ${{ env.RUNNER_TEMP }}/ccache_dir
           key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
+
+  depends-tor:
+    # The only job that builds the bundled Tor daemon (openssl + zlib + tor).
+    # Every other job passes NO_TOR=1 to keep the depends build light. Unrelated
+    # heavy packages (boost, sqlite, zmq, usdt, libomp) are skipped here so this
+    # validates just the Tor toolchain.
+    name: 'depends with Tor (x86_64-linux)'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake automake autoconf libtool pkg-config \
+            bison curl ca-certificates python3 perl
+
+      - name: Cache depends sources
+        uses: actions/cache@v5
+        with:
+          path: depends/sources
+          key: depends-tor-sources-${{ hashFiles('depends/packages/*.mk') }}
+
+      - name: Cache built depends
+        uses: actions/cache@v5
+        with:
+          path: depends/x86_64-pc-linux-gnu
+          key: depends-tor-x86_64-linux-${{ hashFiles('depends/**') }}
+
+      - name: Build depends with Tor
+        run: |
+          # NO_TOR is intentionally NOT set: this job builds the bundled Tor.
+          # The other NO_* flags drop packages Tor does not need so the job
+          # stays focused on libevent + openssl + zlib + tor (gmp is built
+          # unconditionally by depends).
+          env -u CC -u CXX make -C depends -j"$(nproc)" HOST=x86_64-pc-linux-gnu \
+            NO_BOOST=1 NO_SQLITE=1 NO_WALLET=1 NO_ZMQ=1 NO_USDT=1 NO_OPENMP=1
+
+      - name: Verify bundled tor binary
+        run: |
+          tor_bin="depends/x86_64-pc-linux-gnu/bin/tor"
+          test -x "${tor_bin}" || { echo "bundled tor not built at ${tor_bin}"; exit 1; }
+          file "${tor_bin}"
+          "${tor_bin}" --version

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -435,6 +435,11 @@ jobs:
           export BASE_CACHE="${HOME}/depends-cache"
           mkdir -p "${SOURCES_PATH}" "${BASE_CACHE}"
 
+          # Skip the bundled Tor daemon (OpenSSL+zlib+tor) in release builds for
+          # now; it is exercised by the dedicated "depends with Tor" CI job.
+          # Drop this once Tor bundling is wired into the release artifacts.
+          export NO_TOR=1
+
           cd "${GITHUB_WORKSPACE}"
 
           # guix time-machine clones the guix repo from a single git mirror

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -461,6 +461,7 @@ EOF
                                         ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
                                         ${BASE_CACHE:+BASE_CACHE="$BASE_CACHE"} \
                                         ${SDK_PATH:+SDK_PATH="$SDK_PATH"} \
+                                        ${NO_TOR:+NO_TOR="$NO_TOR"} \
                                         DISTSRC="$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")" \
                                         OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")" \
                                         DIST_ARCHIVE_BASE=/outdir-base/dist-archive \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -179,6 +179,7 @@ esac
 # Build the depends tree, overriding variables that assume multilib gcc
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \
+                                   ${NO_TOR:+NO_TOR="$NO_TOR"} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \
                                    ${SDK_PATH+SDK_PATH="$SDK_PATH"} \

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -41,6 +41,7 @@ NO_WALLET ?=
 NO_ZMQ ?=
 NO_USDT ?=
 NO_OPENMP ?=
+NO_TOR ?=
 MULTIPROCESS ?=
 LTO ?=
 NO_HARDEN ?=
@@ -173,7 +174,11 @@ NO_OPENMP=1
 endif
 libomp_packages_$(NO_OPENMP) = $(libomp_packages)
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(boost_packages_) $(libevent_packages_) $(wallet_packages_) $(usdt_packages_) $(libomp_packages_)
+# Bundled Tor daemon (and its crypto/compression deps) for built-in onion
+# support. Skipped when NO_TOR=1 is passed.
+tor_packages_$(NO_TOR) = $(tor_packages)
+
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(boost_packages_) $(libevent_packages_) $(wallet_packages_) $(usdt_packages_) $(libomp_packages_) $(tor_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(zmq_packages_),)
@@ -242,6 +247,7 @@ $(host_prefix)/toolchain.cmake : toolchain.cmake.in $(host_prefix)/.stamp_$(fina
 	    -e 's|@wallet_packages@|$(wallet_packages_)|' \
 	    -e 's|@usdt_packages@|$(usdt_packages_)|' \
 	    -e 's|@multiprocess_packages@|$(multiprocess_packages_)|' \
+	    -e 's|@tor_packages@|$(tor_packages_)|' \
 	    $< > $@
 	touch $@
 
@@ -291,6 +297,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@no_sqlite@|$(NO_SQLITE)|' \
             -e 's|@no_usdt@|$(NO_USDT)|' \
             -e 's|@no_openmp@|$(NO_OPENMP)|' \
+            -e 's|@no_tor@|$(NO_TOR)|' \
             -e 's|@multiprocess@|$(MULTIPROCESS)|' \
             -e 's|@lto@|$(LTO)|' \
             -e 's|@no_harden@|$(NO_HARDEN)|' \

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -41,6 +41,9 @@ endef
 define $(package)_postprocess_cmds
   rm -rf bin lib/pkgconfig && \
   rm include/ev*.h && \
-  rm include/event2/*_compat.h && \
-  rm lib/libevent.a
+  rm include/event2/*_compat.h
 endef
+# Note: the combined lib/libevent.a (which upstream deletes here) is kept so the
+# bundled Tor daemon's --enable-static-libevent can link it. navio itself links
+# the split components (event_core/event_extra/event_pthreads via
+# FindLibevent.cmake), so the extra archive is inert for the main build.

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,0 +1,44 @@
+package=openssl
+$(package)_version=3.0.20
+$(package)_download_path=https://github.com/openssl/openssl/releases/download/openssl-$($(package)_version)/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f
+
+# Static libssl/libcrypto for the bundled Tor daemon only; navio itself does not
+# link OpenSSL. Kept minimal: no shared libs, no engines/tests/zlib.
+define $(package)_set_vars
+$(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)" CROSS_COMPILE=
+$(package)_config_opts=no-shared no-dso no-engine no-tests no-zlib
+$(package)_config_opts+=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl --libdir=lib
+# depends' global CFLAGS pass -std=c11, which both hides POSIX prototypes
+# (usleep) and disables the `asm` keyword OpenSSL's bignum code needs. Append
+# -std=gnu11 last so it overrides the inherited -std=c11.
+$(package)_config_opts+=-D_GNU_SOURCE $($(package)_cflags) $($(package)_cppflags) -std=gnu11
+$(package)_config_opts_linux=-fPIC -Wa,--noexecstack
+$(package)_config_opts_x86_64_linux=linux-x86_64
+$(package)_config_opts_aarch64_linux=linux-aarch64
+$(package)_config_opts_arm_linux=linux-armv4
+$(package)_config_opts_i686_linux=linux-x86
+$(package)_config_opts_riscv64_linux=linux64-riscv64
+$(package)_config_opts_x86_64_mingw32=mingw64
+$(package)_config_opts_i686_mingw32=mingw
+$(package)_config_opts_x86_64_darwin=darwin64-x86_64-cc
+$(package)_config_opts_arm64_darwin=darwin64-arm64-cc
+endef
+
+define $(package)_config_cmds
+  ./Configure $($(package)_config_opts)
+endef
+
+# build_sw/install_sw skip docs and man pages (avoids needing pod2man).
+define $(package)_build_cmds
+  $(MAKE) build_sw
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install_sw
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share etc bin lib/pkgconfig
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -15,6 +15,10 @@ multiprocess_native_packages = native_libmultiprocess native_capnp
 
 usdt_linux_packages=systemtap
 
+# Bundled Tor daemon and its dependencies (libevent is already a package and is
+# pulled in via tor's _dependencies). Built unless NO_TOR=1.
+tor_packages = tor openssl zlib
+
 # Darwin no longer needs a depends-managed toolchain: the guix profile
 # defined by contrib/guix/manifest.scm's darwin branch ships clang +
 # llvm-* + lld, and depends/hosts/darwin.mk wires them via PATH. The

--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -39,14 +39,16 @@ define $(package)_build_cmds
   $(MAKE) src/app/tor
 endef
 
+# Installed as navio-tor(.exe): a navio-managed Tor daemon, distinct from the
+# system `tor` and from naviod itself.
 ifeq ($(host_os),mingw32)
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
-  cp src/app/tor.exe $($(package)_staging_dir)$(host_prefix)/bin/
+  cp src/app/tor.exe $($(package)_staging_dir)$(host_prefix)/bin/navio-tor.exe
 endef
 else
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
-  cp src/app/tor $($(package)_staging_dir)$(host_prefix)/bin/
+  cp src/app/tor $($(package)_staging_dir)$(host_prefix)/bin/navio-tor
 endef
 endif

--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -39,16 +39,16 @@ define $(package)_build_cmds
   $(MAKE) src/app/tor
 endef
 
-# Installed as navio-tor(.exe): a navio-managed Tor daemon, distinct from the
-# system `tor` and from naviod itself.
+# Shipped under Tor's own binary name (tor / tor.exe): this is unmodified
+# upstream Tor, so keep its name rather than rebranding it.
 ifeq ($(host_os),mingw32)
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
-  cp src/app/tor.exe $($(package)_staging_dir)$(host_prefix)/bin/navio-tor.exe
+  cp src/app/tor.exe $($(package)_staging_dir)$(host_prefix)/bin/
 endef
 else
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
-  cp src/app/tor $($(package)_staging_dir)$(host_prefix)/bin/navio-tor
+  cp src/app/tor $($(package)_staging_dir)$(host_prefix)/bin/
 endef
 endif

--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -1,0 +1,52 @@
+package=tor
+$(package)_version=0.4.9.9
+$(package)_download_path=https://dist.torproject.org/
+$(package)_file_name=tor-$($(package)_version).tar.gz
+$(package)_sha256_hash=bd75ba7fd68f607c7806fcf70156a300aa926e9ad69a5e56a8e6414f5227e833
+$(package)_dependencies=libevent openssl zlib
+
+# Client-only Tor: no public-relay or dir-authority modules (smaller binary,
+# less attack surface); onion services live in the client and are kept. The
+# three deps are linked statically so the shipped `tor` binary only needs libc
+# (plus the standard Win32 system DLLs on mingw).
+define $(package)_set_vars
+# depends' global CFLAGS pass -std=c11, which disables GNU keywords Tor relies
+# on (typeof); -std=gnu11 (appended last) restores them and POSIX prototypes.
+$(package)_cflags+=-std=gnu11
+# Match naviod's static-link strategy: deps are linked static (below); on
+# Windows go fully static (-static, like CMakeLists.txt's MINGW branch), on
+# Linux bake in libgcc but keep glibc dynamic (NSS/DNS needs it), on macOS
+# leave the system libs dynamic.
+ifeq ($(host_os),mingw32)
+$(package)_ldflags+=-static
+else ifneq ($(host_os),darwin)
+$(package)_ldflags+=-static-libgcc
+endif
+$(package)_config_opts=--disable-asciidoc --disable-manpage --disable-html-manual
+$(package)_config_opts+=--disable-unittests --disable-system-torrc
+$(package)_config_opts+=--disable-zstd --disable-lzma --disable-seccomp --disable-libscrypt
+$(package)_config_opts+=--disable-module-relay --disable-module-dirauth
+$(package)_config_opts+=--enable-static-libevent --with-libevent-dir=$(host_prefix)
+$(package)_config_opts+=--enable-static-openssl --with-openssl-dir=$(host_prefix)
+$(package)_config_opts+=--enable-static-zlib --with-zlib-dir=$(host_prefix)
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE) src/app/tor
+endef
+
+ifeq ($(host_os),mingw32)
+define $(package)_stage_cmds
+  mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
+  cp src/app/tor.exe $($(package)_staging_dir)$(host_prefix)/bin/
+endef
+else
+define $(package)_stage_cmds
+  mkdir -p $($(package)_staging_dir)$(host_prefix)/bin && \
+  cp src/app/tor $($(package)_staging_dir)$(host_prefix)/bin/
+endef
+endif

--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,0 +1,37 @@
+package=zlib
+$(package)_version=1.3.1
+$(package)_download_path=https://github.com/madler/zlib/releases/download/v$($(package)_version)/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+
+define $(package)_set_vars
+$(package)_config_env=CC="$($(package)_cc)" CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
+$(package)_config_env+=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)"
+$(package)_build_env=CC="$($(package)_cc)" CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
+$(package)_build_env+=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)"
+endef
+
+# zlib's ./configure does not understand cross-compilation triplets; on mingw we
+# build with its dedicated win32 GNU makefile instead.
+ifeq ($(host_os),mingw32)
+define $(package)_build_cmds
+  $(MAKE) -f win32/Makefile.gcc PREFIX="$(host)-" CC="$($(package)_cc)" AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CFLAGS="$($(package)_cflags) $($(package)_cppflags)" libz.a
+endef
+define $(package)_stage_cmds
+  $(MAKE) -f win32/Makefile.gcc install DESTDIR="$($(package)_staging_dir)/" BINARY_PATH="$(host_prefix)/bin" INCLUDE_PATH="$(host_prefix)/include" LIBRARY_PATH="$(host_prefix)/lib"
+endef
+else
+define $(package)_config_cmds
+  ./configure --static --prefix=$(host_prefix)
+endef
+define $(package)_build_cmds
+  $(MAKE) libz.a
+endef
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+endif
+
+define $(package)_postprocess_cmds
+  rm -rf share lib/pkgconfig
+endef

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -144,11 +144,11 @@ if("@tor_packages@" MATCHES "^[ ]*$")
   set(WITH_TOR OFF CACHE BOOL "")
 else()
   set(WITH_TOR ON CACHE BOOL "")
-  # Bundled Tor daemon built by depends, installed alongside naviod.
+  # Bundled Tor daemon built by depends, installed alongside naviod as navio-tor.
   if(WIN32)
-    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor.exe" CACHE FILEPATH "")
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/navio-tor.exe" CACHE FILEPATH "")
   else()
-    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor" CACHE FILEPATH "")
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/navio-tor" CACHE FILEPATH "")
   endif()
 endif()
 

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -140,6 +140,18 @@ else()
   set(USDT_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/systemtap/include" CACHE PATH "")
 endif()
 
+if("@tor_packages@" MATCHES "^[ ]*$")
+  set(WITH_TOR OFF CACHE BOOL "")
+else()
+  set(WITH_TOR ON CACHE BOOL "")
+  # Bundled Tor daemon built by depends, installed alongside naviod.
+  if(WIN32)
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor.exe" CACHE FILEPATH "")
+  else()
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor" CACHE FILEPATH "")
+  endif()
+endif()
+
 set(multiprocess_packages @multiprocess_packages@)
 if("${multiprocess_packages}" STREQUAL "")
   set(ENABLE_IPC OFF CACHE BOOL "")

--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -144,11 +144,11 @@ if("@tor_packages@" MATCHES "^[ ]*$")
   set(WITH_TOR OFF CACHE BOOL "")
 else()
   set(WITH_TOR ON CACHE BOOL "")
-  # Bundled Tor daemon built by depends, installed alongside naviod as navio-tor.
+  # Bundled (unmodified upstream) Tor daemon built by depends.
   if(WIN32)
-    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/navio-tor.exe" CACHE FILEPATH "")
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor.exe" CACHE FILEPATH "")
   else()
-    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/navio-tor" CACHE FILEPATH "")
+    set(BUNDLED_TOR_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/bin/tor" CACHE FILEPATH "")
   endif()
 endif()
 


### PR DESCRIPTION
## What

Adds depends packages to build a **self-contained Tor daemon** so navio can offer built-in onion support without the user installing or configuring Tor separately. This PR is the **depends/build foundation only**; the C++ launcher that auto-spawns the bundled `tor` is a follow-up.

## Packages

- **zlib** 1.3.1, **openssl** 3.0.20 LTS (static `libssl`/`libcrypto`, client-minimal), **tor** 0.4.9.9 (client-only: `--disable-module-relay --disable-module-dirauth`).
- `tor` links libevent/openssl/zlib statically and **mirrors naviod's static-link strategy**: `-static` on Windows, `-static-libgcc` on Linux (glibc stays dynamic — NSS/DNS needs it), system libs dynamic on macOS.
- `libevent.mk` now keeps the combined `lib/libevent.a` (required by tor's `--enable-static-libevent`); navio links the split components, so the meta-lib is inert for the main build.

## `NO_TOR` toggle

A single flag gates everything:
- In depends it drops the `tor`/`openssl`/`zlib` packages.
- It drives the `WITH_TOR` / `BUNDLED_TOR_EXECUTABLE` CMake cache vars via `toolchain.cmake.in`.

## CI

- `NO_TOR=1` on **every** existing `ci.yml` job and all guix jobs (threaded through the guix `--pure` env → `guix-build` → `build.sh`), so the heavy OpenSSL/Tor build never slows the matrix or release builds.
- One new **`depends with Tor (x86_64-linux)`** job builds *with* Tor (skipping boost/sqlite/zmq/usdt/libomp) and asserts `bin/tor` exists and runs.

## Validation

Built end-to-end on x86_64-linux: produces a working **`tor 0.4.9.9`** reporting `Libevent 2.1.12, OpenSSL 3.0.20, Zlib 1.3.1` (all statically linked), with only `libc`/`libcap` dynamic.

## Notes

- Draft: touches `contrib/guix/`, so it stays draft until the fork guix workflow is green.
- Build gotchas handled (relevant for cross builds): depends' global `-std=c11` broke OpenSSL (`usleep`, `asm`) and Tor (`typeof`) → `-std=gnu11` + `-D_GNU_SOURCE`.
- Follow-up: C++ launcher (`src/torproc`) to auto-spawn + supervise the bundled tor, CMake install of `bin/tor`, and release packaging.