### PR TITLE
fix(blsct): only count the unspendable burn output as the consensus fee

### DIFF
--- a/src/blsct/wallet/verification.cpp
+++ b/src/blsct/wallet/verification.cpp
@@ -243,7 +243,17 @@ bool VerifyTxCoreImpl(const CTransaction& tx,
             }
         } else {
             if (out.nValue == 0) continue;
-            if (parsedPredicate.IsPayFeePredicate()) {
+            // The fee is the plaintext value of the dedicated fee output. That
+            // output MUST be the unspendable OP_RETURN burn output
+            // (scriptPubKey.IsFee()) -- the same condition the fee SIGNATURE
+            // binding above (out.scriptPubKey.IsFee() && IsPayFeePredicate())
+            // requires. Counting a PayFee predicate on a *spendable* output as
+            // the fee would let an attacker satisfy the consensus min-fee rule
+            // with value sent to an output they can re-spend: the fee would be
+            // neither burned nor enforced, defeating both the burn and the
+            // anti-spam minimum. Require IsFee() here so only the genuine burn
+            // output counts.
+            if (parsedPredicate.IsPayFeePredicate() && out.scriptPubKey.IsFee()) {
                 if (nFee > 0 || !MoneyRange(out.nValue)) {
                     return state.Invalid(TxValidationResult::TX_CONSENSUS, "more-than-one-fee-output");
                 }

--- a/src/test/blsct/wallet/validation_tests.cpp
+++ b/src/test/blsct/wallet/validation_tests.cpp
@@ -5,6 +5,7 @@
 #include <blsct/wallet/txfactory.h>
 #include <blsct/wallet/verification.h>
 #include <primitives/transaction.h>
+#include <script/script.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <txdb.h>
@@ -273,6 +274,79 @@ BOOST_FIXTURE_TEST_CASE(validation_min_fee_phantom_output_rejected_test, Testing
     // The attacker doesn't actually need to fix up txSig for the min-fee rule
     // to fire -- the rule runs before the BLS aggregate check, and the phantom
     // output's added bytes alone make `nFee < weight * BLSCT_DEFAULT_FEE`.
+    TxValidationState tx_state;
+    BOOST_CHECK(!blsct::VerifyTx(CTransaction(mtx), coins_view_cache, tx_state));
+    BOOST_CHECK_EQUAL(tx_state.GetRejectReason(), "blsct-fee-below-min");
+}
+
+// The fee is counted only from the dedicated unspendable burn output
+// (scriptPubKey.IsFee(), i.e. a bare OP_RETURN). A PayFee predicate placed on a
+// *spendable* output must NOT be counted as the fee: otherwise an attacker
+// could satisfy the consensus minimum-fee rule with value routed to an output
+// they can re-spend -- the "fee" would be neither burned nor enforced. Here we
+// take a valid tx and move its fee value off the IsFee() output onto a spendable
+// one carrying the PayFee predicate; the tx must then fail the min-fee rule
+// because no IsFee() output funds it.
+BOOST_FIXTURE_TEST_CASE(validation_payfee_on_spendable_output_not_counted_test, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 23, .memory_only = true}, {}};
+
+    auto wallet = std::make_unique<wallet::CWallet>(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase());
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_CHECK(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    auto recvAddress = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+
+    const auto txid = Txid::FromUint256(InsecureRand256());
+    COutPoint outpoint(txid);
+
+    Coin coin;
+    auto out = blsct::CreateOutput(recvAddress, 1000 * COIN, "test");
+    coin.nHeight = 1;
+    coin.out = out.out;
+
+    {
+        CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+        coins_view_cache.SetBestBlock(InsecureRand256());
+        coins_view_cache.AddCoin(outpoint, std::move(coin), true);
+        BOOST_CHECK(coins_view_cache.Flush());
+    }
+
+    CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+    auto tx = blsct::TxFactory(blsct_km);
+    BOOST_CHECK(tx.AddInput(coins_view_cache, outpoint));
+    tx.AddOutput(recvAddress, 900 * COIN, "test");
+
+    auto finalTxOpt = tx.BuildTx();
+    BOOST_REQUIRE(finalTxOpt.has_value());
+
+    // Sanity: untampered tx verifies.
+    {
+        TxValidationState tx_state;
+        BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTxOpt.value()), coins_view_cache, tx_state));
+    }
+
+    // Turn the unspendable OP_RETURN fee output into a spendable one while
+    // keeping its PayFee predicate and value. With the fix, this output no
+    // longer counts toward the fee (IsFee() is now required), so nFee drops to
+    // 0 and the min-fee rule rejects the tx.
+    CMutableTransaction mtx(finalTxOpt.value());
+    bool patched = false;
+    for (auto& vout : mtx.vout) {
+        if (vout.scriptPubKey.IsFee()) {
+            BOOST_REQUIRE(vout.nValue > 0);
+            // A non-IsFee() script that is still standard/spendable.
+            vout.scriptPubKey = CScript() << OP_TRUE;
+            patched = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE(patched);
+
     TxValidationState tx_state;
     BOOST_CHECK(!blsct::VerifyTx(CTransaction(mtx), coins_view_cache, tx_state));
     BOOST_CHECK_EQUAL(tx_state.GetRejectReason(), "blsct-fee-below-min");


### PR DESCRIPTION
## Summary

The BLSCT minimum-fee rule reads the transaction fee from the plaintext value of a fee output. The fee **signature binding** requires that output to be the dedicated unspendable burn output (`scriptPubKey.IsFee()` — a bare `OP_RETURN`):

```cpp
} else if (out.scriptPubKey.IsFee() && parsedPredicate.IsPayFeePredicate()) {
```

…but the fee **accounting** that feeds the consensus minimum-fee check only tested the predicate:

```cpp
if (parsedPredicate.IsPayFeePredicate()) { ... nFee = out.nValue; }
```

So a `PayFee` predicate placed on a **spendable** plaintext output was counted as the fee. An attacker could satisfy `nFee >= GetTransactionWeight(tx) * nBLSCTDefaultFee` with value routed to an output they control and re-spend — the "fee" is neither burned nor actually paid, defeating both the burn and the anti-spam minimum.

The balance equation still holds either way (the output's value is subtracted from `balanceKey` regardless), so this is **fee-evasion / anti-spam bypass**, not direct inflation.

## Fix

Require `out.scriptPubKey.IsFee()` in the accounting branch too, mirroring the signature-binding condition — only the genuine burn output funds the fee.

## Tests

Adds `validation_payfee_on_spendable_output_not_counted_test`: takes a valid tx, moves the fee value onto a spendable (non-`IsFee()`) output carrying the `PayFee` predicate, and asserts it now fails with `blsct-fee-below-min`.

Verified the test catches the bug: with the fix reverted it fails (the spendable output is counted, passes min-fee, and only trips later at `failed-signature-check`); with the fix it rejects at `blsct-fee-below-min` as intended.

## Test plan
- [x] `blsct_validation_tests` (6), `blsct_txfactory_tests`, `blsct_txfactory_global_tests`, `pos_chain_tests`, `pos_consensus_tests`, `blsct_signature_checker_tests` — all pass (honest txs always burn the fee via OP_RETURN)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)