### PR TITLE
fix(wallet): honor subtractfeefromamount and store comment/comment_to on BLSCT sends

### DIFF
--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -92,7 +92,7 @@ static std::string FormatRecoveredGamma(const Scalar& gamma)
     return gamma.IsZero() ? "" : HexStr(gamma.GetVch());
 }
 
-UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose)
+UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose, wallet::mapValue_t mapValue)
 {
     // This should always try to sign, if we don't have private keys, don't try to do anything here.
     if (wallet.IsWalletFlagSet(wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
@@ -116,8 +116,10 @@ UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransaction
 
     const CTransactionRef& tx = MakeTransactionRef(res.value());
 
-    wallet::mapValue_t map_value;
-    wallet.CommitTransaction(tx, std::move(map_value), /*orderForm=*/{});
+    // Store any wallet-local comment/comment_to on the sender's CWalletTx so
+    // listtransactions surfaces them (WalletTxToJSON emits every mapValue key).
+    // This is separate from the on-chain BLSCT memo, which the recipient sees.
+    wallet.CommitTransaction(tx, std::move(mapValue), /*orderForm=*/{});
     std::string outputHash = tx->vout[0].GetHash().GetHex();
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
@@ -890,6 +892,9 @@ RPCHelpMan sendtoblsctaddress()
             {"memo", RPCArg::Type::STR, RPCArg::Default{""}, "A memo used to store in the transaction.\n"
                                                              "The recipient will see its value."},
             {"verbose", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, return extra information about the transaction."},
+            {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, the fee is deducted from the amount being sent so the recipient receives less than the requested amount and the wallet spends exactly the requested amount."},
+            {"comment_to", RPCArg::Type::STR, RPCArg::Default{""}, "A wallet-local comment naming the person or organization the payment is to.\n"
+                                                                   "Stored only in this wallet (surfaced by listtransactions as \"to\"); not sent on-chain."},
         },
         {
             RPCResult{"if verbose is not set or set to false",
@@ -928,12 +933,24 @@ RPCHelpMan sendtoblsctaddress()
             const std::string address = request.params[0].get_str();
 
             const bool verbose{request.params[3].isNull() ? false : request.params[3].get_bool()};
+            const bool subtract_fee{request.params[4].isNull() ? false : request.params[4].get_bool()};
 
             blsct::CreateTransactionData transactionData(address, AmountFromValue(request.params[1]), sMemo, TokenId(), blsct::CreateTransactionType::NORMAL, 0);
+            transactionData.fSubtractFeeFromAmount = subtract_fee;
+
+            // Wallet-local comments, stored on the sender's CWalletTx and
+            // surfaced by listtransactions (not sent on-chain). The memo above
+            // is the on-chain, recipient-visible field; mirror it into "comment"
+            // so the sender also sees it in their own transaction history.
+            wallet::mapValue_t mapValue;
+            if (!sMemo.empty())
+                mapValue["comment"] = sMemo;
+            if (!request.params[5].isNull() && !request.params[5].get_str().empty())
+                mapValue["to"] = request.params[5].get_str();
 
             EnsureWalletIsUnlocked(*pwallet);
 
-            return blsct::SendTransaction(*pwallet, transactionData, verbose);
+            return blsct::SendTransaction(*pwallet, transactionData, verbose, std::move(mapValue));
         },
     };
 }

--- a/src/blsct/wallet/rpc.h
+++ b/src/blsct/wallet/rpc.h
@@ -15,7 +15,7 @@ typedef std::multimap<int64_t, CWalletOutput*> OutputItems;
 } // namespace wallet
 
 namespace blsct {
-UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose);
+UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose, wallet::mapValue_t mapValue = {});
 CScript BuildHTLCScript(
     const std::vector<unsigned char>& hash_bytes,
     const std::vector<unsigned char>& spendingKeyA,

--- a/src/blsct/wallet/txfactory_base.cpp
+++ b/src/blsct/wallet/txfactory_base.cpp
@@ -17,21 +17,21 @@ namespace blsct {
 
 void TxFactoryBase::AddOutput(const SubAddress& destination, const CAmount& nAmount, std::string sMemo, const TokenId& token_id, const CreateTransactionType& type, const CAmount& minStake, const bool& fSubtractFeeFromAmount, const Scalar& blindingKey, const CAmount& nBLSCTDefaultFee)
 {
-    UnsignedOutput out;
-
-    out = CreateOutput(destination.GetKeys(), nAmount, sMemo, token_id, blindingKey, type, minStake);
-
-    CAmount nFee = 0;
-
-    if (fSubtractFeeFromAmount) {
-        nFee = GetTransactioOutputWeight(out.out) * nBLSCTDefaultFee;
-        out = CreateOutput(destination.GetKeys(), nAmount - nFee, sMemo, token_id, blindingKey, type, minStake);
-    };
-
     if (!nAmounts.contains(token_id))
         nAmounts[token_id] = {0, 0, 0};
 
-    nAmounts[token_id].nFromOutputs += nAmount - nFee;
+    if (fSubtractFeeFromAmount) {
+        // The final value is (nAmount - total transaction fee), and the total
+        // fee is only known once BuildTx's fee fixpoint converges. Defer the
+        // output; BuildTx materializes it at the reduced value. Reuse the
+        // supplied blindingKey across rebuilds so the deferral is deterministic.
+        subtractFeeOutput = SubtractFeeOutput{destination, nAmount, sMemo, token_id, type, minStake, blindingKey};
+        return;
+    }
+
+    UnsignedOutput out = CreateOutput(destination.GetKeys(), nAmount, sMemo, token_id, blindingKey, type, minStake);
+
+    nAmounts[token_id].nFromOutputs += nAmount;
 
     if (!vOutputs.contains(token_id))
         vOutputs[token_id] = std::vector<UnsignedOutput>();
@@ -138,6 +138,26 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
         // insufficient funds below.
         bool hitInputCap = false;
 
+        // Materialize the deferred subtract-fee-from-amount recipient at
+        // (amount - current fee estimate). BLSCT output size is
+        // value-independent, so lowering the value does not change the fee and
+        // the fixpoint still converges (typically in two passes). Setting
+        // nFromOutputs to the reduced value makes input selection target the
+        // original amount (reduced + fee), so the fee is routed out of the
+        // recipient output rather than out of change.
+        std::optional<UnsignedOutput> sffaOut;
+        if (subtractFeeOutput) {
+            const CAmount fee = nAmounts[TokenId()].nFromFee;
+            const CAmount reduced = subtractFeeOutput->amount - fee;
+            if (reduced < 0) return std::nullopt; // fee exceeds the amount sent
+            nAmounts[subtractFeeOutput->token_id].nFromOutputs = reduced;
+            sffaOut = CreateOutput(subtractFeeOutput->destination.GetKeys(), reduced,
+                                   subtractFeeOutput->memo, subtractFeeOutput->token_id,
+                                   subtractFeeOutput->blindingKey, subtractFeeOutput->type,
+                                   subtractFeeOutput->minStake);
+            gammaAcc = gammaAcc - sffaOut->gamma;
+        }
+
         if (type == STAKED_COMMITMENT_UNSTAKE || type == STAKED_COMMITMENT) {
             for (auto& in_ : vInputs) {
                 for (auto& in : in_.second) {
@@ -203,6 +223,10 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
 
             tx.vout.push_back(changeOutput.out);
             txSigs.push_back(PrivateKey(changeOutput.blindingKey).Sign(changeOutput.out.GetHash()));
+        }
+        if (sffaOut) {
+            tx.vout.push_back(sffaOut->out);
+            txSigs.push_back(PrivateKey(sffaOut->blindingKey).Sign(sffaOut->out.GetHash()));
         }
         CTxOut fee_out{nAmounts[TokenId()].nFromFee, CScript(OP_RETURN)};
 
@@ -315,7 +339,10 @@ std::optional<CMutableTransaction> TxFactoryBase::CreateTransaction(const std::v
                 tx.AddOutput(transactionData.tokenKey, transactionData.destination, transactionData.tokenInfo.publicKey, transactionData.token_id.subid, transactionData.nftMetadata);
             }
         } else if (transactionData.type == NORMAL) {
-            tx.AddOutput(transactionData.destination, transactionData.nAmount, transactionData.sMemo, transactionData.token_id, transactionData.type);
+            // subtract-fee-from-amount is only meaningful for native-token
+            // sends: the fee is always denominated in the native token.
+            const bool subtract_fee = transactionData.fSubtractFeeFromAmount && transactionData.token_id.IsNull();
+            tx.AddOutput(transactionData.destination, transactionData.nAmount, transactionData.sMemo, transactionData.token_id, transactionData.type, transactionData.minStake, subtract_fee, Scalar::Rand(), transactionData.nBLSCTDefaultFee);
         }
     }
     return tx.BuildTx(transactionData.changeDestination, transactionData.minStake, transactionData.type, /*fSubtractedFee=*/false, transactionData.nBLSCTDefaultFee);

--- a/src/blsct/wallet/txfactory_base.h
+++ b/src/blsct/wallet/txfactory_base.h
@@ -7,6 +7,8 @@
 #include <blsct/wallet/txfactory_global.h>
 #include <primitives/transaction.h>
 
+#include <optional>
+
 namespace blsct {
 // Maximum number of inputs the factory will put in a single transaction. Each
 // input adds weight, so an unbounded count (e.g. spending thousands of small PoS
@@ -37,6 +39,12 @@ struct CreateTransactionData {
     // so wallet-built transactions match the consensus minimum-fee rule
     // enforced by `blsct::VerifyTx`.
     CAmount nBLSCTDefaultFee{::BLSCT_DEFAULT_FEE};
+
+    // When true, the recipient bears the transaction fee: the output value is
+    // reduced by the total fee instead of the fee being added on top and taken
+    // from change. Only honored for NORMAL native-token sends. This is the
+    // BLSCT equivalent of the wallet's `subtractfeefromamount`.
+    bool fSubtractFeeFromAmount{false};
 
     // When true (default), stake operations fold every existing staked
     // commitment of the wallet into the new commitment output, so a wallet
@@ -113,6 +121,24 @@ protected:
         vInputs;
     std::map<TokenId, Amounts>
         nAmounts;
+
+    // A pending subtract-fee-from-amount recipient. Its final value is
+    // (amount - total transaction fee), and the total fee is only known once
+    // BuildTx's fee fixpoint converges. Because BLSCT input/output serialized
+    // sizes are value-independent, the fee is identical whatever value we
+    // ultimately commit, so BuildTx can (re)build this output at the reduced
+    // value inside the fixpoint without perturbing the fee. AddOutput records
+    // it here rather than materializing it in vOutputs immediately.
+    struct SubtractFeeOutput {
+        SubAddress destination;
+        CAmount amount;
+        std::string memo;
+        TokenId token_id;
+        CreateTransactionType type;
+        CAmount minStake;
+        Scalar blindingKey;
+    };
+    std::optional<SubtractFeeOutput> subtractFeeOutput;
 
 public:
     TxFactoryBase()= default;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -50,6 +50,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnetworkhashps", 1, "height" },
     { "sendtoblsctaddress", 1, "amount" },
     { "sendtoblsctaddress", 3, "verbose" },
+    { "sendtoblsctaddress", 4, "subtractfeefromamount" },
     { "sendnfttoblsctaddress", 1, "nft_id" },
     { "sendnfttoblsctaddress", 4, "verbose" },
     { "sendtokentoblsctaddress", 2, "amount" },

--- a/src/test/blsct/wallet/txfactory_tests.cpp
+++ b/src/test/blsct/wallet/txfactory_tests.cpp
@@ -115,6 +115,137 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_test, TestingSetup)
     BOOST_CHECK(blsct::TxFactory::CreateTransaction(wallet, wallet->GetOrCreateBLSCTKeyMan(), blsct::CreateTransactionData{recvAddress, 900 * COIN, "test"}) == std::nullopt);
 }
 
+BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_test, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    CCoinsViewDB base{{.path = "test_sffa", .cache_bytes = 1 << 23, .memory_only = true}, {}};
+
+    wallet::CWallet* wallet(new wallet::CWallet(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase()));
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_CHECK(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    auto recvAddress = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+
+    const auto txid = Txid::FromUint256(InsecureRand256());
+    COutPoint outpoint{txid};
+
+    Coin coin;
+    auto out = blsct::CreateOutput(recvAddress, 1000 * COIN, "test");
+    coin.nHeight = 1;
+    coin.out = out.out;
+
+    auto tx = blsct::TxFactory(blsct_km);
+    TxValidationState tx_state;
+
+    {
+        CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+        coins_view_cache.SetBestBlock(InsecureRand256());
+        coins_view_cache.AddCoin(outpoint, std::move(coin), true);
+        BOOST_CHECK(coins_view_cache.Flush());
+    }
+
+    CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+    BOOST_CHECK(tx.AddInput(coins_view_cache, outpoint));
+
+    // Send 900, subtracting the fee from the recipient's amount.
+    tx.AddOutput(recvAddress, 900 * COIN, "test", TokenId(), blsct::NORMAL, 0, /*fSubtractFeeFromAmount=*/true);
+
+    auto finalTx = tx.BuildTx();
+
+    BOOST_REQUIRE(finalTx.has_value());
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+
+    const CAmount fee = GetFeeValue(CTransaction(finalTx.value()));
+    BOOST_REQUIRE(fee > 0);
+
+    // subtract-fee semantics: the recipient bears the fee (receives
+    // amount - fee), and the change is exactly inputs - requested amount,
+    // independent of the fee -- i.e. the wallet spends exactly the requested
+    // amount. (Without the flag the recipient would receive the full 900 and
+    // the change would be 100 - fee.)
+    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    bool foundRecipient = false;
+    bool foundChange = false;
+    for (auto& res : result.amounts) {
+        if (res.message == "test") {
+            foundRecipient = true;
+            BOOST_CHECK_EQUAL(res.amount, 900 * COIN - fee);
+        }
+        if (res.message == "Change") {
+            foundChange = true;
+            BOOST_CHECK_EQUAL(res.amount, 1000 * COIN - 900 * COIN);
+        }
+    }
+    BOOST_CHECK(foundRecipient);
+    BOOST_CHECK(foundChange);
+}
+
+// subtract-fee "send everything": the recipient gets the whole input minus the
+// fee and there is no change output. This is the same shape the `consolidate`
+// RPC builds (one output back to self, fee taken from the merged amount), so it
+// guards that path too.
+BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_sendmax_test, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    CCoinsViewDB base{{.path = "test_sffa_max", .cache_bytes = 1 << 23, .memory_only = true}, {}};
+
+    wallet::CWallet* wallet(new wallet::CWallet(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase()));
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_CHECK(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    auto recvAddress = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+
+    const auto txid = Txid::FromUint256(InsecureRand256());
+    COutPoint outpoint{txid};
+
+    Coin coin;
+    auto out = blsct::CreateOutput(recvAddress, 1000 * COIN, "test");
+    coin.nHeight = 1;
+    coin.out = out.out;
+
+    auto tx = blsct::TxFactory(blsct_km);
+    TxValidationState tx_state;
+
+    {
+        CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+        coins_view_cache.SetBestBlock(InsecureRand256());
+        coins_view_cache.AddCoin(outpoint, std::move(coin), true);
+        BOOST_CHECK(coins_view_cache.Flush());
+    }
+
+    CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+    BOOST_CHECK(tx.AddInput(coins_view_cache, outpoint));
+
+    // Send the entire input, subtracting the fee: no change output can exist.
+    tx.AddOutput(recvAddress, 1000 * COIN, "test", TokenId(), blsct::NORMAL, 0, /*fSubtractFeeFromAmount=*/true);
+
+    auto finalTx = tx.BuildTx();
+
+    BOOST_REQUIRE(finalTx.has_value());
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+
+    const CAmount fee = GetFeeValue(CTransaction(finalTx.value()));
+    BOOST_REQUIRE(fee > 0);
+
+    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    bool foundRecipient = false;
+    for (auto& res : result.amounts) {
+        if (res.message == "test") {
+            foundRecipient = true;
+            BOOST_CHECK_EQUAL(res.amount, 1000 * COIN - fee);
+        }
+        // There must be no change output.
+        BOOST_CHECK(res.message != "Change");
+    }
+    BOOST_CHECK(foundRecipient);
+}
+
 BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
 {
     SeedInsecureRand(SeedRand::ZEROS);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -280,6 +280,20 @@ RPCHelpMan sendtoaddress()
                     verbose_val = request.params[10].get_bool();
                 }
                 inner.push_back(verbose_val);
+                // Forward subtractfeefromamount (sendtoaddress param 4) so the
+                // BLSCT send honors it. sendtoblsctaddress reads it as param 4.
+                bool subtract_fee_val = false;
+                if (request.params.size() > 4 && !request.params[4].isNull()) {
+                    subtract_fee_val = request.params[4].get_bool();
+                }
+                inner.push_back(subtract_fee_val);
+                // Forward comment_to (sendtoaddress param 3) as the wallet-local
+                // "to" comment. sendtoblsctaddress reads it as param 5.
+                if (request.params.size() > 3 && !request.params[3].isNull()) {
+                    inner.push_back(request.params[3]);
+                } else {
+                    inner.push_back("");
+                }
                 JSONRPCRequest subreq = request;
                 subreq.params = inner;
                 return ::sendtoblsctaddress().HandleRequest(subreq);

--- a/test/functional/blsct_subtractfee_comment.py
+++ b/test/functional/blsct_subtractfee_comment.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Regression tests for two BLSCT send-path gaps:
+
+A. `subtractfeefromamount` was a no-op on the BLSCT send path: the recipient
+   received the full amount whether or not the flag was set. It must now reduce
+   the recipient's output by the whole transaction fee (so the wallet spends
+   exactly the requested amount).
+
+B. `comment` / `comment_to` passed to `sendtoaddress` (or `comment_to` to
+   `sendtoblsctaddress`) were dropped for BLSCT wallets, so `listtransactions`
+   never surfaced them for the sender. They must now be stored on the sender's
+   transaction and returned by `listtransactions`.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than
+
+
+class BlsctSubtractFeeCommentTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = 'blsctregtest'
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.createwallet(wallet_name="sender", blsct=True)
+        node.createwallet(wallet_name="receiver", blsct=True)
+        self.sender = node.get_wallet_rpc("sender")
+        self.receiver = node.get_wallet_rpc("receiver")
+
+        self.mining_addr = self.sender.getnewaddress(label="", address_type="blsct")
+        self.generatetoblsctaddress(node, 120, self.mining_addr)
+
+        self.test_subtractfeefromamount()
+        self.test_comment_fields_via_sendtoaddress()
+        self.test_comment_to_via_sendtoblsctaddress()
+
+    def _received(self, addr):
+        rows = self.receiver.listreceivedbyaddress(0, True)
+        row = next((r for r in rows if r["address"] == addr), None)
+        return Decimal(str(row["amount"])) if row is not None else Decimal(0)
+
+    def test_subtractfeefromamount(self):
+        self.log.info("A: subtractfeefromamount reduces the recipient's amount")
+
+        amount = Decimal("10")
+
+        # Baseline: without the flag the receiver gets exactly the full amount.
+        addr_full = self.receiver.getnewaddress(label="", address_type="blsct")
+        self.sender.sendtoaddress(addr_full, amount)
+        self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
+        received_full = self._received(addr_full)
+        assert_equal(received_full, amount)
+
+        # With the flag the receiver gets strictly less: the fee is taken out of
+        # the output rather than added on top.
+        addr_sub = self.receiver.getnewaddress(label="", address_type="blsct")
+        self.sender.sendtoaddress(addr_sub, amount, "", "", True)
+        self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
+        received_sub = self._received(addr_sub)
+
+        fee = amount - received_sub
+        assert_greater_than(fee, Decimal(0))          # a real fee was subtracted
+        assert_greater_than(received_sub, Decimal(0))  # but not the whole amount
+        assert_greater_than(amount, received_sub)      # strictly less than requested
+        # Sanity: the subtracted fee is a small transaction fee, not a huge value.
+        assert_greater_than(Decimal("0.1"), fee)
+        self.log.info(f"receiver got {received_sub} of {amount} (fee {fee} subtracted)")
+
+        # The sendtoblsctaddress subtractfeefromamount arg (positional) behaves
+        # identically.
+        addr_direct = self.receiver.getnewaddress(label="", address_type="blsct")
+        self.sender.sendtoblsctaddress(addr_direct, amount, "", False, True)
+        self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
+        assert_greater_than(amount, self._received(addr_direct))
+
+    def _find_send_row(self, wallet, comment):
+        for e in wallet.listtransactions("*", 1000, 0, True):
+            if e.get("category") == "send" and e.get("comment") == comment:
+                return e
+        return None
+
+    def test_comment_fields_via_sendtoaddress(self):
+        self.log.info("B: sendtoaddress comment/comment_to reach listtransactions")
+
+        addr = self.receiver.getnewaddress(label="", address_type="blsct")
+        self.sender.sendtoaddress(addr, Decimal("1"), "invoice-42", "Acme Corp")
+        self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
+
+        row = self._find_send_row(self.sender, "invoice-42")
+        assert row is not None, "send row with comment 'invoice-42' not found in listtransactions"
+        assert_equal(row.get("comment"), "invoice-42")
+        assert_equal(row.get("to"), "Acme Corp")
+
+    def test_comment_to_via_sendtoblsctaddress(self):
+        self.log.info("B: sendtoblsctaddress comment_to reaches listtransactions")
+
+        addr = self.receiver.getnewaddress(label="", address_type="blsct")
+        # positional: address, amount, memo, verbose, subtractfeefromamount, comment_to
+        self.sender.sendtoblsctaddress(addr, Decimal("1"), "memo-note", False, False, "Bob")
+        self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
+
+        row = self._find_send_row(self.sender, "memo-note")
+        assert row is not None, "send row with comment 'memo-note' not found in listtransactions"
+        assert_equal(row.get("comment"), "memo-note")
+        assert_equal(row.get("to"), "Bob")
+
+
+if __name__ == '__main__':
+    BlsctSubtractFeeCommentTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -371,6 +371,7 @@ BASE_SCRIPTS = [
     'blsct_rawtransaction.py',
     'blsct_cold_signing.py',
     'blsct_import_scriptpubkeys.py',
+    'blsct_subtractfee_comment.py',
     'bls_message_signing.py'
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time


### PR DESCRIPTION
Fixes two independent gaps on the BLSCT send path.

## 1. `subtractfeefromamount` was a no-op
The recipient received the full amount whether or not the flag was set. The flag never reached the tx factory: `sendtoblsctaddress` had no such argument, `CreateTransactionData` had no field for it, and `CreateTransaction`'s NORMAL branch called `AddOutput` without it — so the fee was always added on top and taken from change.

Correct `subtractfeefromamount` requires the recipient to bear the **total** transaction fee (so "send everything" works), but the total fee is only known once `BuildTx`'s fee fixpoint converges. Since BLSCT input/output serialized sizes are **value-independent**, the fee is identical whatever value we finally commit — so `AddOutput` now **defers** a subtract-fee recipient and `BuildTx` materializes it at `amount - total_fee` inside the fixpoint (converges in two passes). Input selection then targets the original amount and the fee is routed out of the recipient output instead of out of change.

Wired end to end: a `subtractfeefromamount` arg on `sendtoblsctaddress`, a field on `CreateTransactionData`, and forwarding of `sendtoaddress` param 4 through the BLSCT routing in `spend.cpp`. The `consolidate` RPC (which already used the subtract-fee path) now gets correct full-fee subtraction too.

## 2. `comment` / `comment_to` were dropped for BLSCT wallets
`sendtoaddress` routes to `sendtoblsctaddress`, whose commit path passed an **empty** `mapValue` to `CommitTransaction`, so the sender's `CWalletTx` carried no `comment`/`to` and `listtransactions` never surfaced them (and `comment_to` was dropped entirely).

`blsct::SendTransaction` now takes a `mapValue` and forwards it to `CommitTransaction`; `sendtoblsctaddress` builds it from the memo (as `comment`) and a new `comment_to` arg (as `to`); `sendtoaddress` forwards param 3. `WalletTxToJSON` already emits every `mapValue` key, so no change was needed there.

## Tests
- **`blsct_txfactory_tests`** (unit): subtract-fee reduces the recipient by exactly the fee, with change = `inputs - requested amount`; a send-everything case yields recipient = `input - fee` and **no change** — the exact shape `consolidate` builds.
- **`blsct_subtractfee_comment.py`** (functional): end-to-end `subtractfeefromamount` reduces the received amount (baseline gets the full amount); `comment`/`comment_to` via both `sendtoaddress` and `sendtoblsctaddress` are surfaced by `listtransactions` for the sender.

Full BLSCT functional suite (htlc, staking, token, output_storage, rawtransaction, same_block_multi_send, listtransactions_stake) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)