### PR TITLE
feat(wallet): auto-register atomic_swap HTLC as watch-only on build

### DIFF
--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -1749,6 +1749,7 @@ RPCHelpMan createblsctrawtransaction()
                             {"locktime", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Locktime (block height or timestamp) for atomic_swap refund branch"},
                             {"timelock_opcode", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Timelock opcode for atomic_swap refund branch: \"cltv\" (default) or \"csv\""},
                             {"blinding_key", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional 32-byte blinding key to deterministically derive atomic_swap spending keys"},
+                            {"watch_only", RPCArg::Type::BOOL, RPCArg::Default{true}, "For atomic_swap outputs, automatically register the HTLC script as watch-only (with address_a's recovery nonce) so this wallet tracks and can recover the output without a separate importblsctscript call. Set to false to skip auto-import."},
                         },
                     },
                 },
@@ -2062,6 +2063,25 @@ RPCHelpMan createblsctrawtransaction()
 
                     // Nullify the spending key
                     unsigned_output.out.blsctData.spendingKey = MclG1Point();
+
+                    // Auto-register the HTLC as a watch-only script so the party
+                    // building the swap tracks the output without a separate
+                    // importblsctscript call. This matters most for the refund
+                    // initiator (address_b): the output is blinded to address_a,
+                    // so address_b never matches its viewTag and is otherwise
+                    // blind to the output. The recovery nonce is address_a's
+                    // shared secret (address_a_view_key * blindingKey), which is
+                    // all that is needed to decrypt the amount regardless of
+                    // which participant owns this wallet. Registering is
+                    // idempotent, so re-building the same swap is harmless.
+                    // Opt out with "watch_only": false (e.g. when building a swap
+                    // on behalf of another wallet).
+                    const bool import_watch_only = !o.exists("watch_only") || o["watch_only"].get_bool();
+                    MclG1Point address_a_view_key;
+                    if (import_watch_only && address_a.GetViewKey(address_a_view_key)) {
+                        blsct::PublicKey recovery_nonce(address_a_view_key * blindingKey);
+                        blsct_km->AddWatchOnly(script, recovery_nonce);
+                    }
                 } else {
                     blsct::SubAddress subAddress;
                     if (o.exists("address")) {

--- a/src/test/blsct/wallet/keyman_tests.cpp
+++ b/src/test/blsct/wallet/keyman_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <blsct/wallet/rpc.h>
 #include <blsct/wallet/txfactory.h>
 #include <blsct/wallet/verification.h>
 #include <test/util/random.h>
@@ -43,6 +44,108 @@ BOOST_FIXTURE_TEST_CASE(wallet_test, TestingSetup)
         auto recvAddress = blsct::SubAddress(std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value()));
         BOOST_CHECK(recvAddress.GetString() == expectedAddresses[i]);
     }
