### PR TITLE
fix(blsct): correct out-of-bounds verbose param index in RPCs

### DIFF
--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -1002,7 +1002,7 @@ RPCHelpMan sendtokentoblsctaddress()
 
             const std::string address = request.params[1].get_str();
 
-            const bool verbose{request.params[4].isNull() ? false : request.params[11].get_bool()};
+            const bool verbose{request.params[4].isNull() ? false : request.params[4].get_bool()};
 
             blsct::SubAddress subAddress(std::get<blsct::DoublePublicKey>(destination));
             blsct::CreateTransactionData transactionData(address, AmountFromValue(request.params[2]), sMemo, TokenId(token_id), blsct::CreateTransactionType::NORMAL, 0);
@@ -1137,7 +1137,7 @@ RPCHelpMan stakelock()
 
             std::vector<wallet::CBLSCTRecipient> recipients;
             blsct::ParseBLSCTRecipients(address_amounts, false, "", recipients);
-            const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
+            const bool verbose{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
             blsct::CreateTransactionData transactionData(recipients[0].destination, recipients[0].nAmount, recipients[0].sMemo, TokenId(), blsct::CreateTransactionType::STAKED_COMMITMENT, Params().GetConsensus().nPePoSMinStakeAmount);
             transactionData.fConsolidateStakedCommitments = gArgs.GetBoolArg("-consolidatestakedcommitments", blsct::DEFAULT_CONSOLIDATE_STAKED_COMMITMENTS);
@@ -1199,7 +1199,7 @@ RPCHelpMan stakeunlock()
 
             std::vector<wallet::CBLSCTRecipient> recipients;
             blsct::ParseBLSCTRecipients(address_amounts, false, "", recipients);
-            const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
+            const bool verbose{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
 
             blsct::CreateTransactionData transactionData(recipients[0].destination, recipients[0].nAmount, recipients[0].sMemo, TokenId(), blsct::CreateTransactionType::STAKED_COMMITMENT_UNSTAKE, Params().GetConsensus().nPePoSMinStakeAmount);

--- a/test/functional/blsct_staking.py
+++ b/test/functional/blsct_staking.py
@@ -135,25 +135,32 @@ class NavioBlsctStakingTest(BitcoinTestFramework):
         wallet = self.nodes[0].get_wallet_rpc("wallet1")
         blsct_address = wallet.getnewaddress(label="", address_type="blsct")
 
-        # Test stakelock with verbose=false (default)
+        # Test stakelock with verbose=false (default): plain output hash string.
         stake_txid_simple = wallet.stakelock(self.min_stake)
         assert isinstance(stake_txid_simple, str), "Non-verbose output should be a string"
         assert len(stake_txid_simple) == 64, "Transaction ID should be 64 characters"
         self.generate_blsct_blocks(self.nodes[0], blsct_address, 1)
 
-        # Test stakelock with verbose=true
-        # Note: there might be a bug in verbose parameter handling
-        try:
-            stake_result_verbose = wallet.stakelock(self.min_stake, True)
-            if isinstance(stake_result_verbose, dict):
-                assert "txid" in stake_result_verbose, "Verbose output should contain txid"
-                assert len(stake_result_verbose["txid"]) == 64, "Transaction ID should be 64 characters"
-            else:
-                # If verbose doesn't work as expected, just check it's a valid txid
-                assert len(stake_result_verbose) == 64, "Should still return valid txid"
-            self.generate_blsct_blocks(self.nodes[0], blsct_address, 1)
-        except Exception as e:
-            self.log.info(f"Verbose staking may have parameter handling issue: {e}")
+        # Test stakelock with verbose=true: an object with an outputHash field.
+        # (stakelock's verbose arg is index 1; a prior bug read params[10],
+        # which is always null, silently ignoring the flag.)
+        stake_result_verbose = wallet.stakelock(self.min_stake, True)
+        assert isinstance(stake_result_verbose, dict), "Verbose output should be an object"
+        assert "outputHash" in stake_result_verbose, "Verbose output should contain outputHash"
+        assert len(stake_result_verbose["outputHash"]) == 64, "outputHash should be 64 characters"
+        self.generate_blsct_blocks(self.nodes[0], blsct_address, 1)
+
+        # Same check for stakeunlock (shares the same previously-buggy params[10] read).
+        unlock_txid_simple = wallet.stakeunlock(self.min_stake)
+        assert isinstance(unlock_txid_simple, str), "Non-verbose output should be a string"
+        assert len(unlock_txid_simple) == 64, "Transaction ID should be 64 characters"
+        self.generate_blsct_blocks(self.nodes[0], blsct_address, 1)
+
+        unlock_result_verbose = wallet.stakeunlock(self.min_stake, True)
+        assert isinstance(unlock_result_verbose, dict), "Verbose output should be an object"
+        assert "outputHash" in unlock_result_verbose, "Verbose output should contain outputHash"
+        assert len(unlock_result_verbose["outputHash"]) == 64, "outputHash should be 64 characters"
+        self.generate_blsct_blocks(self.nodes[0], blsct_address, 1)
 
 if __name__ == '__main__':
     NavioBlsctStakingTest(__file__).main()

--- a/test/functional/blsct_token.py
+++ b/test/functional/blsct_token.py
@@ -124,6 +124,23 @@ class NavioBlsctTokenTest(BitcoinTestFramework):
         self.log.info(f"Balance in NODE 1: {token_balance}")
         self.log.info(f"Balance in NODE 2: {token_balance_2}")
 
+        self.log.info("Testing sendtokentoblsctaddress verbose flag (params[4])")
+        # Non-verbose (default): plain output hash string.
+        send_result = wallet.sendtokentoblsctaddress(token['tokenId'], blsct_address_2, 0.1)
+        assert isinstance(send_result, str), "Non-verbose result should be a string"
+        assert len(send_result) == 64, "outputHash should be 64 characters"
+        self.generate_blsct_blocks(self.nodes[0], blsct_address, 2)
+
+        # Verbose=true: an object with outputHash.
+        # (A prior bug read params[11] instead of params[4] for this flag,
+        # which is always null, so verbose was silently ignored.)
+        send_result_verbose = wallet.sendtokentoblsctaddress(
+            token['tokenId'], blsct_address_2, 0.1, "", True)
+        assert isinstance(send_result_verbose, dict), "Verbose result should be an object"
+        assert "outputHash" in send_result_verbose, "Verbose result should contain outputHash"
+        assert len(send_result_verbose["outputHash"]) == 64, "outputHash should be 64 characters"
+        self.generate_blsct_blocks(self.nodes[0], blsct_address, 2)
+
     def test_output(self):
         self.log.info("Creating wallet1 with BLSCT")
 


### PR DESCRIPTION
## Summary

`sendtokentoblsctaddress`, `stakelock` and `stakeunlock` read their `verbose` flag from `request.params[11]`/`[10]` — indices far beyond their declared argument counts. Those reads always returned null, so `verbose` was **silently a no-op** (always false, always returned the plain string result even when the caller asked for the verbose dict).

## Fix (`src/blsct/wallet/rpc.cpp`)
- `sendtokentoblsctaddress`: `params[11]` → `params[4]` (`verbose` is declared arg 4: token_id, address, amount, memo, **verbose**).
- `stakelock` / `stakeunlock`: `params[10]` → `params[1]` (`verbose` is declared arg 1: amount, **verbose**).
- `sendnfttoblsctaddress` was checked and already used the correct `params[4]` — unchanged.

## Testing
- `cmake --build build -j4` clean.
- `blsct_staking.py`: replaced the old `try/except` block (which explicitly tolerated "there might be a bug in verbose parameter handling") with a strict assertion that `verbose=true` returns a dict with `outputHash`, for both `stakelock` and `stakeunlock`.
- `blsct_token.py`: added coverage for `sendtokentoblsctaddress` with verbose omitted (string) and verbose=true (dict with `outputHash`).
- `blsct_staking.py`, `blsct_token.py`, `blsct_stake_no_consolidate.py` all pass.

---
Part of the navio-cli BLSCT-first cleanup. Independent of #305–#311. Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa