### PR TITLE
fix(wallet): default createwallet and navio-wallet to BLSCT

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -9,7 +9,7 @@ Wallets can be created with the `createwallet` RPC or with the `Create wallet` G
 
 In the GUI, the `Create a new wallet` button is displayed on the main screen when there is no wallet loaded. Alternatively, there is the option `File` ->`Create wallet`.
 
-The following command, for example, creates a descriptor wallet. More information about this command may be found by running `navio-cli help createwallet`.
+The following command, for example, creates a BLSCT wallet, navio's default and standard wallet type. Pass `blsct=false` to create a descriptor wallet instead. More information about this command may be found by running `navio-cli help createwallet`.
 
 ```
 $ navio-cli createwallet "wallet-01"

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -42,7 +42,7 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddArg("-dumpfile=<file name>", "When used with 'dump', writes out the records to this file. When used with 'createfromdump', loads the records into a new wallet.", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-debug=<category>", "Output debugging information (default: 0).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-descriptors", "Create descriptors wallet. Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-blsct", "Create blsct wallet. Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-blsct", "Create blsct wallet (default wallet type on navio when -legacy and -descriptors are not set). Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-seed", "Seed used for the wallet creation. Only for 'create'. Can be a master seed or an audit key.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mnemonic", "BIP-39 mnemonic phrase (24 words) to restore a BLSCT wallet from. Only for 'create'. Mutually exclusive with '-seed'.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-legacy", "Create legacy wallet. Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -350,17 +350,17 @@ static RPCHelpMan createwallet()
 {
     return RPCHelpMan{
         "createwallet",
-        "\nCreates and loads a new wallet.\n",
+        "\nCreates and loads a new wallet. By default this creates a BLSCT wallet, navio's standard wallet type; pass blsct=false to create a legacy/descriptor wallet instead.\n",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name for the new wallet. If this is a path, the wallet will be created at the path location."},
             {"disable_private_keys", RPCArg::Type::BOOL, RPCArg::Default{false}, "Disable the possibility of private keys (only watchonlys are possible in this mode)."},
             {"blank", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using setblsctseed."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Encrypt the wallet with this passphrase."},
             {"avoid_reuse", RPCArg::Type::BOOL, RPCArg::Default{false}, "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind."},
-            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{true}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation."},
+            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{true}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation. Ignored while 'blsct' is true (the default); explicitly setting both 'descriptors' and 'blsct' to true is an error. Set 'blsct' to false to create a descriptor wallet."},
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
-            {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true."},
-            {"blsct", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a wallet with BLSCT keys."},
+            {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true (and blsct set to false)."},
+            {"blsct", RPCArg::Type::BOOL, RPCArg::Default{true}, "Create a wallet with BLSCT keys. This is the default and standard wallet type on navio. Set to false to create a legacy or descriptor wallet instead."},
             {"storage_output", RPCArg::Type::BOOL, RPCArg::Default{false}, "Enables the storage of outputs instead of full txs (experimental)."},
             {"seed", RPCArg::Type::STR_HEX, RPCArg::Default{""}, "Create the BLSCT wallet from the specified seed (can be a master seed or an audit key). Requires blsct=true."},
             {"mnemonic", RPCArg::Type::STR, RPCArg::Default{""}, "BIP-39 mnemonic phrase (24 words) to restore a BLSCT wallet from. Requires blsct=true. Mutually exclusive with 'seed'."},
@@ -374,7 +374,7 @@ static RPCHelpMan createwallet()
                                                                                                                                  }},
                                               {RPCResult::Type::STR, "mnemonic", /*optional=*/true, "BIP-39 mnemonic phrase (24 words) for new BLSCT wallets. Only returned for new BLSCT wallets created without a seed or mnemonic."},
                                           }},
-        RPCExamples{HelpExampleCli("createwallet", "\"testwallet\"") + HelpExampleRpc("createwallet", "\"testwallet\"") + HelpExampleCliNamed("createwallet", {{"wallet_name", "descriptors"}, {"avoid_reuse", true}, {"descriptors", true}, {"load_on_startup", true}}) + HelpExampleRpcNamed("createwallet", {{"wallet_name", "descriptors"}, {"avoid_reuse", true}, {"descriptors", true}, {"load_on_startup", true}})},
+        RPCExamples{HelpExampleCli("createwallet", "\"testwallet\"") + HelpExampleRpc("createwallet", "\"testwallet\"") + HelpExampleCliNamed("createwallet", {{"wallet_name", "descriptors"}, {"avoid_reuse", true}, {"descriptors", true}, {"blsct", false}, {"load_on_startup", true}}) + HelpExampleRpcNamed("createwallet", {{"wallet_name", "descriptors"}, {"avoid_reuse", true}, {"descriptors", true}, {"blsct", false}, {"load_on_startup", true}})},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             WalletContext& context = EnsureWalletContext(request.context);
             uint64_t flags = 0;
@@ -399,10 +399,22 @@ static RPCHelpMan createwallet()
             if (!request.params[4].isNull() && request.params[4].get_bool()) {
                 flags |= WALLET_FLAG_AVOID_REUSE;
             }
-            // TODO(@aguycalled, @gogo): Discuss whether to remove legacy BDB and descriptor wallet support.
-            // With BLSCT as the standard wallet type, keeping these options may lead to users
-            // misconfiguring wallets. Consider simplifying to BLSCT-only.
-            if (request.params[5].isNull() || request.params[5].get_bool()) {
+            // BLSCT is the default and standard wallet type on navio. 'descriptors' still
+            // defaults to true for compatibility with upstream callers, but it is only
+            // honored when the wallet is not a BLSCT wallet. Explicitly requesting both
+            // blsct=true and descriptors=true is rejected rather than silently resolved,
+            // so users don't accidentally end up with a wallet type they didn't intend.
+            bool blsct_explicit = !request.params[8].isNull();
+            bool blsct = blsct_explicit ? request.params[8].get_bool() : true;
+
+            bool descriptors_explicit = !request.params[5].isNull();
+            bool descriptors = descriptors_explicit ? request.params[5].get_bool() : true;
+
+            if (blsct && descriptors_explicit && descriptors) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot set both 'blsct' and 'descriptors' to true. BLSCT is the default wallet type on navio; omit 'descriptors' (or set it to false) to create a BLSCT wallet, or set 'blsct' to false to create a descriptor wallet.");
+            }
+
+            if (descriptors && !blsct) {
 #ifndef USE_SQLITE
                 throw JSONRPCError(RPC_WALLET_ERROR, "Compiled without sqlite support (required for descriptor wallets)");
 #endif
@@ -416,10 +428,7 @@ static RPCHelpMan createwallet()
 #endif
             }
 
-
-            // TODO(@aguycalled, @gogo): Should blsct=true become the default? This would eliminate
-            // the need for the flag and reduce misconfiguration risk for new users.
-            if (!request.params[8].isNull() && request.params[8].get_bool()) {
+            if (blsct) {
                 flags |= WALLET_FLAG_BLSCT;
                 flags &= ~WALLET_FLAG_DESCRIPTORS;
                 // Output storage mode is default for BLSCT wallets

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -159,18 +159,15 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         DatabaseOptions options;
         ReadDatabaseArgs(args, options);
         options.require_create = true;
-        // TODO(@aguycalled, @gogo): Discuss whether to remove -legacy and -descriptors options.
-        // With BLSCT as the standard wallet type, these options create confusion and increase
-        // the chance of users creating the wrong wallet type. Consider making -blsct the default.
+        // BLSCT is the default and standard wallet type on navio: when none of
+        // -legacy, -descriptors or -blsct are specified, a BLSCT wallet is created.
         bool make_legacy = args.GetBoolArg("-legacy", false);
-        bool make_blsct = args.GetBoolArg("-blsct", false);
-        bool make_descriptors = (!args.IsArgSet("-descriptors") && !args.IsArgSet("-legacy") && !args.IsArgSet("-blsct")) || (args.IsArgSet("-descriptors") && args.GetBoolArg("-descriptors", true));
+        bool make_descriptors = args.GetBoolArg("-descriptors", false);
+        bool make_blsct = (!args.IsArgSet("-descriptors") && !args.IsArgSet("-legacy") && !args.IsArgSet("-blsct")) || (args.IsArgSet("-blsct") && args.GetBoolArg("-blsct", true));
         if (make_legacy + make_descriptors + make_blsct > 1) {
             tfm::format(std::cerr, "Only one of -legacy, -blsct or -descriptors can be set to true, not both\n");
             return false;
         }
-        // TODO(@aguycalled, @gogo): If legacy/descriptors are removed, this check can be simplified
-        // to just defaulting to BLSCT, removing the need for users to specify wallet type at all.
         if (!make_legacy && !make_descriptors && !make_blsct) {
             tfm::format(std::cerr, "One of -legacy, -blsct or -descriptors must be set to true (or omitted)\n");
             return false;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -441,7 +441,11 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if wallet_name is not False:
             n = self.nodes[node]
             if wallet_name is not None:
-                n.createwallet(wallet_name=wallet_name, descriptors=self.options.descriptors, load_on_startup=True, blsct=blsct)
+                # BLSCT is the default wallet type on navio, and createwallet rejects
+                # explicitly requesting both blsct=true and descriptors=true, so only
+                # request a descriptor wallet when not creating a BLSCT wallet.
+                descriptors = False if blsct else self.options.descriptors
+                n.createwallet(wallet_name=wallet_name, descriptors=descriptors, load_on_startup=True, blsct=blsct)
             n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase', rescan=True)
 
     def run_test(self):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -855,7 +855,11 @@ class RPCOverloadWrapper():
 
     def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None, blsct=False, storage_output=False, seed=None, mnemonic=None):
         if descriptors is None:
-            descriptors = self.descriptors
+            # BLSCT is the default wallet type on navio, and the RPC rejects
+            # explicitly requesting both blsct=true and descriptors=true. Only
+            # fall back to the node's configured descriptors default when not
+            # creating a BLSCT wallet.
+            descriptors = False if blsct else self.descriptors
         kwargs = {}
         if seed is not None:
             kwargs['seed'] = seed

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -33,8 +33,12 @@ class ToolWalletTest(BitcoinTestFramework):
 
     def bitcoin_wallet_process(self, *args):
         default_args = ['-datadir={}'.format(self.nodes[0].datadir_path), '-chain=%s' % self.chain]
-        if not self.options.descriptors and 'create' in args:
-            default_args.append('-legacy')
+        # navio-wallet defaults to creating a BLSCT wallet when none of
+        # -legacy, -descriptors or -blsct are given, so pin down the wallet
+        # type explicitly here to match this test's self.options.descriptors
+        # expectations instead of relying on the tool's own default.
+        if 'create' in args:
+            default_args.append('-legacy' if not self.options.descriptors else '-descriptors')
 
         return subprocess.Popen([self.options.naviowallet] + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 

--- a/test/functional/wallet_mnemonic.py
+++ b/test/functional/wallet_mnemonic.py
@@ -258,10 +258,13 @@ class WalletMnemonicTest(BitcoinTestFramework):
         assert "Only 24-word" in stderr_12w
 
         self.log.info("Test CLI tool: navio-wallet create with -mnemonic but without -blsct errors")
+        # BLSCT is the tool's default wallet type, so -descriptors must be passed
+        # explicitly here to exercise the "-mnemonic requires -blsct" validation.
         cli_no_blsct_args = [
             '-datadir={}'.format(self.nodes[0].datadir_path),
             '-chain={}'.format(self.chain),
             '-wallet=test_cli_mnemonic_no_blsct',
+            '-descriptors',
             '-mnemonic={}'.format(cli_mnemonic),
             'create',
         ]
@@ -273,10 +276,13 @@ class WalletMnemonicTest(BitcoinTestFramework):
         assert "requires -blsct" in stderr_nb
 
         self.log.info("Test CLI tool: navio-wallet create with -seed but without -blsct errors")
+        # BLSCT is the tool's default wallet type, so -descriptors must be passed
+        # explicitly here to exercise the "-seed requires -blsct" validation.
         cli_no_blsct_seed_args = [
             '-datadir={}'.format(self.nodes[0].datadir_path),
             '-chain={}'.format(self.chain),
             '-wallet=test_cli_seed_no_blsct',
+            '-descriptors',
             '-seed={}'.format("00" * 32),
             'create',
         ]


### PR DESCRIPTION
## Summary

BLSCT is navio's standard mainnet wallet type, but a bare `createwallet "name"` (and `navio-wallet create`) silently produced a **transparent descriptor wallet**, forcing users to opt in with `blsct=true`. This flips the default so BLSCT is created unless the caller explicitly opts out — resolving the standing in-code TODOs.

## Changes
- **`createwallet` RPC**: `blsct` arg now defaults to `true`. Explicitly requesting `blsct=true` **and** `descriptors=true` together is now a hard `RPC_INVALID_PARAMETER` error instead of a silent override. `blsct=false` still yields a legacy/descriptor wallet exactly as before.
- **`navio-wallet` tool**: `-blsct` is the default when no wallet-type flag is given, symmetric with the previous descriptor default. `-descriptors`/`-legacy` remain explicit opt-outs.
- Help text, `doc/managing-wallets.md`, and RPC examples updated for BLSCT-by-default.
- Removed the resolved `createwallet`/`wallettool` TODOs.

## Test framework
`createwallet()` in the Python framework always resolved `descriptors` to a bool before the RPC call, which would now collide with the new conflict check for every `blsct=True` test. Fixed centrally: only request descriptors when **not** creating a BLSCT wallet (`test_node.py`, `test_framework.py`). `tool_wallet.py` and `wallet_mnemonic.py` CLI negative tests now pin the wallet type explicitly.

## Testing
- `cmake --build build -j4` clean (naviod + navio-wallet).
- Full wallet/blsct/tool functional suite (85 units) passed.
- Manual regtest smoke: bare `createwallet` → BLSCT; `blsct=true,descriptors=true` → error; `blsct=false` → descriptor wallet; `navio-wallet create` → BLSCT.

---
Part of the navio-cli BLSCT-first cleanup. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa