### PR TITLE
fix(wallet): make getrawchangeaddress BLSCT-aware and guard address_type

### DIFF
--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -16,6 +16,38 @@
 #include <univalue.h>
 
 namespace wallet {
+namespace {
+//! Whether this wallet only ever hands out BLSCT (confidential) addresses.
+bool IsBlsctWallet(const CWallet& wallet)
+{
+    return wallet.IsWalletFlagSet(WALLET_FLAG_BLSCT);
+}
+
+//! Parse an optional address_type RPC argument, applying BLSCT-aware rules:
+//! on a BLSCT wallet the type defaults to (and, if explicit, must be) "blsct",
+//! since handing back a transparent address would silently break the
+//! confidentiality the wallet is supposed to provide.
+OutputType ParseAddressTypeArg(const CWallet& wallet, const UniValue& address_type_param, OutputType default_type)
+{
+    const bool is_blsct = IsBlsctWallet(wallet);
+    OutputType output_type = is_blsct ? OutputType::BLSCT : default_type;
+    if (!address_type_param.isNull()) {
+        std::optional<OutputType> parsed = ParseOutputType(address_type_param.get_str());
+        if (!parsed) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", address_type_param.get_str()));
+        }
+        if (is_blsct && parsed.value() != OutputType::BLSCT) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("This is a BLSCT wallet; addresses must be of type \"blsct\" (requested '%s')", address_type_param.get_str()));
+        }
+        if (parsed.value() == OutputType::BECH32M && wallet.GetLegacyScriptPubKeyMan()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
+        }
+        output_type = parsed.value();
+    }
+    return output_type;
+}
+} // namespace
+
 RPCHelpMan getnewaddress()
 {
     return RPCHelpMan{
@@ -44,16 +76,7 @@ RPCHelpMan getnewaddress()
             // Parse the label first so we don't generate a key if there's an error
             const std::string label{LabelFromValue(request.params[0])};
 
-            OutputType output_type = pwallet->IsWalletFlagSet(WALLET_FLAG_BLSCT) ? OutputType::BLSCT : pwallet->m_default_address_type;
-            if (!request.params[1].isNull()) {
-                std::optional<OutputType> parsed = ParseOutputType(request.params[1].get_str());
-                if (!parsed) {
-                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[1].get_str()));
-                } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
-                }
-                output_type = parsed.value();
-            }
+            OutputType output_type = ParseAddressTypeArg(*pwallet, request.params[1], pwallet->m_default_address_type);
 
             auto op_dest = pwallet->GetNewDestination(output_type, label);
             if (!op_dest) {
@@ -72,7 +95,7 @@ RPCHelpMan getrawchangeaddress()
         "\nReturns a new Navio address, for receiving change.\n"
         "This is for use with raw transactions, NOT normal use.\n",
         {
-            {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -changetype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
+            {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -changetype"}, "The address type to use. Options are \"blsct\", \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
         },
         RPCResult{
             RPCResult::Type::STR, "address", "The address"},
@@ -84,22 +107,22 @@ RPCHelpMan getrawchangeaddress()
 
             LOCK(pwallet->cs_wallet);
 
-            if (!pwallet->CanGetAddresses(true)) {
+            const bool is_blsct = IsBlsctWallet(*pwallet);
+            if ((!is_blsct && !pwallet->CanGetAddresses(true)) || (is_blsct && !pwallet->GetOrCreateBLSCTKeyMan()->CanGenerateKeys())) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
             }
 
-            OutputType output_type = pwallet->m_default_change_type.value_or(pwallet->m_default_address_type);
-            if (!request.params[0].isNull()) {
-                std::optional<OutputType> parsed = ParseOutputType(request.params[0].get_str());
-                if (!parsed) {
-                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[0].get_str()));
-                } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
-                }
-                output_type = parsed.value();
-            }
+            OutputType output_type = ParseAddressTypeArg(*pwallet, request.params[0], pwallet->m_default_change_type.value_or(pwallet->m_default_address_type));
 
-            auto op_dest = pwallet->GetNewChangeDestination(output_type);
+            // BLSCT wallets don't register a ScriptPubKeyMan for OutputType::BLSCT, so
+            // CWallet::GetNewChangeDestination (which only looks at legacy/descriptor
+            // ScriptPubKeyMans) can't serve them. Change addresses for BLSCT are derived
+            // from a dedicated account (blsct::CHANGE_ACCOUNT) on the BLSCT key manager,
+            // matching how change destinations are generated for real BLSCT sends (see
+            // blsct::TxFactory / blsct wallet rpc, which call
+            // GetOrCreateBLSCTKeyMan()->GetNewDestination(blsct::CHANGE_ACCOUNT)).
+            auto op_dest = is_blsct ? pwallet->GetOrCreateBLSCTKeyMan()->GetNewDestination(blsct::CHANGE_ACCOUNT)
+                                    : pwallet->GetNewChangeDestination(output_type);
             if (!op_dest) {
                 throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
             }

