### PR TITLE
validation: report verificationprogress 1.0 for a recent tip

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5772,6 +5772,17 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pin
 
     int64_t nNow = time(nullptr);
 
+    // Both estimates below extrapolate the expected chain size for the time
+    // elapsed since the given block, so they asymptotically approach but never
+    // reach 1.0 while the clock keeps ticking. On a chain with a low
+    // transaction rate the resulting deficit is clearly visible (e.g. a fully
+    // synced mainnet node reporting 0.99998), so treat a block within a few
+    // block intervals of the current time as fully synced.
+    static constexpr int64_t FULLY_SYNCED_TIP_AGE{10 * 60};
+    if (nNow - pindex->GetBlockTime() <= FULLY_SYNCED_TIP_AGE) {
+        return 1.0;
+    }
+
     // When no transaction-rate statistics are available (e.g. a freshly reset
     // network whose chainTxData is still empty), the tx-count based estimate
     // below degenerates: fTxTotal becomes equal to nChainTx and the result is

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5770,7 +5770,7 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pin
     if (pindex == nullptr)
         return 0.0;
 
-    int64_t nNow = time(nullptr);
+    const int64_t nNow = GetTime();
 
     // Both estimates below extrapolate the expected chain size for the time
     // elapsed since the given block, so they asymptotically approach but never


### PR DESCRIPTION
## Problem

A fully synced mainnet node still reports `"verificationprogress": 0.99998...` after #303 (reported on Discord running v0.1.4).

`GuessVerificationProgress` computes `nChainTx / (nChainTx + (now - tipTime) * txRate)`, extrapolating the expected chain size for the time elapsed since the tip. The estimate asymptotically approaches but never reaches 1.0 while the clock keeps ticking. Bitcoin has the same behavior, but with `nChainTx` ~10^9 the deficit hides beyond the 6th decimal; with navio mainnet's ~4k transactions it shows up in the 5th (`(now - tipTime) * 0.0083 / 4018`). #303 shrank the gap (0.999 → 0.99998) but literal 1.0 was mathematically unreachable.

## Fix

Treat a block within 10 minutes (five mainnet PoS block intervals) of the current time as fully synced and return exactly 1.0. Applies before both estimate paths (tx-rate based and the empty-chainTxData timestamp fallback). A tip older than that keeps the existing estimates, so IBD reporting is unchanged.

Verified on regtest: freshly mined tip now reports `"verificationprogress": 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)