### PR TITLE
fix(blsct): reject NFT mint ids that exceed supply via signed-cast bypass

### DIFF
--- a/src/blsct/tokens/predicate_exec.cpp
+++ b/src/blsct/tokens/predicate_exec.cpp
@@ -41,7 +41,15 @@ bool ExecutePredicate(const ParsedPredicate& predicate, CCoinsViewCache& view, c
         if (!view.GetToken(hash, token))
             return false;
 
-        if ((CAmount)predicate.GetNftId() >= token.info.nTotalSupply)
+        // nftId is uint64_t; nTotalSupply is signed CAmount. Casting the id to
+        // CAmount makes any id >= 2^63 negative, which would pass a signed
+        // ">= nTotalSupply" test and let an attacker mint NFT ids outside the
+        // issuer's fixed [0, nTotalSupply) range. Compare in the unsigned
+        // domain instead, after rejecting a non-positive supply (no NFT id is
+        // valid then). nTotalSupply is MoneyRange-bounded and >= 0 in practice.
+        if (token.info.nTotalSupply <= 0)
+            return false;
+        if (predicate.GetNftId() >= static_cast<uint64_t>(token.info.nTotalSupply))
             return false;
 
         if ((token.mapMintedNft.contains(predicate.GetNftId())) == !fDisconnect)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(test_navio
   blsct/set_mem_proof/set_mem_proof_setup_tests.cpp
   blsct/set_mem_proof/set_mem_proof_tests.cpp
   blsct/signature_tests.cpp
+  blsct/tokens/predicate_exec_tests.cpp
   blsct/sign_verify_tests.cpp
   blsct/wallet/address_tests.cpp
   blsct/wallet/chain_tests.cpp

--- a/src/test/blsct/tokens/predicate_exec_tests.cpp
+++ b/src/test/blsct/tokens/predicate_exec_tests.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 The Navio developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blsct/private_key.h>
+#include <blsct/tokens/info.h>
+#include <blsct/tokens/predicate_exec.h>
+#include <blsct/tokens/predicate_parser.h>
+#include <coins.h>
+#include <test/util/setup_common.h>
+#include <txdb.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <limits>
+
+BOOST_FIXTURE_TEST_SUITE(predicate_exec_tests, BasicTestingSetup)
+
+// Register an NFT token with a small fixed supply, returning its consensus
+// token key (publicKey hash) and the owner public key.
+static blsct::PublicKey RegisterNftToken(CCoinsViewCache& view, CAmount total_supply)
+{
+    blsct::PrivateKey owner_sk(7);
+    blsct::PublicKey owner_pk = owner_sk.GetPublicKey();
+
+    blsct::TokenInfo info;
+    info.type = blsct::NFT;
+    info.publicKey = owner_pk;
+    info.nTotalSupply = total_supply;
+
+    blsct::TokenEntry entry(info, std::map<uint64_t, std::map<std::string, std::string>>{});
+    view.AddToken(owner_pk.GetHash(), std::move(entry));
+    return owner_pk;
+}
+
+BOOST_AUTO_TEST_CASE(mint_nft_within_supply_ok)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
+
+    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
+}
+
+BOOST_AUTO_TEST_CASE(mint_nft_at_or_above_supply_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
+
+    // id == supply is out of [0, supply)
+    blsct::MintNftPredicate at(owner_pk, /*nftId=*/10, {});
+    blsct::ParsedPredicate parsed_at(at);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed_at, view));
+}
+
+// Regression: a uint64 nftId with the high bit set must NOT be accepted. The
+// old check cast nftId to signed CAmount, making any id >= 2^63 negative and
+// thus "< nTotalSupply", bypassing the issuer's fixed-supply bound.
+BOOST_AUTO_TEST_CASE(mint_nft_high_bit_id_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
+
+    const uint64_t high_bit_id = (static_cast<uint64_t>(1) << 63) + 5; // negative if cast to int64
+    blsct::MintNftPredicate evil(owner_pk, high_bit_id, {});
+    blsct::ParsedPredicate parsed(evil);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+
+    // And the largest possible uint64 likewise.
+    blsct::MintNftPredicate evil_max(owner_pk, std::numeric_limits<uint64_t>::max(), {});
+    blsct::ParsedPredicate parsed_max(evil_max);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed_max, view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`ExecutePredicate`'s NFT mint path bounded the minted id against the token's fixed supply with a signed cast:

```cpp
if ((CAmount)predicate.GetNftId() >= token.info.nTotalSupply) return false;
```

`predicate.GetNftId()` is `uint64_t`; `CAmount` is signed `int64_t`. **Any id ≥ 2^63 casts to a negative value**, so `>= nTotalSupply` is false and the supply-cap check is bypassed.

A MintNft predicate is attacker-controlled and runs on the consensus path (`ExecutePredicate` is invoked from `ConnectBlock`), so an attacker could mint NFT ids far outside the issuer's intended `[0, nTotalSupply)` range, breaking the fixed-supply guarantee. `mapMintedNft` is keyed by the raw `uint64` id, so the out-of-range ids also persist in token state.

## Fix

Compare in the unsigned domain, after rejecting a non-positive supply (no id is valid then). `nTotalSupply` is MoneyRange-bounded and ≥ 0 in practice.

```cpp
if (token.info.nTotalSupply <= 0) return false;
if (predicate.GetNftId() >= static_cast<uint64_t>(token.info.nTotalSupply)) return false;
```

## Tests

New `predicate_exec_tests`:
- mint within supply succeeds
- id == supply rejected
- high-bit ids (`2^63 + 5` and `UINT64_MAX`) rejected

Verified the high-bit case **fails against the pre-fix code** (the signed cast accepted both bogus ids), and passes with the fix.

## Test plan
- [x] `predicate_exec_tests` (3)
- [x] `external_api_tests`, `blsct_validation_tests` — no regression
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)