### PR TITLE
fix(wallet): guard transparent-only spend RPCs against BLSCT

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -28,6 +28,59 @@
 #include <univalue.h>
 
 namespace wallet {
+//! Guards for transparent-only spend RPCs that would otherwise silently build a
+//! transparent transaction (or skip confidential coins entirely) when run against
+//! a BLSCT (confidential) wallet, or when asked to pay a BLSCT destination.
+//! This is guards-only: none of these RPCs are rerouted to their blsct equivalents.
+static void EnsureNotBLSCTWallet(const CWallet& wallet, const std::string& blsct_rpc_alternative)
+{
+    if (wallet.IsWalletFlagSet(WALLET_FLAG_BLSCT)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf(
+                                                  "This RPC does not support BLSCT (confidential) wallets: it would silently "
+                                                  "build a transparent transaction and/or ignore confidential coins. Use %s instead.",
+                                                  blsct_rpc_alternative));
+    }
+}
+
+static void EnsureDestinationNotBLSCT(const CTxDestination& dest, const std::string& address, const std::string& blsct_rpc_alternative)
+{
+    if (std::holds_alternative<blsct::DoublePublicKey>(dest)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf(
+                                                       "%s is a BLSCT (confidential) address; this RPC cannot pay it and would "
+                                                       "silently build a broken transparent output. Use %s instead.",
+                                                       address, blsct_rpc_alternative));
+    }
+}
+
+//! Scan an `outputs`-style argument -- either the dict form ({"addr": amount, ...})
+//! or the array-of-single-key-object form ([{"addr": amount}, {"data": hex}, ...],
+//! as accepted by send()/walletcreatefundedpsbt()'s OutputsDoc() -- for any address
+//! key that decodes to a BLSCT destination.
+static void EnsureOutputsHaveNoBLSCTDestination(const UniValue& outputs_in, const std::string& blsct_rpc_alternative)
+{
+    if (outputs_in.isNull()) return;
+
+    auto check_key = [&](const std::string& name) {
+        if (name == "data") return;
+        CTxDestination dest = DecodeDestination(name);
+        if (IsValidDestination(dest)) {
+            EnsureDestinationNotBLSCT(dest, name, blsct_rpc_alternative);
+        }
+    };
+
+    if (outputs_in.isObject()) {
+        for (const std::string& name : outputs_in.getKeys()) check_key(name);
+        return;
+    }
+
+    const UniValue& outputs = outputs_in.get_array();
+    for (unsigned int i = 0; i < outputs.size(); ++i) {
+        const UniValue& output = outputs[i];
+        if (!output.isObject()) continue;
+        for (const std::string& name : output.getKeys()) check_key(name);
+    }
+}
+
 static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient>& recipients)
 {
     std::set<CTxDestination> destinations;
@@ -218,8 +271,10 @@ RPCHelpMan sendtoaddress()
         "sendtoaddress",
         "\nSend an amount to a given address." +
             HELP_REQUIRING_PASSPHRASE +
-            "\n\nOn BLSCT networks this call is routed like sendtoblsctaddress: use address, amount, "
-            "optional comment (stored as an on-chain memo), and optional verbose; other arguments are ignored.",
+            "\n\nOn BLSCT networks this call is routed like sendtoblsctaddress: only address, amount, "
+            "optional comment (stored as an on-chain memo), and optional verbose are used. The following "
+            "arguments are silently IGNORED in that case: comment_to, subtractfeefromamount, replaceable, "
+            "conf_target, estimate_mode, avoid_reuse, and fee_rate.",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Navio address to send to."},
             {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The amount in " + CURRENCY_UNIT + " to send. eg 0.1"},
@@ -395,6 +450,8 @@ RPCHelpMan sendmany()
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
 
+            EnsureNotBLSCTWallet(*pwallet, "sendtoblsctaddress");
+
             // Make sure the results are valid at least up to the most recent block
             // the user could have gotten from another RPC command prior to now
             pwallet->BlockUntilSyncedToCurrentChain();
@@ -405,6 +462,7 @@ RPCHelpMan sendmany()
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Dummy value must be set to \"\"");
             }
             UniValue sendTo = request.params[1].get_obj();
+            EnsureOutputsHaveNoBLSCTDestination(sendTo, "sendtoblsctaddress");
 
             mapValue_t mapValue;
             if (!request.params[3].isNull() && !request.params[3].get_str().empty())
@@ -836,6 +894,8 @@ RPCHelpMan fundrawtransaction()
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
 
+            EnsureNotBLSCTWallet(*pwallet, "fundblsctrawtransaction");
+
             // parse hex string from parameter
             CMutableTransaction tx;
             bool try_witness = request.params[2].isNull() ? true : request.params[2].get_bool();
@@ -919,6 +979,8 @@ RPCHelpMan signrawtransactionwithwallet()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
+
+            EnsureNotBLSCTWallet(*pwallet, "signblsctrawtransaction");
 
             CMutableTransaction mtx;
             if (!DecodeHexTx(mtx, request.params[0].get_str())) {
@@ -1044,6 +1106,11 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
         [want_psbt](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
+
+            if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLSCT)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "BLSCT (confidential) wallets do not support transparent RBF fee bumping. "
+                                                      "Construct and broadcast a new confidential transaction instead (see sendtoblsctaddress).");
+            }
 
             if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER) && !want_psbt) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "bumpfee is not available with wallets that have private keys disabled. Use psbtbumpfee instead.");
@@ -1261,6 +1328,9 @@ RPCHelpMan send()
                           std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
                           if (!pwallet) return UniValue::VNULL;
 
+                          EnsureNotBLSCTWallet(*pwallet, "sendtoblsctaddress");
+                          EnsureOutputsHaveNoBLSCTDestination(request.params[0], "sendtoblsctaddress");
+
                           UniValue options{request.params[4].isNull() ? UniValue::VOBJ : request.params[4]};
                           InterpretFeeEstimationInstructions(/*conf_target=*/request.params[1], /*estimate_mode=*/request.params[2], /*fee_rate=*/request.params[3], options);
                           PreventOutdatedOptions(options);
@@ -1359,6 +1429,9 @@ RPCHelpMan sendall()
                       [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
                           std::shared_ptr<CWallet> const pwallet{GetWalletForJSONRPCRequest(request)};
                           if (!pwallet) return UniValue::VNULL;
+
+                          EnsureNotBLSCTWallet(*pwallet, "sendtoblsctaddress");
+
                           // Make sure the results are valid at least up to the most recent block
                           // the user could have gotten from another RPC command prior to now
                           pwallet->BlockUntilSyncedToCurrentChain();
@@ -1562,6 +1635,8 @@ RPCHelpMan walletprocesspsbt()
             const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
 
+            EnsureNotBLSCTWallet(*pwallet, "the blsct raw transaction RPCs (createblsctrawtransaction/fundblsctrawtransaction/signblsctrawtransaction)");
+
             const CWallet& wallet{*pwallet};
             // Make sure the results are valid at least up to the most recent block
             // the user could have gotten from another RPC command prior to now
@@ -1692,6 +1767,8 @@ RPCHelpMan walletcreatefundedpsbt()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
+
+            EnsureNotBLSCTWallet(*pwallet, "the blsct raw transaction RPCs (createblsctrawtransaction/fundblsctrawtransaction/signblsctrawtransaction)");
 
             CWallet& wallet{*pwallet};
             // Make sure the results are valid at least up to the most recent block

--- a/test/functional/blsct_spend_rpc_guards.py
+++ b/test/functional/blsct_spend_rpc_guards.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Functional tests for the BLSCT guards on transparent-only spend RPCs.
+
+navio's proper wallet format is BLSCT (confidential). The transparent-only
+spend RPCs in wallet/rpc/spend.cpp must never silently be driven against a
+BLSCT wallet (they would build a transparent transaction and/or leave
+confidential balance behind), nor against a BLSCT destination address (they
+would build a broken, unspendable transparent output). This test asserts
+that each guarded RPC fails fast with an actionable error pointing at the
+correct blsct RPC, instead of silently doing the wrong thing.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+
+class BLSCTSpendRPCGuardsTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Create a blank BLSCT (confidential) wallet")
+        node.createwallet(wallet_name="blsct_wallet", blsct=True, blank=True)
+        blsct_wallet = node.get_wallet_rpc("blsct_wallet")
+        blsct_wallet.setblsctseed()
+        blsct_addr = blsct_wallet.getnewaddress(label="", address_type="blsct")
+
+        self.log.info("Create a transparent wallet")
+        node.createwallet(wallet_name="transparent_wallet")
+        transparent_wallet = node.get_wallet_rpc("transparent_wallet")
+        transparent_addr = transparent_wallet.getnewaddress()
+
+        dummy_txid = "00" * 32
+
+        self.log.info("sendmany is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "sendtoblsctaddress",
+            blsct_wallet.sendmany, "", {transparent_addr: 1},
+        )
+
+        self.log.info("send is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "sendtoblsctaddress",
+            blsct_wallet.send, {transparent_addr: 1},
+        )
+
+        self.log.info("sendall is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "sendtoblsctaddress",
+            blsct_wallet.sendall, [transparent_addr],
+        )
+
+        self.log.info("fundrawtransaction is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "fundblsctrawtransaction",
+            blsct_wallet.fundrawtransaction, "00",
+        )
+
+        self.log.info("signrawtransactionwithwallet is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "signblsctrawtransaction",
+            blsct_wallet.signrawtransactionwithwallet, "00",
+        )
+
+        self.log.info("bumpfee is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "BLSCT",
+            blsct_wallet.bumpfee, dummy_txid,
+        )
+
+        self.log.info("psbtbumpfee is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "BLSCT",
+            blsct_wallet.psbtbumpfee, dummy_txid,
+        )
+
+        self.log.info("walletprocesspsbt is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "blsct",
+            blsct_wallet.walletprocesspsbt, "cHNidP8AAAA=",
+        )
+
+        self.log.info("walletcreatefundedpsbt is rejected on a BLSCT wallet")
+        assert_raises_rpc_error(
+            -4, "blsct",
+            blsct_wallet.walletcreatefundedpsbt, [], [{"data": "00"}],
+        )
+
+        self.log.info("sendmany rejects a BLSCT destination even from a transparent wallet")
+        assert_raises_rpc_error(
+            -8, "sendtoblsctaddress",
+            transparent_wallet.sendmany, "", {blsct_addr: 1},
+        )
+
+        self.log.info("send rejects a BLSCT destination even from a transparent wallet")
+        assert_raises_rpc_error(
+            -8, "sendtoblsctaddress",
+            transparent_wallet.send, {blsct_addr: 1},
+        )
+
+
+if __name__ == '__main__':
+    BLSCTSpendRPCGuardsTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -363,6 +363,7 @@ BASE_SCRIPTS = [
     'blsct_nft.py',
     'blsct_htlc.py',
     'blsct_setblsctseed.py',
+    'blsct_spend_rpc_guards.py',
     'blsct_script_validation.py',
     'blsct_balance_proof.py',
     'blsct_pops_consensus.py',


### PR DESCRIPTION
## Summary

The transparent-only spend RPCs in `wallet/rpc/spend.cpp` accept a BLSCT (`nv1…`) destination — it passes `DecodeDestination` via the `DoublePublicKey` variant — or run on a BLSCT wallet, then **silently build a transparent transaction, skip confidential coins, or emit a broken anyone-can-spend output** (`GetScriptForDestination` on a BLSCT dest yields a bogus `OP_1`-style script). This PR makes them **fail fast** with an actionable error pointing at the correct blsct RPC. Guards only — full BLSCT rerouting of these commands is deliberately left as follow-up.

## Guards added
Fail on a **BLSCT wallet**: `sendmany`, `send`, `sendall`, `fundrawtransaction` (→ `fundblsctrawtransaction`), `walletprocesspsbt`, `walletcreatefundedpsbt` (→ blsct raw-tx RPCs), `signrawtransactionwithwallet` (→ `signblsctrawtransaction`), `bumpfee`/`psbtbumpfee`.
Fail on a **BLSCT recipient address** (even from a transparent wallet): `sendmany`, `send` (→ `sendtoblsctaddress`).
`sendtoaddress` routing is **unchanged**; its help now spells out exactly which args are ignored under BLSCT routing (doc-only).

## Detection
- BLSCT wallet: `IsWalletFlagSet(WALLET_FLAG_BLSCT)` (canonical predicate across `src/wallet/`).
- BLSCT destination: `std::holds_alternative<blsct::DoublePublicKey>(dest)`.
- Three small helpers (`EnsureNotBLSCTWallet`, `EnsureDestinationNotBLSCT`, `EnsureOutputsHaveNoBLSCTDestination`) at the top of `spend.cpp`.

## Testing
- New `blsct_spend_rpc_guards.py` — asserts every guard raises on a BLSCT wallet, plus the per-destination guard on `sendmany`/`send` from a transparent wallet. Registered in `test_runner.py`.
- `cmake --build build -j4` clean.
- New test + `blsct_setblsctseed`/`blsct_rawtransaction` (blsct RPCs unaffected) + `wallet_sendall`/`wallet_bumpfee` (transparent wallets unaffected) all pass.

## Notes for review
- PSBT and `bumpfee` guards can't name a single blsct-equivalent RPC (none exists); their messages describe the workflow instead.
- `EnsureOutputsHaveNoBLSCTDestination` re-scans the `outputs` UniValue rather than reusing `rawtransaction_util.cpp` (kept out of scope for a spend.cpp-only PR).

---
Part of the navio-cli BLSCT-first cleanup. Independent of #305. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa