### PR TITLE
fix(blsct): validate token type in mint predicates (prevent inflation)

### DIFF
--- a/src/blsct/tokens/predicate_exec.cpp
+++ b/src/blsct/tokens/predicate_exec.cpp
@@ -27,6 +27,15 @@ bool ExecutePredicate(const ParsedPredicate& predicate, CCoinsViewCache& view, c
 
         if (!view.GetToken(hash, token))
             return false;
+        // The fungible-token mint path mutates nSupply, which TokenEntry only
+        // serializes for TOKEN-type entries (NFT-type serializes mapMintedNft
+        // instead). Minting against an NFT-type token would bump an nSupply
+        // that is never persisted -- after a flush it reads back 0, letting
+        // the owner re-mint up to nTotalSupply repeatedly (supply-cap break /
+        // inflation). The token type is attacker-chosen at creation, so it
+        // must be validated here.
+        if (token.info.type != blsct::TOKEN)
+            return false;
         if (!token.Mint(predicate.GetAmount() * (1 - 2 * fDisconnect)))
             return false;
 
@@ -39,6 +48,12 @@ bool ExecutePredicate(const ParsedPredicate& predicate, CCoinsViewCache& view, c
         blsct::TokenEntry token;
 
         if (!view.GetToken(hash, token))
+            return false;
+
+        // Symmetric guard: the NFT mint path mutates mapMintedNft, which is
+        // only serialized for NFT-type entries. Reject mints against a
+        // non-NFT token.
+        if (token.info.type != blsct::NFT)
             return false;
 
         if ((CAmount)predicate.GetNftId() >= token.info.nTotalSupply)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(test_navio
   blsct/set_mem_proof/set_mem_proof_setup_tests.cpp
   blsct/set_mem_proof/set_mem_proof_tests.cpp
   blsct/signature_tests.cpp
+  blsct/tokens/predicate_exec_tests.cpp
   blsct/sign_verify_tests.cpp
   blsct/wallet/address_tests.cpp
   blsct/wallet/chain_tests.cpp

--- a/src/test/blsct/tokens/predicate_exec_tests.cpp
+++ b/src/test/blsct/tokens/predicate_exec_tests.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2024 The Navio developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blsct/private_key.h>
+#include <blsct/tokens/info.h>
+#include <blsct/tokens/predicate_exec.h>
+#include <blsct/tokens/predicate_parser.h>
+#include <coins.h>
+#include <test/util/setup_common.h>
+#include <txdb.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(predicate_exec_tests, BasicTestingSetup)
+
+static blsct::PublicKey RegisterToken(CCoinsViewCache& view, blsct::TokenType type, CAmount total_supply)
+{
+    blsct::PrivateKey owner_sk(7);
+    blsct::PublicKey owner_pk = owner_sk.GetPublicKey();
+
+    blsct::TokenInfo info;
+    info.type = type;
+    info.publicKey = owner_pk;
+    info.nTotalSupply = total_supply;
+
+    blsct::TokenEntry entry(info);
+    view.AddToken(owner_pk.GetHash(), std::move(entry));
+    return owner_pk;
+}
+
+// Minting a fungible token against a TOKEN-type entry works.
+BOOST_AUTO_TEST_CASE(mint_token_on_token_type_ok)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterToken(view, blsct::TOKEN, /*total_supply=*/1000);
+
+    blsct::MintTokenPredicate p(owner_pk, /*amount=*/100);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
+}
+
+// Regression: minting a fungible token against an NFT-type entry must be
+// rejected. MintToken mutates nSupply, which TokenEntry serializes only for
+// TOKEN-type entries; against an NFT-type token nSupply would not persist,
+// so the supply cap resets to 0 on reload and the owner could re-mint
+// unbounded amounts of the fungible asset H(pubkey) (inflation).
+BOOST_AUTO_TEST_CASE(mint_token_on_nft_type_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterToken(view, blsct::NFT, /*total_supply=*/1000);
+
+    blsct::MintTokenPredicate p(owner_pk, /*amount=*/100);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+// Minting an NFT against an NFT-type entry works.
+BOOST_AUTO_TEST_CASE(mint_nft_on_nft_type_ok)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterToken(view, blsct::NFT, /*total_supply=*/10);
+
+    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
+}
+
+// Symmetric regression: minting an NFT against a TOKEN-type entry must be
+// rejected (mapMintedNft is only serialized for NFT-type entries).
+BOOST_AUTO_TEST_CASE(mint_nft_on_token_type_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterToken(view, blsct::TOKEN, /*total_supply=*/10);
+
+    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blsct/tokens/predicate_exec_tests.cpp
+++ b/src/test/blsct/tokens/predicate_exec_tests.cpp
@@ -27,6 +27,8 @@ static blsct::CreateTokenPredicate MakeCreate(uint8_t type, CAmount total_supply
     return blsct::CreateTokenPredicate(info);
 }
 
+// Register a token of the given type and supply directly in the view, and
+// return the owner public key (the consensus token key is its hash).
 static blsct::PublicKey RegisterToken(CCoinsViewCache& view, blsct::TokenType type, CAmount total_supply)
 {
     blsct::PrivateKey owner_sk(7);
@@ -41,6 +43,8 @@ static blsct::PublicKey RegisterToken(CCoinsViewCache& view, blsct::TokenType ty
     view.AddToken(owner_pk.GetHash(), std::move(entry));
     return owner_pk;
 }
+
+// ---- CreateToken validation (#286) ----------------------------------------
 
 BOOST_AUTO_TEST_CASE(create_token_valid_ok)
 {
@@ -96,6 +100,8 @@ BOOST_AUTO_TEST_CASE(create_token_supply_above_money_range_rejected)
     BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
 }
 
+// ---- Mint type confusion (#285) -------------------------------------------
+
 // Minting a fungible token against a TOKEN-type entry works.
 BOOST_AUTO_TEST_CASE(mint_token_on_token_type_ok)
 {
@@ -115,24 +121,6 @@ BOOST_AUTO_TEST_CASE(mint_token_on_token_type_ok)
 // so the supply cap resets to 0 on reload and the owner could re-mint
 // unbounded amounts of the fungible asset H(pubkey) (inflation).
 BOOST_AUTO_TEST_CASE(mint_token_on_nft_type_rejected)
-// Register an NFT token with a small fixed supply, returning its consensus
-// token key (publicKey hash) and the owner public key.
-static blsct::PublicKey RegisterNftToken(CCoinsViewCache& view, CAmount total_supply)
-{
-    blsct::PrivateKey owner_sk(7);
-    blsct::PublicKey owner_pk = owner_sk.GetPublicKey();
-
-    blsct::TokenInfo info;
-    info.type = blsct::NFT;
-    info.publicKey = owner_pk;
-    info.nTotalSupply = total_supply;
-
-    blsct::TokenEntry entry(info, std::map<uint64_t, std::map<std::string, std::string>>{});
-    view.AddToken(owner_pk.GetHash(), std::move(entry));
-    return owner_pk;
-}
-
-BOOST_AUTO_TEST_CASE(mint_nft_within_supply_ok)
 {
     CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
     CCoinsViewCache view{&base};
@@ -146,14 +134,6 @@ BOOST_AUTO_TEST_CASE(mint_nft_within_supply_ok)
 
 // Minting an NFT against an NFT-type entry works.
 BOOST_AUTO_TEST_CASE(mint_nft_on_nft_type_ok)
-    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
-
-    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
-    blsct::ParsedPredicate parsed(p);
-    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
-}
-
-BOOST_AUTO_TEST_CASE(mint_nft_at_or_above_supply_rejected)
 {
     CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
     CCoinsViewCache view{&base};
@@ -168,9 +148,27 @@ BOOST_AUTO_TEST_CASE(mint_nft_at_or_above_supply_rejected)
 // Symmetric regression: minting an NFT against a TOKEN-type entry must be
 // rejected (mapMintedNft is only serialized for NFT-type entries).
 BOOST_AUTO_TEST_CASE(mint_nft_on_token_type_rejected)
-    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
 
-    // id == supply is out of [0, supply)
+    auto owner_pk = RegisterToken(view, blsct::TOKEN, /*total_supply=*/10);
+
+    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+// ---- NFT id supply bound (#284) -------------------------------------------
+
+// id == supply is out of the [0, supply) range and must be rejected.
+BOOST_AUTO_TEST_CASE(mint_nft_at_or_above_supply_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto owner_pk = RegisterToken(view, blsct::NFT, /*total_supply=*/10);
+
     blsct::MintNftPredicate at(owner_pk, /*nftId=*/10, {});
     blsct::ParsedPredicate parsed_at(at);
     BOOST_CHECK(!blsct::ExecutePredicate(parsed_at, view));
@@ -184,12 +182,7 @@ BOOST_AUTO_TEST_CASE(mint_nft_high_bit_id_rejected)
     CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
     CCoinsViewCache view{&base};
 
-    auto owner_pk = RegisterToken(view, blsct::TOKEN, /*total_supply=*/10);
-
-    blsct::MintNftPredicate p(owner_pk, /*nftId=*/3, {});
-    blsct::ParsedPredicate parsed(p);
-    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
-    auto owner_pk = RegisterNftToken(view, /*total_supply=*/10);
+    auto owner_pk = RegisterToken(view, blsct::NFT, /*total_supply=*/10);
 
     const uint64_t high_bit_id = (static_cast<uint64_t>(1) << 63) + 5; // negative if cast to int64
     blsct::MintNftPredicate evil(owner_pk, high_bit_id, {});


### PR DESCRIPTION
## Summary

`ExecutePredicate`'s mint paths never checked `token.info.type`:

- `MintToken` mutates `token.nSupply`
- `MintNft` mutates `token.mapMintedNft`

But `TokenEntry::Serialize` persists only **one** of those, by type:

```cpp
if (info.type == TOKEN) READWRITE(nSupply);
else if (info.type == NFT) READWRITE(mapMintedNft);
```

The token `type` is **attacker-chosen** at `CreateToken`. So an attacker can:

1. Create an **NFT-type** token (with some `nTotalSupply`).
2. Issue `MintToken` predicates against it. `Mint()` checks the in-memory `nSupply` (starts at 0) and the balance equation forces a real `amount`-valued output, so `amount` fungible units of `H(pubkey)` are minted.
3. Because the entry is NFT-type, `nSupply` is **not serialized**. After a flush/reload it reads back 0 — the cap resets — and the owner re-mints up to `nTotalSupply` again, repeatedly ⇒ **unbounded inflation** of the fungible asset.

The mirror case (`MintNft` against a TOKEN-type entry) writes a `mapMintedNft` that is likewise never persisted.

## Fix

Require `token.info.type == TOKEN` in the MintToken path and `== NFT` in the MintNft path.

## Tests

New `predicate_exec_tests`: both correct-type mints accepted; both cross-type mints rejected. Verified both cross-type cases are **accepted by the pre-fix code** (the two rejection tests fail without the guards) and rejected with the fix.

## Test plan
- [x] `predicate_exec_tests` (4)
- [x] `external_api_tests`, `blsct_validation_tests` — no regression
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)