### PR TITLE
blsct: fix regtest bech32 HRP (rnav → rnv)

### DIFF
--- a/src/blsct/key_io.h
+++ b/src/blsct/key_io.h
@@ -25,7 +25,7 @@ namespace bech32_hrp {
     const std::string Mainnet = "nav";
     const std::string Testnet = "tnv";
     const std::string Signet = "snv";
-    const std::string Regtest = "rnav";
+    const std::string Regtest = "rnv";
 }
 
 /** Encode DoublePublicKey to Bech32 or Bech32m string. Encoding must be one of BECH32 or BECH32M. */


### PR DESCRIPTION
`blsct::bech32_hrp::Regtest` was `"rnav"`, but the regtest/blsctregtest chainparams use `bech32_mod_hrp = "rnv"`. The two disagreeing meant:

- the external BLSCT API (and the light-wallet bindings/WASM built on it) produced regtest BLSCT addresses the daemon **could not decode**, and
- a 4-character HRP violates the 3-byte-hrp `DOUBLE_PUBKEY_ENC_SIZE` layout documented in `key_io.h`, corrupting decode.

This one-line change aligns the constant with chainparams so regtest addresses round-trip. Mainnet/testnet/signet are unaffected.

Surfaced while building the navio-dex-webapp-example against a local blsctregtest network: navio-blsct produced `rnav1…` addresses that the daemon rejected. (The same fix already rides along in #263; this is the standalone version for the binding to pin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)