### PR TITLE
fix(blsct): validate TokenInfo at CreateToken (type + supply range)

### DIFF
--- a/src/blsct/tokens/predicate_exec.cpp
+++ b/src/blsct/tokens/predicate_exec.cpp
@@ -16,7 +16,27 @@ bool ExecutePredicate(const ParsedPredicate& predicate, CCoinsViewCache& view, c
         if (fDisconnect)
             view.EraseToken(hash);
         else {
-            view.AddToken(hash, blsct::TokenInfo{predicate.GetTokenInfo()});
+            // Validate the attacker-supplied TokenInfo before storing it.
+            // Nothing else checks these fields, and CreateToken writes them
+            // verbatim into the consensus token set.
+            const blsct::TokenInfo info = predicate.GetTokenInfo();
+            // Only TOKEN/NFT are known types; TokenEntry::Serialize persists
+            // nSupply or mapMintedNft based on this. An unknown type would
+            // serialize neither (silently dropping all supply state) and can
+            // never be minted, so reject it outright.
+            if (info.type != blsct::TOKEN && info.type != blsct::NFT)
+                return false;
+            // nTotalSupply must be non-negative: it is a signed CAmount used
+            // as the upper bound in Mint()/the NFT-id check, and a negative
+            // value only yields a permanently dead token. For fungible TOKEN
+            // the supply is an amount, so additionally bound it by MoneyRange;
+            // NFT supply is a count of ids (not an amount), so only the
+            // non-negative constraint applies there.
+            if (info.nTotalSupply < 0)
+                return false;
+            if (info.type == blsct::TOKEN && !MoneyRange(info.nTotalSupply))
+                return false;
+            view.AddToken(hash, blsct::TokenInfo{info});
         }
 
         return true;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(test_navio
   blsct/set_mem_proof/set_mem_proof_setup_tests.cpp
   blsct/set_mem_proof/set_mem_proof_tests.cpp
   blsct/signature_tests.cpp
+  blsct/tokens/predicate_exec_tests.cpp
   blsct/sign_verify_tests.cpp
   blsct/wallet/address_tests.cpp
   blsct/wallet/chain_tests.cpp

--- a/src/test/blsct/tokens/predicate_exec_tests.cpp
+++ b/src/test/blsct/tokens/predicate_exec_tests.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 The Navio developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blsct/private_key.h>
+#include <blsct/tokens/info.h>
+#include <blsct/tokens/predicate_exec.h>
+#include <blsct/tokens/predicate_parser.h>
+#include <coins.h>
+#include <consensus/amount.h>
+#include <test/util/setup_common.h>
+#include <txdb.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <limits>
+
+BOOST_FIXTURE_TEST_SUITE(predicate_exec_tests, BasicTestingSetup)
+
+static blsct::CreateTokenPredicate MakeCreate(uint8_t type, CAmount total_supply, uint8_t key_seed = 7)
+{
+    blsct::PrivateKey owner_sk(key_seed);
+    blsct::TokenInfo info;
+    info.type = static_cast<blsct::TokenType>(type);
+    info.publicKey = owner_sk.GetPublicKey();
+    info.nTotalSupply = total_supply;
+    return blsct::CreateTokenPredicate(info);
+}
+
+BOOST_AUTO_TEST_CASE(create_token_valid_ok)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto p = MakeCreate(blsct::TOKEN, /*total_supply=*/1000);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
+}
+
+BOOST_AUTO_TEST_CASE(create_nft_valid_ok)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto p = MakeCreate(blsct::NFT, /*total_supply=*/10);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(blsct::ExecutePredicate(parsed, view));
+}
+
+// Unknown token type is rejected: TokenEntry::Serialize would persist neither
+// nSupply nor mapMintedNft, and such a token can never be minted.
+BOOST_AUTO_TEST_CASE(create_token_unknown_type_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto p = MakeCreate(/*type=*/7, /*total_supply=*/1000);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+// Negative supply is rejected (never satisfiable by Mint / the NFT-id check).
+BOOST_AUTO_TEST_CASE(create_token_negative_supply_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto p = MakeCreate(blsct::TOKEN, /*total_supply=*/-1);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+// Fungible token supply above MoneyRange is rejected.
+BOOST_AUTO_TEST_CASE(create_token_supply_above_money_range_rejected)
+{
+    CCoinsViewDB base{{.path = "test", .cache_bytes = 1 << 20, .memory_only = true}, {}};
+    CCoinsViewCache view{&base};
+
+    auto p = MakeCreate(blsct::TOKEN, /*total_supply=*/MAX_MONEY + 1);
+    blsct::ParsedPredicate parsed(p);
+    BOOST_CHECK(!blsct::ExecutePredicate(parsed, view));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`CreateToken` wrote the attacker-supplied `TokenInfo` into the consensus token set **verbatim** — nothing validated `info.type` or `info.nTotalSupply` anywhere on the path (`verification.cpp` only adds the owner pubkey to the signature set; `ExecutePredicate` just `AddToken`s it).

Two unvalidated fields:

- **`info.type`** — only `TOKEN(0)` / `NFT(1)` are meaningful. `TokenEntry::Serialize` persists `nSupply` for TOKEN, `mapMintedNft` for NFT, and **nothing** for any other value — so an unknown-type token silently drops all supply state and can never be minted (a dead entry that still consumes token-set space).
- **`info.nTotalSupply`** — a signed `CAmount` used as the `Mint()` upper bound and in the NFT-id range check. A negative value yields a permanently unmintable token; an out-of-range fungible supply is meaningless.

Lower severity than the sibling token bugs (an invalid token is inert rather than exploitable, especially once #285 rejects cross-type mints), but this is missing consensus validation of attacker-controlled state that gets persisted, so it's worth closing.

## Fix

In the CreateToken branch: reject unknown types, reject negative `nTotalSupply`, and additionally bound fungible-TOKEN supply by `MoneyRange` (NFT supply is an id count, not an amount, so only the non-negative constraint applies there).

## Tests

New `predicate_exec_tests`: valid TOKEN/NFT creation accepted; unknown-type, negative-supply, and above-`MoneyRange` creation rejected. Verified all three rejection cases are **accepted by the pre-fix code**.

## Test plan
- [x] `predicate_exec_tests` (5)
- [x] `external_api_tests`, `blsct_validation_tests` — no regression
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)