### PR TITLE
wallet: surface startup rescan progress in RPC warmup status

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2323,7 +2323,17 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
             m_scanning_progress = 0;
         }
         if (block_height % 100 == 0 && progress_end - progress_begin > 0.0) {
-            ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
+            const int progress_percent = std::max(1, std::min(99, (int)(m_scanning_progress * 100)));
+            ShowProgress(strprintf("%s " + _("Rescanning…").translated, GetDisplayName()), progress_percent);
+            // The startup rescan (the only caller passing save_progress=true) runs
+            // during init, before the RPC warmup ends and before the wallet is
+            // registered, so getwalletinfo's scanning.progress is not yet
+            // reachable. Surface the percentage through the init message so it
+            // appears in the RPC warmup status (and on the GUI splash), giving
+            // users load feedback while the wallet is still loading.
+            if (save_progress) {
+                chain().initMessage(strprintf(_("Rescanning… (%d%%)").translated, progress_percent));
+            }
         }
 
         bool next_interval = reserver.now() >= current_time + INTERVAL_TIME;


### PR DESCRIPTION
## Problem

When a wallet hasn't been opened for a long time, it rescans at node startup while blocks load. During this window users get **no load feedback**:

- The scan runs synchronously inside `CWallet::Create` → `AttachChain` (`wallet.cpp:3788`), and `AddWallet` only registers the wallet *after* `Create` returns (`load.cpp:135`). So the wallet handle doesn't exist yet.
- Wallet load (`init.cpp:1610`) runs **before** `SetRPCWarmupFinished()` (`init.cpp:1905`), so every RPC returns `RPC_IN_WARMUP`.

Net result: `getwalletinfo.scanning.progress` (which already exists for loaded wallets) is unreachable during startup — there's no wallet to target and RPC is in warmup.

## Change

Route the rescan percentage through `chain().initMessage()` during the startup scan — the only `ScanForWalletTransactions` caller passing `save_progress=true`. `initMessage` is already connected to `SetRPCWarmupStatus` (`init.cpp:1175`), so:

- A client polling **any** RPC during startup now receives `Rescanning… (NN%)` in the `RPC_IN_WARMUP` status message.
- The GUI splash shows the same text.

Emitted at the existing 100-block cadence, alongside the `ShowProgress` call. Runtime RPC rescans (`rescanblockchain`, imports, `RescanFromTime`) pass `save_progress=false` and are **unaffected** — no log/UI spam outside startup.

## Notes

- For already-loaded wallets, programmatic progress remains available via `getwalletinfo` → `scanning: { duration, progress }` (unchanged).
- A fully structured JSON RPC queryable *during* startup would require either warmup-bypass or async wallet load; that's a larger change left out of scope here.

## Test

`naviod` builds clean. String-and-status only; no functional/consensus change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)