--- a/test/functional/blsct_address_rpc.py
+++ b/test/functional/blsct_address_rpc.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that address-generating RPCs are consistently BLSCT-aware.
+
+On a BLSCT wallet, `getnewaddress` and `getrawchangeaddress` must both
+return confidential (`rnv1...`) addresses, and requesting an explicit
+transparent `address_type` must be rejected rather than silently handing
+back an address that breaks the wallet's confidentiality guarantees.
+
+Transparent wallets must be unaffected: `getrawchangeaddress` should keep
+returning addresses of the wallet's configured change/address type.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class BlsctAddressRpcTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "blsctregtest"
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Create a BLSCT wallet and a transparent (bech32) wallet")
+        node.createwallet(wallet_name="blsct_wallet", blsct=True)
+        node.createwallet(wallet_name="plain_wallet", blsct=False)
+        blsct_wallet = node.get_wallet_rpc("blsct_wallet")
+        plain_wallet = node.get_wallet_rpc("plain_wallet")
+
+        self.log.info("getnewaddress on a BLSCT wallet returns an rnv1... address by default")
+        addr = blsct_wallet.getnewaddress()
+        assert addr.startswith("rnv1")
+        assert_equal(blsct_wallet.getaddressinfo(addr)["isblsct"], True)
+
+        self.log.info("getnewaddress with address_type=blsct explicitly also works")
+        addr = blsct_wallet.getnewaddress(label="", address_type="blsct")
+        assert addr.startswith("rnv1")
+        assert_equal(blsct_wallet.getaddressinfo(addr)["isblsct"], True)
+
+        self.log.info("getnewaddress rejects an explicit transparent address_type on a BLSCT wallet")
+        for bad_type in ("bech32", "legacy", "p2sh-segwit", "bech32m"):
+            assert_raises_rpc_error(
+                -8,
+                "This is a BLSCT wallet; addresses must be of type \"blsct\"",
+                blsct_wallet.getnewaddress,
+                "",
+                bad_type,
+            )
+
+        self.log.info("getrawchangeaddress on a BLSCT wallet returns an rnv1... change address")
+        change_addr = blsct_wallet.getrawchangeaddress()
+        assert change_addr.startswith("rnv1")
+        assert_equal(blsct_wallet.getaddressinfo(change_addr)["isblsct"], True)
+
+        self.log.info("getrawchangeaddress with address_type=blsct explicitly also works")
+        change_addr2 = blsct_wallet.getrawchangeaddress(address_type="blsct")
+        assert change_addr2.startswith("rnv1")
+
+        self.log.info("getrawchangeaddress rejects an explicit transparent address_type on a BLSCT wallet")
+        for bad_type in ("bech32", "legacy", "p2sh-segwit", "bech32m"):
+            assert_raises_rpc_error(
+                -8,
+                "This is a BLSCT wallet; addresses must be of type \"blsct\"",
+                blsct_wallet.getrawchangeaddress,
+                bad_type,
+            )
+
+        self.log.info("BLSCT change addresses are drawn from a distinct pool than receive addresses")
+        receive_addr = blsct_wallet.getnewaddress()
+        assert receive_addr != change_addr
+        assert receive_addr != change_addr2
+        # NOTE: change_addr == change_addr2 here. This mirrors a pre-existing
+        # quirk of blsct::KeyMan's negative "special account" handling
+        # (CHANGE_ACCOUNT/STAKING_ACCOUNT always resolve to sub-address index 0,
+        # see blsct::KeyMan::GetSubAddressFromPool in src/blsct/wallet/keyman.cpp)
+        # that also affects real BLSCT sends via blsct::TxFactory, which calls
+        # the identical GetNewDestination(blsct::CHANGE_ACCOUNT) path. It is out
+        # of scope for this RPC-consistency fix to change keyman derivation
+        # behavior, so this test documents current behavior rather than
+        # asserting index uniqueness across repeated change-address calls.
+        assert_equal(change_addr, change_addr2)
+
+        self.log.info("Transparent wallets are unaffected: getnewaddress/getrawchangeaddress keep working")
+        plain_addr = plain_wallet.getnewaddress()
+        assert not plain_addr.startswith("rnv1")
+        assert_equal(plain_wallet.getaddressinfo(plain_addr).get("isblsct"), None)
+
+        plain_change_addr = plain_wallet.getrawchangeaddress()
+        assert not plain_change_addr.startswith("rnv1")
+
+        # Default address/change type is bech32 (see DEFAULT_ADDRESS_TYPE);
+        # explicit non-BLSCT address_type requests keep working unaffected.
+        legacy_change = plain_wallet.getrawchangeaddress(address_type="legacy")
+        info = plain_wallet.getaddressinfo(legacy_change)
+        assert not info.get("iswitness", False)
+
+        bech32_change = plain_wallet.getrawchangeaddress(address_type="bech32")
+        info = plain_wallet.getaddressinfo(bech32_change)
+        assert info.get("iswitness", False)
+
+
+if __name__ == "__main__":
+    BlsctAddressRpcTest(__file__).main()

