### PR TITLE
chore(rpc): remove PoW getnetworkhashps and mining difficulty fields

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -46,8 +46,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generatetodescriptor", 2, "maxtries" },
     { "generateblock", 1, "transactions" },
     { "generateblock", 2, "submit" },
-    { "getnetworkhashps", 0, "nblocks" },
-    { "getnetworkhashps", 1, "height" },
     { "sendtoblsctaddress", 1, "amount" },
     { "sendtoblsctaddress", 3, "verbose" },
     { "sendnfttoblsctaddress", 1, "nft_id" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -47,83 +47,6 @@ using node::NodeContext;
 using node::RegenerateCommitments;
 using node::UpdateTime;
 
-/**
- * Return average network hashes per second based on the last 'lookup' blocks,
- * or from the last difficulty change if 'lookup' is -1.
- * If 'height' is -1, compute the estimate from current chain tip.
- * If 'height' is a valid block height, compute the estimate at the time when a given block was found.
- */
-static UniValue GetNetworkHashPS(int lookup, int height, const CChain& active_chain) {
-    if (lookup < -1 || lookup == 0) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid nblocks. Must be a positive number or -1.");
-    }
-
-    if (height < -1 || height > active_chain.Height()) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block does not exist at specified height");
-    }
-
-    const CBlockIndex* pb = active_chain.Tip();
-
-    if (height >= 0) {
-        pb = active_chain[height];
-    }
-
-    if (pb == nullptr || !pb->nHeight)
-        return 0;
-
-    // If lookup is -1, then use blocks since last difficulty change.
-    if (lookup == -1)
-        lookup = pb->nHeight % Params().GetConsensus().DifficultyAdjustmentInterval() + 1;
-
-    // If lookup is larger than chain, then set it to chain length.
-    if (lookup > pb->nHeight)
-        lookup = pb->nHeight;
-
-    const CBlockIndex* pb0 = pb;
-    int64_t minTime = pb0->GetBlockTime();
-    int64_t maxTime = minTime;
-    for (int i = 0; i < lookup; i++) {
-        pb0 = pb0->pprev;
-        int64_t time = pb0->GetBlockTime();
-        minTime = std::min(time, minTime);
-        maxTime = std::max(time, maxTime);
-    }
-
-    // In case there's a situation where minTime == maxTime, we don't want a divide by zero exception.
-    if (minTime == maxTime)
-        return 0;
-
-    arith_uint256 workDiff = pb->nChainWork - pb0->nChainWork;
-    int64_t timeDiff = maxTime - minTime;
-
-    return workDiff.getdouble() / timeDiff;
-}
-
-static RPCHelpMan getnetworkhashps()
-{
-    return RPCHelpMan{"getnetworkhashps",
-                "\nReturns the estimated network hashes per second based on the last n blocks.\n"
-                "Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change.\n"
-                "Pass in [height] to estimate the network speed at the time when a certain block was found.\n",
-                {
-                    {"nblocks", RPCArg::Type::NUM, RPCArg::Default{120}, "The number of previous blocks to calculate estimate from, or -1 for blocks since last difficulty change."},
-                    {"height", RPCArg::Type::NUM, RPCArg::Default{-1}, "To estimate at the time of the given height."},
-                },
-                RPCResult{
-                    RPCResult::Type::NUM, "", "Hashes per second estimated"},
-                RPCExamples{
-                    HelpExampleCli("getnetworkhashps", "")
-            + HelpExampleRpc("getnetworkhashps", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    ChainstateManager& chainman = EnsureAnyChainman(request.context);
-    LOCK(cs_main);
-    return GetNetworkHashPS(self.Arg<int>(0), self.Arg<int>(1), chainman.ActiveChain());
-},
-    };
-}
-
 static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, std::shared_ptr<const CBlock>& block_out, bool process_new_block)
 {
     block_out.reset();
@@ -472,8 +395,6 @@ static RPCHelpMan getmininginfo()
                         {RPCResult::Type::NUM, "blocks", "The current block"},
                         {RPCResult::Type::NUM, "currentblockweight", /*optional=*/true, "The block weight of the last assembled block (only present if a block was ever assembled)"},
                         {RPCResult::Type::NUM, "currentblocktx", /*optional=*/true, "The number of block transactions of the last assembled block (only present if a block was ever assembled)"},
-                        {RPCResult::Type::NUM, "difficulty", "The current difficulty"},
-                        {RPCResult::Type::NUM, "networkhashps", "The network hashes per second"},
                         {RPCResult::Type::NUM, "pooledtx", "The size of the mempool"},
                         {RPCResult::Type::STR, "chain", "current network name (main, test, signet, regtest)"},
                         {RPCResult::Type::STR, "warnings", "any network and blockchain warnings"},
@@ -494,8 +415,6 @@ static RPCHelpMan getmininginfo()
     obj.pushKV("blocks",           active_chain.Height());
     if (BlockAssembler::m_last_block_weight) obj.pushKV("currentblockweight", *BlockAssembler::m_last_block_weight);
     if (BlockAssembler::m_last_block_num_txs) obj.pushKV("currentblocktx", *BlockAssembler::m_last_block_num_txs);
-    obj.pushKV("difficulty", GetDifficulty(*CHECK_NONFATAL(active_chain.Tip())));
-    obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain", chainman.GetParams().GetChainTypeString());
     obj.pushKV("warnings",         GetWarnings(false).original);
@@ -1193,7 +1112,6 @@ static RPCHelpMan submitheader()
 void RegisterMiningRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
-        {"mining", &getnetworkhashps},
         {"mining", &getmininginfo},
         {"mining", &prioritisetransaction},
         {"mining", &getprioritisedtransactions},

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -139,7 +139,6 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getmempoolinfo",
     "getmininginfo",
     "getnettotals",
-    "getnetworkhashps",
     "getnetworkinfo",
     "getnodeaddresses",
     "getpeerinfo",

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test basic signet functionality"""
 
-from decimal import Decimal
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
@@ -56,7 +54,6 @@ class SignetBasicTest(BitcoinTestFramework):
         assert_equal(mining_info['chain'], 'signet')
         assert 'currentblocktx' not in mining_info
         assert 'currentblockweight' not in mining_info
-        assert_equal(mining_info['networkhashps'], Decimal('0'))
         assert_equal(mining_info['pooledtx'], 0)
 
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -138,8 +138,6 @@ class MiningTest(BitcoinTestFramework):
         assert_equal(mining_info['chain'], self.chain)
         assert 'currentblocktx' not in mining_info
         assert 'currentblockweight' not in mining_info
-        assert_equal(mining_info['difficulty'], Decimal('4.656542373906925E-10'))
-        assert_equal(mining_info['networkhashps'], Decimal('0.003333333333333334'))
         assert_equal(mining_info['pooledtx'], 0)
 
         self.log.info("getblocktemplate: Test default witness commitment")

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -11,7 +11,6 @@ Test the following RPCs:
     - gettxoutsetinfo
     - getblockheader
     - getdifficulty
-    - getnetworkhashps
     - waitforblockheight
     - getblock
     - getblockhash
@@ -25,7 +24,6 @@ from decimal import Decimal
 import http.client
 import os
 import subprocess
-import textwrap
 
 from test_framework.blocktools import (
     MAX_FUTURE_BLOCK_TIME,
@@ -58,7 +56,6 @@ TIME_RANGE_STEP = 600  # ten-minute steps
 TIME_RANGE_MTP = TIME_GENESIS_BLOCK + (HEIGHT - 6) * TIME_RANGE_STEP
 TIME_RANGE_TIP = TIME_GENESIS_BLOCK + (HEIGHT - 1) * TIME_RANGE_STEP
 TIME_RANGE_END = TIME_GENESIS_BLOCK + HEIGHT * TIME_RANGE_STEP
-DIFFICULTY_ADJUSTMENT_INTERVAL = 2016
 
 
 class BlockchainTest(BitcoinTestFramework):
@@ -86,7 +83,6 @@ class BlockchainTest(BitcoinTestFramework):
         self._test_gettxoutsetinfo()
         self._test_getblockheader()
         self._test_getdifficulty()
-        self._test_getnetworkhashps()
         self._test_stopatheight()
         self._test_waitforblockheight()
         self._test_getblock()
@@ -436,60 +432,6 @@ class BlockchainTest(BitcoinTestFramework):
         # 1 hash in 2 should be valid, so difficulty should be 1/2**31
         # binary => decimal => binary math is why we do this check
         assert abs(difficulty * 2**31 - 1) < 0.0001
-
-    def _test_getnetworkhashps(self):
-        self.log.info("Test getnetworkhashps")
-        assert_raises_rpc_error(
-            -3,
-            textwrap.dedent("""
-            Wrong type passed:
-            {
-                "Position 1 (nblocks)": "JSON value of type string is not of expected type number",
-                "Position 2 (height)": "JSON value of type array is not of expected type number"
-            }
-            """).strip(),
-            lambda: self.nodes[0].getnetworkhashps("a", []),
-        )
-        assert_raises_rpc_error(
-            -8,
-            "Block does not exist at specified height",
-            lambda: self.nodes[0].getnetworkhashps(100, self.nodes[0].getblockcount() + 1),
-        )
-        assert_raises_rpc_error(
-            -8,
-            "Block does not exist at specified height",
-            lambda: self.nodes[0].getnetworkhashps(100, -10),
-        )
-        assert_raises_rpc_error(
-            -8,
-            "Invalid nblocks. Must be a positive number or -1.",
-            lambda: self.nodes[0].getnetworkhashps(-100),
-        )
-        assert_raises_rpc_error(
-            -8,
-            "Invalid nblocks. Must be a positive number or -1.",
-            lambda: self.nodes[0].getnetworkhashps(0),
-        )
-
-        # Genesis block height estimate should return 0
-        hashes_per_second = self.nodes[0].getnetworkhashps(100, 0)
-        assert_equal(hashes_per_second, 0)
-
-        # This should be 2 hashes every 10 minutes or 1/300
-        hashes_per_second = self.nodes[0].getnetworkhashps()
-        assert abs(hashes_per_second * 300 - 1) < 0.0001
-
-        # Test setting the first param of getnetworkhashps to -1 returns the average network
-        # hashes per second from the last difficulty change.
-        current_block_height = self.nodes[0].getmininginfo()['blocks']
-        blocks_since_last_diff_change = current_block_height % DIFFICULTY_ADJUSTMENT_INTERVAL + 1
-        expected_hashes_per_second_since_diff_change = self.nodes[0].getnetworkhashps(blocks_since_last_diff_change)
-
-        assert_equal(self.nodes[0].getnetworkhashps(-1), expected_hashes_per_second_since_diff_change)
-
-        # Ensure long lookups get truncated to chain length
-        hashes_per_second = self.nodes[0].getnetworkhashps(self.nodes[0].getblockcount() + 1000)
-        assert hashes_per_second > 0.003
 
     def _test_stopatheight(self):
         self.log.info("Test stopping at height")


### PR DESCRIPTION
## Summary

navio is **Proof-of-Stake**; network hashrate and difficulty are PoW concepts that are meaningless under PoPS and mislead users. Block production runs through `getblocktemplate`/`submitblock`, which do not use these.

## Changes
- **Remove `getnetworkhashps`** (`src/rpc/mining.cpp`): the RPC handler + its sole helper `GetNetworkHashPS` (confirmed single caller via grep), its `mining` command-table entry, its `client.cpp` arg-conversion entries, and its entry in the fuzz `RPC_COMMANDS_SAFE_FOR_FUZZING` list (kept in sync with the live command table).
- **Strip `getmininginfo`** of `difficulty` and `networkhashps` (both schema and body). Remaining fields: `blocks`, `currentblockweight`/`currentblocktx` (optional), `pooledtx`, `chain`, `warnings`.
- **Untouched**: `getblocktemplate` (incl. PoS extensions), `submitblock`, `submitheader`, `prioritisetransaction`, `getprioritisedtransactions`, and the hidden `generate*` commands.
- `GetDifficulty` is **not** removed — still used by `getblockchaininfo`/`getblockheader`/`getblock`; the separate `getdifficulty` RPC is untouched.

## Testing
- `cmake --build build -j4` clean (naviod + navio-cli), no dead-code warnings.
- `mining_basic.py`, `rpc_blockchain.py`, `feature_signet.py` updated (drop the removed RPC + field assertions) — all pass. `miner_tests` C++ suite passes.

## Notes for review
- The fuzz-list edit (`src/test/fuzz/rpc.cpp`) is a mechanical consequence of removing the RPC so the safe-list stays consistent with the command table; flagging since it's slightly outside the core mining files.

---
Part of the navio-cli BLSCT-first cleanup. Independent of #305–#308. Complements the client-side PoW cleanup in #308. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa