### PR TITLE
chore(cli): drop PoW -generate and Difficulty from navio-cli

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -16,7 +16,6 @@
 #include <compat/stdin.h>
 #include <policy/feerate.h>
 #include <rpc/client.h>
-#include <rpc/mining.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <tinyformat.h>
@@ -64,9 +63,6 @@ static constexpr std::array NETWORKS{"not_publicly_routable", "ipv4", "ipv6", "o
 static constexpr std::array NETWORK_SHORT_NAMES{"npr", "ipv4", "ipv6", "onion", "i2p", "cjdns", "int"};
 static constexpr std::array UNREACHABLE_NETWORK_IDS{/*not_publicly_routable*/0, /*internal*/6};
 
-/** Default number of blocks to generate for RPC generatetoaddress. */
-static const std::string DEFAULT_NBLOCKS = "1";
-
 /** Default -color setting. */
 static const std::string DEFAULT_COLOR_SETTING{"auto"};
 
@@ -83,12 +79,6 @@ static void SetupCliArgs(ArgsManager& argsman)
     argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-generate",
-                   strprintf("Generate blocks, equivalent to RPC getnewaddress followed by RPC generatetoaddress. Optional positional integer "
-                             "arguments are number of blocks to generate (default: %s) and maximum iterations to try (default: %s), equivalent to "
-                             "RPC generatetoaddress nblocks and maxtries arguments. Example: navio-cli -generate 4 1000",
-                             DEFAULT_NBLOCKS, DEFAULT_MAX_TRIES),
-                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-addrinfo", "Get the number of addresses known to the node, per network and total, after filtering for quality and recency. The total number of addresses known to the node may be higher.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the output of -getinfo is the result of multiple non-atomic requests. Some entries in the output may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-netinfo", "Get network peer connection information from the remote server. An optional integer argument from 0 to 4 can be passed for different peers listings (default: 0). Pass \"help\" for detailed help documentation.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -356,7 +346,6 @@ public:
         result.pushKV("connections", connections);
 
         result.pushKV("networks", batch[ID_NETWORKINFO]["result"]["networks"]);
-        result.pushKV("difficulty", batch[ID_BLOCKCHAININFO]["result"]["difficulty"]);
         result.pushKV("chain", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"]));
         if (!batch[ID_WALLETINFO]["result"].isNull()) {
             result.pushKV("has_wallet", true);
@@ -368,6 +357,9 @@ public:
             result.pushKV("paytxfee", batch[ID_WALLETINFO]["result"]["paytxfee"]);
         }
         if (!batch[ID_BALANCES]["result"].isNull()) {
+            // getbalances' mine.trusted already sums the transparent and BLSCT
+            // trusted balances (see GetBlsctBalance() usage in getbalances()),
+            // so this headline figure reflects the wallet's total spendable funds.
             result.pushKV("balance", batch[ID_BALANCES]["result"]["mine"]["trusted"]);
         }
         result.pushKV("relayfee", batch[ID_NETWORKINFO]["result"]["relayfee"]);
@@ -697,28 +689,6 @@ public:
         "> navio-cli -netinfo help\n"};
 };
 
-/** Process RPC generatetoaddress request. */
-class GenerateToAddressRequestHandler : public BaseRequestHandler
-{
-public:
-    UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
-    {
-        address_str = args.at(1);
-        UniValue params{RPCConvertValues("generatetoaddress", args)};
-        return JSONRPCRequestObj("generatetoaddress", params, 1);
-    }
-
-    UniValue ProcessReply(const UniValue &reply) override
-    {
-        UniValue result(UniValue::VOBJ);
-        result.pushKV("address", address_str);
-        result.pushKV("blocks", reply.get_obj()["result"]);
-        return JSONRPCReplyObj(result, NullUniValue, 1);
-    }
-protected:
-    std::string address_str;
-};
-
 /** Process default single requests */
 class DefaultRequestHandler: public BaseRequestHandler {
 public:
@@ -1019,8 +989,7 @@ static void ParseGetInfoResult(UniValue& result)
       ibd_progress_bar += " ";
     }
 
-    result_string += strprintf("Verification progress: %s%.4f%%\n", ibd_progress_bar, ibd_progress * 100);
-    result_string += strprintf("Difficulty: %s\n\n", result["difficulty"].getValStr());
+    result_string += strprintf("Verification progress: %s%.4f%%\n\n", ibd_progress_bar, ibd_progress * 100);
 
     result_string += strprintf(
         "%sNetwork: in %s, out %s, total %s%s\n",
@@ -1092,34 +1061,6 @@ static void ParseGetInfoResult(UniValue& result)
     result.setStr(result_string);
 }
 