--- a/test/functional/blsct_legacy_rpc_guards.py
+++ b/test/functional/blsct_legacy_rpc_guards.py
@@ -126,10 +126,17 @@ class BLSCTLegacyRPCGuardsTest(BitcoinTestFramework):
         ones. importprivkey/dumpprivkey/importaddress/importpubkey/
         importmulti are guarded on Params().GetConsensus().fBLSCT (the
         chain's consensus flag, not the wallet's BLSCT flag) and now raise a
-        clear error here instead of silently operating on dead keys."""
+        clear error here instead of silently operating on dead keys.
+
+        The transparent address these RPCs are called with is minted by a
+        separate plain wallet: a BLSCT wallet does not hand out transparent
+        addresses at all (blsct_address_rpc.py covers that refusal). Its
+        origin does not matter here -- every guard below fires before the RPC
+        parses its arguments."""
         self.log.info("Transparent-key import/dump RPCs raise a clear guard error on an fBLSCT chain")
 
-        legacy_addr = wallet.getnewaddress(label="", address_type="legacy")
+        self.nodes[0].createwallet(wallet_name="transparent_addr_source", descriptors=False, blsct=False)
+        legacy_addr = self.nodes[0].get_wallet_rpc("transparent_addr_source").getnewaddress(label="", address_type="legacy")
 
         assert_raises_rpc_error(
             -4,
@@ -170,11 +177,16 @@ class BLSCTLegacyRPCGuardsTest(BitcoinTestFramework):
             }],
         )
 
-        # signmessage on a transparent address inside a BLSCT wallet is
-        # unaffected: it only signs a message with the key, it does not
-        # touch transparent-tx spendability, so it keeps working.
-        sig = wallet.signmessage(legacy_addr, "hello transparent")
-        assert sig
+        # The BLSCT wallet holds no transparent key to sign with, so this
+        # address is not its own. signmessage with a transparent key is
+        # covered on a plain wallet in test_legacy_wallet_unaffected.
+        assert_raises_rpc_error(
+            -4,
+            "Private key not available",
+            wallet.signmessage,
+            legacy_addr,
+            "hello transparent",
+        )
 
     def test_legacy_wallet_unaffected(self):
         """A plain (non-BLSCT-flagged) wallet is unaffected by the 4

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -367,6 +367,7 @@ BASE_SCRIPTS = [
     'blsct_watchonly_balances.py',
     'blsct_setblsctseed.py',
     'blsct_spend_rpc_guards.py',
+    'blsct_address_rpc.py',
     'blsct_script_validation.py',
     'blsct_balance_proof.py',
     'blsct_pops_consensus.py',


### PR DESCRIPTION
## Summary

Address handling was inconsistent on BLSCT wallets: `getnewaddress` returned a BLSCT (`nv1…`) address, but `getrawchangeaddress` returned a **transparent** one (`GetNewChangeDestination` only consults legacy/descriptor `ScriptPubKeyMan`s, which never register `OutputType::BLSCT`), and both RPCs would silently hand back a transparent address when the caller passed a non-blsct `address_type` — breaking the confidentiality the wallet is meant to provide.

## Changes (`src/wallet/rpc/addresses.cpp`)
- **`getrawchangeaddress`**: on a BLSCT wallet, derive change from `GetOrCreateBLSCTKeyMan()->GetNewDestination(blsct::CHANGE_ACCOUNT)` — the same path `blsct::TxFactory` uses to generate change for real sends. Fix its no-available-keys guard for BLSCT wallets; add `"blsct"` to the `address_type` help.
- **`getnewaddress` + `getrawchangeaddress`**: reject an explicit non-blsct `address_type` on a BLSCT wallet with a clear error, via a shared `ParseAddressTypeArg` helper (also preserves the existing bech32m-on-legacy guard).
- **`addmultisigaddress`**: unchanged — it already errors clearly ("Only legacy wallets are supported by this command") on non-legacy wallets; confidential multisig is out of scope.

## Testing
- `cmake --build build -j4` clean.
- New `blsct_address_rpc.py` (registered in `test_runner.py`): BLSCT wallet returns `rnv1…` for default/explicit-blsct; rejects `bech32`/`legacy`/`p2sh-segwit`/`bech32m` on both RPCs; `getrawchangeaddress` returns a BLSCT change address; transparent wallets unaffected. Passes.
- Regression: `blsct_setblsctseed`, `blsct_keypool_restore`, `wallet_change_address`, `wallet_address_types` all pass.

## ⚠️ Pre-existing bug surfaced (separate follow-up, NOT fixed here)
`blsct::KeyMan::GetSubAddressFromPool` (`src/blsct/wallet/keyman.cpp:1162-1181`) tests `account > -1` instead of `nIndex > -1`, so negative special accounts (`CHANGE_ACCOUNT=-1`, `STAKING_ACCOUNT=-2`) **always derive subaddress index 0** — BLSCT change/staking addresses never advance. This affects production sends via `txfactory`, not just this RPC. Flagged for a dedicated one-line fix PR (out of this PR's scope).

---
Part of the navio-cli BLSCT-first cleanup. Independent of #305–#309. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa