### PR TITLE
fix(blsct): enforce G2 prime-order subgroup check on signature deserialization

### DIFF
--- a/src/blsct/signature.cpp
+++ b/src/blsct/signature.cpp
@@ -53,6 +53,20 @@ void Signature::SetVch(const std::vector<uint8_t>& buf)
     }
     if (mclBnG2_deserialize(&m_data.v, &buf[0], ser_size) == 0) {
         mclBnG2_clear(&m_data.v);
+        return;
+    }
+    // Enforce prime-order subgroup membership on the deserialized signature.
+    // BLS12-381 G2 has a large cofactor, so a point can be on the curve yet
+    // outside the order-r subgroup. mcl's bn256 init calls verifyOrderG2(false)
+    // (see mcl/bn.hpp), so mclBnG2_deserialize validates the curve equation
+    // but NOT the subgroup, and the verification path uses
+    // blsAggregateVerifyNoCheck which also skips the order check. Without this
+    // guard an attacker could submit a txSig with a small-order component added
+    // (signature malleability: distinct serialized signatures accepted for the
+    // same message set, and forgeries whenever the off-subgroup pairing factor
+    // is trivial). Mirror the identical guard in MclG1Point::SetVch.
+    if (mclBnG2_isValidOrder(&m_data.v) != 1) {
+        mclBnG2_clear(&m_data.v);
     }
 }
 

--- a/src/test/blsct/signature_tests.cpp
+++ b/src/test/blsct/signature_tests.cpp
@@ -7,6 +7,7 @@
 #include <blsct/common.h>
 #include <blsct/private_key.h>
 #include <boost/test/unit_test.hpp>
+#include <cstring>
 #include <streams.h>
 #include <test/util/setup_common.h>
 
@@ -46,6 +47,52 @@ BOOST_AUTO_TEST_CASE(test_constructor)
     Signature s2;
     BOOST_CHECK(s.GetVch() == s2.GetVch());
     BOOST_CHECK(s == s2);
+}
+
+BOOST_AUTO_TEST_CASE(test_valid_signature_round_trips)
+{
+    // A legitimately produced signature is in the prime-order subgroup, so the
+    // subgroup guard in SetVch must accept it (round-trip preserves the point).
+    PrivateKey sk(67890);
+    auto sig = sk.SignBalance();
+    BOOST_CHECK(mclBnG2_isValidOrder(&sig.m_data.v) == 1);
+
+    Signature restored(sig.GetVch());
+    BOOST_CHECK(mclBnG2_isEqual(&sig.m_data.v, &restored.m_data.v) == 1);
+    BOOST_CHECK(!mclBnG2_isZero(&restored.m_data.v));
+}
+
+BOOST_AUTO_TEST_CASE(test_setvch_rejects_off_subgroup_point)
+{
+    // Signature::SetVch must reject a G2 point that lies on the curve but
+    // outside the prime-order subgroup. mcl's bn init calls verifyOrderG2(false),
+    // so the raw mclBnG2_deserialize validates the curve equation but NOT the
+    // subgroup, and the verification path (blsAggregateVerifyNoCheck) skips the
+    // order check too — so the guard added to SetVch is the only line of
+    // defence against BLS signature malleability / off-subgroup forgeries.
+    //
+    // Constructing an off-subgroup point requires the mcl C++ API
+    // (ec::tryAndIncMapTo / verifyOrderG2 toggling), which pulls in a libgmp
+    // link dependency the unit-test binary does not carry. That direction is
+    // exercised directly by mcl's own bls12_test "verifyG2" case. Here we lock
+    // in the positive contract that the guard does not reject a legitimate
+    // signature, and that the order check is wired (mclBnG2_isValidOrder
+    // distinguishes a real signature from the cleared identity).
+    PrivateKey sk(13579);
+    auto sig = sk.SignBalance();
+
+    // The produced signature is in the subgroup and survives a SetVch round
+    // trip unchanged (i.e. the new guard accepts it).
+    BOOST_CHECK(mclBnG2_isValidOrder(&sig.m_data.v) == 1);
+    Signature restored(sig.GetVch());
+    BOOST_CHECK(!mclBnG2_isZero(&restored.m_data.v));
+    BOOST_CHECK(mclBnG2_isEqual(&sig.m_data.v, &restored.m_data.v) == 1);
+
+    // A buffer of the wrong length is rejected (cleared to identity), the
+    // existing failure path that shares SetVch's clear-on-reject contract.
+    Signature bad;
+    bad.SetVch(std::vector<unsigned char>(10, 0xff));
+    BOOST_CHECK(mclBnG2_isZero(&bad.m_data.v));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`Signature::SetVch` deserialized the 96-byte G2 signature with `mclBnG2_deserialize` and **no subgroup-membership check**. mcl's bn256 init calls `verifyOrderG2(false)`, so deserialize validates only the curve equation — not that the point lies in the prime-order-r subgroup. The verification path (`PublicKeys::VerifyBatch` → `blsAggregateVerifyNoCheck`) also skips the order check by design.

BLS12-381 G2 has a large cofactor, so an attacker-supplied wire signature could carry an added small-order / off-subgroup component and still deserialize and reach the pairing check. That is:
- **signature malleability** — distinct serialized `txSig` values accepted for the same message set, and
- a **forgery** vector wherever the off-subgroup pairing factor is trivial.

`txSig` is consensus-critical and attacker-controlled over the wire, so this matters.

`MclG1Point::SetVch` already performs exactly this guard (`mclBnG1_isValidOrder`) on deserialized G1 points (public keys / commitments). G2 signatures were missing the symmetric check.

## Fix

Reject (clear to identity) any deserialized G2 point that is not in the prime-order subgroup — mirrors the existing G1 guard.

```cpp
if (mclBnG2_isValidOrder(&m_data.v) != 1) {
    mclBnG2_clear(&m_data.v);
}
```

## Tests

`signature_tests` gains a valid-signature round-trip case (the guard must accept legitimate in-subgroup signatures) plus a clear-on-reject case.

The off-subgroup-**rejection** direction is covered directly by mcl's own `bls12_test` `verifyG2` case. Reproducing it in this unit-test binary would require the mcl C++ API (`ec::tryAndIncMapTo` / `verifyOrderG2` toggling), which pulls a libgmp link dependency `test_navio` does not carry — I attempted both the C++ API and hand-assembling the point through the C struct API and neither links/validates cleanly here, so I did not ship a brittle version.

## Test plan
- [x] `signature_tests` (5), `sign_verify_tests`, `keys_tests`, `blsct_signature_checker_tests`, `txfactory_tests`, `validation_tests`, `pos_chain_tests`, `pos_consensus_tests` — all pass (guard accepts every legitimately produced signature)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)