+}
+
+namespace {
+// Set up a BLSCT wallet with a defined view key and a fresh subaddress keypool,
+// ready for GetNewDestination()/IsMineMode().
+std::unique_ptr<wallet::CWallet> MakeBLSCTWallet(interfaces::Chain* chain)
+{
+    auto wallet = std::make_unique<wallet::CWallet>(chain, "", wallet::CreateMockableWalletDatabase());
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_REQUIRE(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+    return wallet;
+}
+
+// Mirror the branch-key derivation used by the createblsctrawtransaction /
+// importblsctscript atomic-swap paths: the blinded per-output spending pubkey
+// baked into one HTLC branch of the script.
+blsct::PublicKey DeriveBranchKey(const blsct::DoublePublicKey& dpk, const MclScalar& blindingKey)
+{
+    MclG1Point vk, sk;
+    BOOST_REQUIRE(dpk.GetViewKey(vk));
+    BOOST_REQUIRE(dpk.GetSpendKey(sk));
+    auto rV = vk * blindingKey;
+    return blsct::PublicKey(sk + blsct::PrivateKey(MclScalar(rV.GetHashWithSalt(0))).GetPoint());
+}
+} // namespace
+
+// An atomic-swap HTLC output is blinded to a single address (address_a, the
+// hashlock/redeem branch). The output is therefore cryptographically
+// recognizable by exactly one party's view key: the swap initiator selling nav
+// (address_b, the timelock/refund branch) can neither match the viewTag nor
+// reconstruct its branch nonce from the output alone, so it is otherwise blind
+// to its own refund output. createblsctrawtransaction closes this gap by
+// auto-registering the HTLC script as watch-only with address_a's recovery
+// nonce when the swap is built. This test reproduces that end state and asserts
+// the refund initiator then (a) classifies the output as watch-only and (b)
+// recovers the amount — WITHOUT a manual importblsctscript call.
+BOOST_FIXTURE_TEST_CASE(htlc_watch_only_registration_detects_refund_output, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+
+    auto wallet_a = MakeBLSCTWallet(m_node.chain.get()); // redeem branch (address_a) — output is blinded here
+    auto wallet_b = MakeBLSCTWallet(m_node.chain.get()); // refund branch (address_b) — swap initiator
+    auto wallet_c = MakeBLSCTWallet(m_node.chain.get()); // unrelated third party
+
+    LOCK(wallet_a->cs_wallet);
+    LOCK(wallet_b->cs_wallet);
+    LOCK(wallet_c->cs_wallet);
+    auto km_a = wallet_a->GetOrCreateBLSCTKeyMan();
+    auto km_b = wallet_b->GetOrCreateBLSCTKeyMan();
+    auto km_c = wallet_c->GetOrCreateBLSCTKeyMan();
+
+    auto addr_a = std::get<blsct::DoublePublicKey>(km_a->GetNewDestination(0).value());
+    auto addr_b = std::get<blsct::DoublePublicKey>(km_b->GetNewDestination(0).value());
+
+    const MclScalar blindingKey(uint256(uint64_t{0x5eed})); // shared, known blinding key
+    const std::vector<unsigned char> hash_bytes(32, 0x11);
+
+    auto keyA = DeriveBranchKey(addr_a, blindingKey).GetVch();
+    auto keyB = DeriveBranchKey(addr_b, blindingKey).GetVch();
+    BOOST_REQUIRE_EQUAL(keyA.size(), blsct::PublicKey::SIZE);
+    BOOST_REQUIRE_EQUAL(keyB.size(), blsct::PublicKey::SIZE);
+
+    CScript htlc_script = blsct::BuildHTLCScript(hash_bytes, keyA, keyB, /*locktime=*/100);
+
+    // Build the funding output exactly like the atomic_swap createblsctrawtransaction
+    // path: blinded to address_a, HTLC script as scriptPubKey, spendingKey nullified.
+    auto unsigned_output = blsct::CreateOutput(std::make_pair(addr_a, htlc_script), 42 * COIN, "swap", TokenId(), blindingKey);
+    CTxOut txout = unsigned_output.out;
+    txout.blsctData.spendingKey = MclG1Point();
+
+    // Pre-condition: without registration, the refund initiator is blind to the
+    // output — it is not the party the output is blinded to. (The redeem party,
+    // address_a, still owns its branch subaddress and detects it.)
+    BOOST_CHECK_EQUAL(km_b->IsMineMode(txout), wallet::ISMINE_NO);
+    BOOST_CHECK_EQUAL(km_a->IsMineMode(txout), wallet::ISMINE_WATCH_ONLY);
+
+    // The recovery nonce createblsctrawtransaction auto-registers for the script:
+    // address_a's shared secret, which decrypts the amount for any participant.
+    MclG1Point addr_a_view_key;
+    BOOST_REQUIRE(addr_a.GetViewKey(addr_a_view_key));
+    blsct::PublicKey recovery_nonce(addr_a_view_key * blindingKey);
+
+    // Registering only on wallet_b models auto-registration firing on the
+    // initiator's wallet as it builds the swap.
+    BOOST_CHECK(km_b->AddWatchOnly(htlc_script, recovery_nonce));
+
+    // Post-condition: the refund initiator now sees its own refund output as
+    // watch-only, with no importblsctscript call.
+    BOOST_CHECK_EQUAL(km_b->IsMineMode(txout), wallet::ISMINE_WATCH_ONLY);
+    BOOST_CHECK(km_b->IsMine(txout));
+
+    // ...and can recover the amount using the registered nonce.
+    auto recovered = km_b->RecoverOutputsWithNonce({txout}, recovery_nonce.GetG1Point());
+    BOOST_REQUIRE(recovered.is_completed);
+    BOOST_REQUIRE(!recovered.amounts.empty());
+    BOOST_CHECK_EQUAL(recovered.amounts[0].amount, 42 * COIN);
+
+    // A wallet that never registered the script must not claim the output.
+    BOOST_CHECK_EQUAL(km_c->IsMineMode(txout), wallet::ISMINE_NO);
+    BOOST_CHECK(!km_c->IsMine(txout));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/blsct_htlc.py
+++ b/test/functional/blsct_htlc.py
@@ -296,6 +296,7 @@ class BLSCTHTLCTest(BitcoinTestFramework):
         self.test_height_time_mode_mismatch(wallet1, wallet2, address1, address2)
         self.test_atomic_swap_timelock_opcode_selection(wallet1, address1, address2)
         self.test_importblsctscript(wallet1, wallet2, address1, address2)
+        self.test_auto_import_watch_only(wallet1, wallet2, address1, address2)
 
     def _create_and_broadcast_htlc(self, wallet, address_a, address_b,
                                     amount_sats, secret_hash_hex, locktime, blinding_key_hex,
@@ -923,6 +924,77 @@ class BLSCTHTLCTest(BitcoinTestFramework):
         self.log.info("Raw script import succeeded")
 
         self.log.info("=== importblsctscript test PASSED ===")
+
+    def test_auto_import_watch_only(self, wallet1, wallet2, address1, address2):
+        """createblsctrawtransaction auto-registers the atomic_swap HTLC script
+        as watch-only (default), so the party building the swap detects its own
+        output WITHOUT a separate importblsctscript call.
+
+        Here wallet2 owns address_b (the refund/timelock branch — the seller
+        initiating the swap) and funds the HTLC. The output is blinded to
+        address_a (wallet1), so wallet2 never matches its viewTag and was
+        previously blind to its own refund output. The auto-import closes that
+        gap; the ``watch_only`` output flag opts out of it."""
+        self.log.info("=== Testing atomic_swap auto watch-only import ===")
+
+        amount_sats = 1 * COIN
+
+        def build_and_broadcast(blinding_hex, secret_byte, watch_only=None):
+            secret_hash = hashlib.sha256(bytes([secret_byte] * 32)).hexdigest()
+            locktime = self.nodes[0].getblockcount() + 50
+            output = {
+                "type": "atomic_swap",
+                "address_a": address1,   # counterparty / redeem branch (output blinded here)
+                "address_b": address2,   # funder itself / refund branch
+                "amount": amount_sats,
+                "hash": secret_hash,
+                "locktime": locktime,
+                "blinding_key": blinding_hex,
+            }
+            if watch_only is not None:
+                output["watch_only"] = watch_only
+
+            # Auto-import (when enabled) happens at build time as a side effect.
+            raw = wallet2.createblsctrawtransaction([], [output])
+            funded = wallet2.fundblsctrawtransaction(raw)
+            signed = wallet2.signblsctrawtransaction(funded)
+            self.nodes[0].sendrawtransaction(signed)
+            self.generatetoblsctaddress(self.nodes[0], 1, self.miner_addr)
+            self.sync_blocks()
+
+            # wallet1 owns address_a, so it can recover the exact script bytes and
+            # output hash for the assertions below (no side effect on wallet2).
+            recovery = wallet1.getblsctrecoverydata(signed)
+            htlc = next(o for o in recovery["outputs"]
+                        if o["amount_navoshi"] == amount_sats and o.get("gamma"))
+            return htlc["script"], htlc["out_hash"]
+
+        # --- Default (watch_only omitted => true): auto-import ON. wallet2 never
+        #     calls importblsctscript. ---
+        script_auto, outid_auto = build_and_broadcast("a1" * 32, 0x71)
+        watch = [u for u in wallet2.listblsctunspent()
+                 if u.get("scriptPubKey") == script_auto]
+        assert len(watch) == 1, (
+            "funder did not auto-detect its atomic_swap output as watch-only "
+            "without importblsctscript")
+        utxo = watch[0]
+        assert utxo.get("watchonly") is True, "auto-imported HTLC output should be watch-only"
+        assert utxo.get("signable") is False, "watch-only HTLC output must not be signable"
+        assert utxo["outid"] == outid_auto
+        assert utxo["amount"] == Decimal(amount_sats) / Decimal(COIN), (
+            "auto-imported HTLC output should have its amount recovered via the "
+            "registered recovery nonce")
+        self.log.info(f"Funder auto-detected HTLC output as watch-only: {outid_auto}")
+
+        # --- watch_only=false: opt out. The funder stays blind to the output. ---
+        script_optout, _ = build_and_broadcast("a2" * 32, 0x72, watch_only=False)
+        matches = [u for u in wallet2.listblsctunspent()
+                   if u.get("scriptPubKey") == script_optout]
+        assert len(matches) == 0, (
+            "watch_only=false must skip auto-import; funder should not detect the output")
+        self.log.info("watch_only=false correctly skipped auto-import")
+
+        self.log.info("=== atomic_swap auto watch-only import test PASSED ===")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

In an atomic swap, the HTLC funding output is blinded to `address_a` (the hashlock/redeem branch). A BLSCT output is cryptographically recognizable by exactly one party's view key, so the swap **initiator selling nav** — who owns `address_b`, the timelock/refund branch — can neither match the output's `viewTag` nor reconstruct its branch nonce from the output alone. It was therefore blind to its own refund output unless it manually ran `importblsctscript`.

## Change

`createblsctrawtransaction` now auto-registers the HTLC script as watch-only (with `address_a`'s recovery nonce) when it builds an `atomic_swap` output. The party building the swap tracks and can recover the output with **no separate `importblsctscript` call**. The recovery nonce is `address_a`'s shared secret (`address_a_view_key * blinding_key`), which decrypts the amount regardless of which participant owns the building wallet.

A per-output `watch_only` flag (default `true`) opts out — e.g. when building a swap on behalf of another wallet.

### Note on the originally-proposed approach
The Discord sketch (add an `isHTLC` arg to `KeyMan::IsMine` and skip the `viewTag` gate while probing branch keys) was implemented and unit-tested first — it does **not** make `address_b` detectable. Because the output's `blsctData.blindingKey` binds recognition to `address_a`, `GetHashId(blindingKey, branchKey_b)` never resolves to `address_b`'s subaddress even with the `viewTag` skip. Detecting the counterparty from the output alone isn't achievable without the blinding key, which is exactly what the watch-only registration supplies. That exploratory change was reverted; this PR keeps `IsMine` untouched.

## Tests
- **`blsct_keyman_tests`** (unit): a wallet owning only the refund branch returns `ISMINE_NO` for the output until the script is registered, after which it classifies the output as `ISMINE_WATCH_ONLY` and recovers the amount; an unrelated wallet stays `ISMINE_NO`.
- **`blsct_htlc.py`** (functional): the funder auto-detects its `atomic_swap` output via `listblsctunspent` (watch-only, correct amount) without `importblsctscript`, and `watch_only=false` skips the auto-import.

Both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)