### PR TITLE
fix(blsct): advance change/staking subaddress index past 0

### DIFF
--- a/src/blsct/wallet/keyman.cpp
+++ b/src/blsct/wallet/keyman.cpp
@@ -1167,7 +1167,7 @@ bool KeyMan::GetSubAddressFromPool(const int64_t& account, CKeyID& result, SubAd
     SubAddressPool keypool;
 
     ReserveSubAddressFromPool(account, nIndex, keypool);
-    id = SubAddressIdentifier{account, (account > -1 ? static_cast<uint64_t>(nIndex) : 0)};
+    id = SubAddressIdentifier{account, (nIndex > -1 ? static_cast<uint64_t>(nIndex) : 0)};
     if (nIndex <= -1) {
         if (m_storage.IsLocked()) return false;
         SubAddress subAddress = GenerateNewSubAddress(account, id);

--- a/src/test/blsct/wallet/keyman_tests.cpp
+++ b/src/test/blsct/wallet/keyman_tests.cpp
@@ -46,6 +46,43 @@ BOOST_FIXTURE_TEST_CASE(wallet_test, TestingSetup)
     }
 }
 
+// Regression test for a bug where GetSubAddressFromPool() derived the
+// SubAddressIdentifier's address index by checking `account > -1` instead of
+// `nIndex > -1`. For the special negative accounts (CHANGE_ACCOUNT = -1,
+// STAKING_ACCOUNT = -2) that guard was always false, so every reservation was
+// recorded under address index 0 regardless of the index actually reserved
+// from the pool by ReserveSubAddressFromPool() — change/staking subaddresses
+// never advanced past index 0.
+BOOST_FIXTURE_TEST_CASE(get_subaddress_from_pool_advances_index_for_negative_accounts, TestingSetup)
+{
+    auto wallet = std::make_unique<wallet::CWallet>(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase());
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_REQUIRE(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    for (const int64_t account : {blsct::CHANGE_ACCOUNT, blsct::STAKING_ACCOUNT}) {
+        CKeyID keyId1, keyId2;
+        blsct::SubAddressIdentifier id1, id2;
+
+        BOOST_REQUIRE(blsct_km->GetSubAddressFromPool(account, keyId1, id1));
+        BOOST_REQUIRE(blsct_km->GetSubAddressFromPool(account, keyId2, id2));
+
+        BOOST_CHECK_EQUAL(id1.account, account);
+        BOOST_CHECK_EQUAL(id2.account, account);
+
+        // The bug forced both id1.address and id2.address to 0. Fixed
+        // behaviour advances the index on each reservation.
+        BOOST_CHECK_EQUAL(id1.address, uint64_t{0});
+        BOOST_CHECK_EQUAL(id2.address, uint64_t{1});
+        BOOST_CHECK(id1.address != id2.address);
+
+        // Distinct indices must also yield distinct keys.
+        BOOST_CHECK(keyId1 != keyId2);
+    }
+}
+
 namespace {
 // Set up a BLSCT wallet with a defined view key and a fresh subaddress keypool,
 // ready for GetNewDestination()/IsMineMode().


### PR DESCRIPTION
## Summary

`KeyMan::GetSubAddressFromPool` derived the `SubAddressIdentifier`'s address index with the guard `(account > -1 ? static_cast<uint64_t>(nIndex) : 0)`. For the negative special accounts `CHANGE_ACCOUNT` (-1) and `STAKING_ACCOUNT` (-2) that guard is **always false**, so `id.address` was pinned to **0** no matter which index `ReserveSubAddressFromPool` actually reserved. Since `GetNewDestination` returns `GetSubAddress(id)`, **every change/staking destination resolved to subaddress 0** — all change reused a single address (privacy leak), and the reserved pool indices leaked.

## Not by design — evidence
- The sibling `ReserveSubAddressFromPool` uses the correct guard `(nIndex > -1 ? … : 0)` at the *identical* cast (protecting against casting a `-1` sentinel to `uint64_t`); line 1170 testing `account` instead of `nIndex` is a copy mistake.
- The whole recovery architecture is built for advancing indices: `IsMineMode` maintains a per-account `nSubAddressCounter` and scans a **lookahead window** `[counter, counter+lookahead)` for `CHANGE_ACCOUNT`/`STAKING_ACCOUNT` — pointless if change were fixed at index 0.
- `OutputIsChange` classifies change by **account only** (`account == CHANGE_ACCOUNT`), not by index, so advancing the index doesn't break change detection.

## The fix
One line — guard on the reserved index, matching the sibling:
```cpp
-    id = SubAddressIdentifier{account, (account > -1 ? static_cast<uint64_t>(nIndex) : 0)};
+    id = SubAddressIdentifier{account, (nIndex > -1 ? static_cast<uint64_t>(nIndex) : 0)};
```
The `nIndex <= -1` fallback (empty pool) is unaffected: `GenerateNewSubAddress` overwrites `id` from `nSubAddressCounter` regardless.

## Compatibility
No fund loss for existing wallets. Recovery matches outputs by subaddress **key-hash** (map lookup + per-account lookahead scan), not by a fixed index — pre-fix index-0 change stays recognized, and post-fix higher-index change is picked up by the normal lookahead/top-up path. Observable change: change/staking addresses stop being reused. (Wallets that transacted under the buggy build left stale reserved-pool bookkeeping at index 0; harmless, no migration needed.)

## Testing
- `cmake --build build -j4` clean (naviod + test_navio).
- New `keyman_tests` case `get_subaddress_from_pool_advances_index_for_negative_accounts`: consecutive reservations for `CHANGE_ACCOUNT`/`STAKING_ACCOUNT` now advance 0 → 1 with distinct keys. **Fails on old code (0 → 0), passes on fixed code** (verified by reverting the one-liner).

---
Follow-up bug surfaced during the navio-cli BLSCT-first cleanup (independent of #305–#313). Opened as **draft** pending manual review.

https://claude.ai/code/session_01UUgZCV3HwpY5S6zHY8ojNa