-/**
- * Call RPC getnewaddress.
- * @returns getnewaddress response as a UniValue object.
- */
-static UniValue GetNewAddress()
-{
-    std::optional<std::string> wallet_name{};
-    if (gArgs.IsArgSet("-rpcwallet")) wallet_name = gArgs.GetArg("-rpcwallet", "");
-    DefaultRequestHandler rh;
-    return ConnectAndCallRPC(&rh, "getnewaddress", /* args=*/{}, wallet_name);
-}
-
-/**
- * Check bounds and set up args for RPC generatetoaddress params: nblocks, address, maxtries.
- * @param[in] address  Reference to const string address to insert into the args.
- * @param     args     Reference to vector of string args to modify.
- */
-static void SetGenerateToAddressArgs(const std::string& address, std::vector<std::string>& args)
-{
-    if (args.size() > 2) throw std::runtime_error("too many arguments (maximum 2 for nblocks and maxtries)");
-    if (args.size() == 0) {
-        args.emplace_back(DEFAULT_NBLOCKS);
-    } else if (args.at(0) == "0") {
-        throw std::runtime_error("the first argument (number of blocks to generate, default: " + DEFAULT_NBLOCKS + ") must be an integer value greater than zero");
-    }
-    args.emplace(args.begin() + 1, address);
-}
-
 static int CommandLineRPC(int argc, char *argv[])
 {
     std::string strPrint;
@@ -1184,15 +1125,6 @@ static int CommandLineRPC(int argc, char *argv[])
                 return 0;
             }
             rh.reset(new NetinfoRequestHandler());
-        } else if (gArgs.GetBoolArg("-generate", false)) {
-            const UniValue getnewaddress{GetNewAddress()};
-            const UniValue& error{getnewaddress.find_value("error")};
-            if (error.isNull()) {
-                SetGenerateToAddressArgs(getnewaddress.find_value("result").get_str(), args);
-                rh.reset(new GenerateToAddressRequestHandler());
-            } else {
-                ParseError(error, strPrint, nRet);
-            }
         } else if (gArgs.GetBoolArg("-addrinfo", false)) {
             rh.reset(new AddrinfoRequestHandler());
         } else {

--- a/test/functional/interface_navio_cli.py
+++ b/test/functional/interface_navio_cli.py
@@ -24,12 +24,6 @@ import time
 BLOCKS = COINBASE_MATURITY + 1
 BALANCE = (BLOCKS - 100) * 50
 
-JSON_PARSING_ERROR = 'error: Error parsing JSON: foo'
-BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
-TOO_MANY_ARGS = 'error: too many arguments (maximum 2 for nblocks and maxtries)'
-WALLET_NOT_LOADED = 'Requested wallet does not exist or is not loaded'
-WALLET_NOT_SPECIFIED = 'Wallet file not specified'
-
 
 def cli_get_info_string_to_dict(cli_get_info_string):
     """Helper method to convert human-readable -getinfo into a dictionary"""
@@ -139,7 +133,6 @@ class TestBitcoinCli(BitcoinTestFramework):
         expected_network_info = f"in {network_info['connections_in']}, out {network_info['connections_out']}, total {network_info['connections']}"
         assert_equal(cli_get_info["Network"], expected_network_info)
         assert_equal(cli_get_info['Proxies'], network_info['networks'][0]['proxy'])
-        assert_equal(Decimal(cli_get_info['Difficulty']), blockchain_info['difficulty'])
         assert_equal(cli_get_info['Chain'], blockchain_info['chain'])
 
         self.log.info("Test -getinfo and navio-cli return all proxies")
@@ -163,7 +156,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_equal(Decimal(cli_get_info['Min tx relay fee rate (NAV/kvB)']), network_info['relayfee'])
             assert_equal(self.nodes[0].cli.getwalletinfo(), wallet_info)
 
-            # Setup to test -getinfo, -generate, and -rpcwallet= with multiple wallets.
+            # Setup to test -getinfo and -rpcwallet= with multiple wallets.
             wallets = [self.default_wallet_name, 'Encrypted', 'secret']
             amounts = [BALANCE + Decimal('9.99988720'), Decimal(9), Decimal(31)]
             self.nodes[0].createwallet(wallet_name=wallets[1])
@@ -235,84 +228,9 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert 'Balance' not in cli_get_info_keys
             assert 'Balances' not in cli_get_info_string
 
-            # Test navio-cli -generate.
-            n1 = 3
-            n2 = 4
-            w2.walletpassphrase(password, self.rpc_timeout)
-            blocks = self.nodes[0].getblockcount()
-
-            self.log.info('Test -generate with no args')
-            generate = self.nodes[0].cli('-generate').send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), 1)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1)
-
-            self.log.info('Test -generate with bad args')
-            assert_raises_process_error(1, JSON_PARSING_ERROR, self.nodes[0].cli('-generate', 'foo').echo)
-            assert_raises_process_error(1, BLOCKS_VALUE_OF_ZERO, self.nodes[0].cli('-generate', 0).echo)
-            assert_raises_process_error(1, TOO_MANY_ARGS, self.nodes[0].cli('-generate', 1, 2, 3).echo)
-
-            self.log.info('Test -generate with nblocks')
-            generate = self.nodes[0].cli('-generate', n1).send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), n1)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n1)
-
-            self.log.info('Test -generate with nblocks and maxtries')
-            generate = self.nodes[0].cli('-generate', n2, 1000000).send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), n2)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n1 + n2)
-
-            self.log.info('Test -generate -rpcwallet in single-wallet mode')
-            generate = self.nodes[0].cli(rpcwallet2, '-generate').send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), 1)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 2 + n1 + n2)
-
-            self.log.info('Test -generate -rpcwallet=unloaded wallet raises RPC error')
-            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate').echo)
-            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 'foo').echo)
-            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 0).echo)
-            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 1, 2, 3).echo)
-
-            # Test navio-cli -generate with -rpcwallet in multiwallet mode.
-            self.nodes[0].loadwallet(wallets[2])
-            n3 = 4
-            n4 = 10
-            blocks = self.nodes[0].getblockcount()
-
-            self.log.info('Test -generate -rpcwallet with no args')
-            generate = self.nodes[0].cli(rpcwallet2, '-generate').send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), 1)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1)
-
-            self.log.info('Test -generate -rpcwallet with bad args')
-            assert_raises_process_error(1, JSON_PARSING_ERROR, self.nodes[0].cli(rpcwallet2, '-generate', 'foo').echo)
-            assert_raises_process_error(1, BLOCKS_VALUE_OF_ZERO, self.nodes[0].cli(rpcwallet2, '-generate', 0).echo)
-            assert_raises_process_error(1, TOO_MANY_ARGS, self.nodes[0].cli(rpcwallet2, '-generate', 1, 2, 3).echo)
-
-            self.log.info('Test -generate -rpcwallet with nblocks')
-            generate = self.nodes[0].cli(rpcwallet2, '-generate', n3).send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), n3)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3)
-
-            self.log.info('Test -generate -rpcwallet with nblocks and maxtries')
-            generate = self.nodes[0].cli(rpcwallet2, '-generate', n4, 1000000).send_cli()
-            assert_equal(set(generate.keys()), {'address', 'blocks'})
-            assert_equal(len(generate["blocks"]), n4)
-            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3 + n4)
-
-            self.log.info('Test -generate without -rpcwallet in multiwallet mode raises RPC error')
-            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate').echo)
-            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 'foo').echo)
-            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 0).echo)
-            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 1, 2, 3).echo)
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
-            self.generate(self.nodes[0], 25)  # maintain block parity with the wallet_compiled conditional branch
+            self.generate(self.nodes[0], 1)  # maintain block parity with the wallet_compiled conditional branch
 
         self.log.info("Test -version with node stopped")
         self.stop_node(0)
@@ -324,7 +242,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.nodes[0].wait_for_cookie_credentials()  # ensure cookie file is available to avoid race condition
         blocks = self.nodes[0].cli('-rpcwait').send_cli('getblockcount')
         self.nodes[0].wait_for_rpc_connection()
-        assert_equal(blocks, BLOCKS + 25)
+        assert_equal(blocks, BLOCKS + 1)
 
         self.log.info("Test -rpcwait option waits at most -rpcwaittimeout seconds for startup")
         self.stop_node(0)  # stop the node so we time out


### PR DESCRIPTION
## Summary

navio is **Proof-of-Stake** — blocks are produced by `navio-staker` via `getblocktemplate`/`submitblock`. But `navio-cli` still carried PoW-mining leftovers: the `-generate` flag ran `getnewaddress` + `generatetoaddress` (a PoW nonce-grind) which **cannot produce a valid PoS block outside regtest** and misleads users, and `-getinfo` reported a PoW **Difficulty** field.

## Changes (`src/bitcoin-cli.cpp`)
- **Remove `-generate`**: the arg, its dispatch branch, and the now-dead helpers `GetNewAddress` / `SetGenerateToAddressArgs` / `GenerateToAddressRequestHandler`, the `DEFAULT_NBLOCKS` constant, and the now-unused `#include <rpc/mining.h>`. (`GetNewAddress` was confirmed used only by `-generate`.)
- **`-getinfo`**: drop the **Difficulty** line. The headline **Balance** is left sourced from `getbalances` `mine.trusted`, which **already sums transparent + BLSCT** (`GetBlsctBalance()`), so it reflects total spendable funds — verified in `getbalances()` and documented inline. No PoW/mining server RPCs touched (separate phase).

`-addrinfo`, `-getinfo`, `-netinfo`, `-rpcwait`, peer/network info all untouched.

## Testing
- `cmake --build build -j4 --target navio-cli` — clean, no unused-function/variable warnings.
- `interface_navio_cli.py` updated (drop `-generate` block + Difficulty assertion, fix block-count parity) — passes.

## Notes for review
- `doc/release-notes/release-notes-0.21.0.md` still mentions historical `-generate` behavior — left as a historical release note.

---
Part of the navio-cli BLSCT-first cleanup. Independent of #305, #306, #307. Server-side mining/PoW RPC cleanup (`getnetworkhashps`, `getmininginfo`) is a separate follow-up PR. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa