### PR TITLE
wallet: don't crash when a BLSCT output arrives on a locked wallet

### DIFF
--- a/src/blsct/wallet/keyman.cpp
+++ b/src/blsct/wallet/keyman.cpp
@@ -755,6 +755,12 @@ bool KeyMan::GetSpendingKeyForOutput(const CTxOut& out, const SubAddressIdentifi
     if (!fViewKeyDefined || !viewKey.IsValid())
         throw std::runtime_error(strprintf("%s: the wallet has no view key available", __func__));
 
+    // A locked encrypted wallet cannot decrypt the spend key; report the key
+    // as unavailable instead of letting GetSpendingKey() throw. Callers treat
+    // false as "cannot derive", which is the correct answer while locked.
+    if (m_storage.HasEncryptionKeys() && m_storage.IsLocked())
+        return false;
+
     auto sk = GetSpendingKey();
 
     key = CalculatePrivateSpendingKey(out.blsctData.blindingKey, viewKey.GetScalar(), sk.GetScalar(), id.account, id.address);
@@ -783,6 +789,12 @@ bool KeyMan::GetSpendingKeyForOutputWithCache(const CTxOut& out, const SubAddres
 {
     if (!fViewKeyDefined || !viewKey.IsValid())
         throw std::runtime_error(strprintf("%s: the wallet has no view key available", __func__));
+
+    // The cache id below is derived from the spend key scalar, so even a
+    // cache hit needs the decrypted spend key. Locked encrypted wallet:
+    // report unavailable rather than throw (see GetSpendingKeyForOutput).
+    if (m_storage.HasEncryptionKeys() && m_storage.IsLocked())
+        return false;
 
     auto sk = GetSpendingKey();
 

--- a/src/test/blsct/wallet/keyman_tests.cpp
+++ b/src/test/blsct/wallet/keyman_tests.cpp
@@ -148,4 +148,51 @@ BOOST_FIXTURE_TEST_CASE(htlc_watch_only_registration_detects_refund_output, Test
     BOOST_CHECK(!km_c->IsMine(txout));
 }
 
+// A locked encrypted wallet must behave like a watch wallet for incoming BLSCT
+// outputs: detection and amount recovery work (view key is stored in the
+// clear), while spending-key derivation reports unavailable instead of
+// throwing. Regression test for the AddToWallet crash where a bridged output
+// arriving while the wallet was locked threw "GetSpendingKey: could not access
+// the spend key" out of AppInit() and shut the node down.
+BOOST_FIXTURE_TEST_CASE(locked_wallet_spending_key_unavailable_no_throw, TestingSetup)
+{
+    auto wallet = MakeBLSCTWallet(m_node.chain.get());
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+
+    auto dest = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+    auto unsigned_output = blsct::CreateOutput(dest, 42 * COIN, "memo");
+    const CTxOut& txout = unsigned_output.out;
+
+    BOOST_REQUIRE(blsct_km->IsMine(txout));
+
+    // Unencrypted wallet derives the spending key.
+    blsct::PrivateKey key_before;
+    BOOST_REQUIRE(blsct_km->GetSpendingKeyForOutput(txout, key_before));
+    BOOST_REQUIRE(key_before.IsValid());
+
+    BOOST_REQUIRE(wallet->EncryptWallet("passphrase"));
+    BOOST_REQUIRE(wallet->Lock());
+    BOOST_REQUIRE(wallet->IsLocked());
+
+    // Locked: detection and amount recovery still work off the view key...
+    BOOST_CHECK(blsct_km->IsMine(txout));
+    auto recovered = blsct_km->RecoverOutputs({txout});
+    BOOST_REQUIRE(recovered.is_completed);
+    BOOST_REQUIRE(!recovered.amounts.empty());
+    BOOST_CHECK_EQUAL(recovered.amounts[0].amount, 42 * COIN);
+
+    // ...but spending-key derivation reports unavailable rather than throwing.
+    blsct::PrivateKey key_locked;
+    BOOST_CHECK(!blsct_km->GetSpendingKeyForOutput(txout, key_locked));
+    BOOST_CHECK(!blsct_km->GetSpendingKeyForOutputWithCache(txout, key_locked));
+
+    // Unlocked again: derivation recovers and matches the pre-encryption key.
+    BOOST_REQUIRE(wallet->Unlock("passphrase"));
+    blsct::PrivateKey key_after;
+    BOOST_REQUIRE(blsct_km->GetSpendingKeyForOutputWithCache(txout, key_after));
+    BOOST_CHECK(key_after.IsValid());
+    BOOST_CHECK(key_after.GetScalar() == key_before.GetScalar());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1363,10 +1363,13 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     auto blsct_man = GetBLSCTKeyMan();
     if (wtx.tx->IsBLSCT()) {
         // Warm the spending-key cache for owned outputs. Skip this on watch-only
-        // / view-key (audit key) wallets: they have no private spend key, so
-        // GetSpendingKeyForOutputWithCache would throw (uncaught, on the
-        // scheduler thread). The cached value is not used here in any case.
-        if (blsct_man && !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        // / view-key (audit key) wallets (no private spend key) and on locked
+        // encrypted wallets (spend key not decryptable): in both cases
+        // GetSpendingKeyForOutputWithCache would throw, uncaught, on the
+        // scheduler or init thread and take the node down mid-sync. The cached
+        // value is not used here in any case; spending keys are derived lazily
+        // when actually spending, with the wallet unlocked.
+        if (blsct_man && !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !IsLocked()) {
             for (auto& out : wtx.tx->vout) {
                 if (blsct_man->IsMine(out)) {
                     blsct::PrivateKey spending_key;


### PR DESCRIPTION
Fixes the daemon shutdown reported on Discord: an encrypted wallet receiving a BLSCT output (e.g. bridged wNav) while locked took the node down with

```
EXCEPTION: St13runtime_error
GetSpendingKey: could not access the spend key
bitcoin in AppInit()
```

and then crash-looped on every restart, since the startup rescan replayed the same block before the wallet could be unlocked.

**Cause**: `AddToWallet` eagerly warms the spending-key cache for incoming owned BLSCT outputs. With the wallet locked the spend key is not decryptable, `GetKey` fails and `GetSpendingKey()` throws, uncaught, on the init/scheduler thread. The existing guard only covered watch-only wallets (`WALLET_FLAG_DISABLE_PRIVATE_KEYS`).

**Fix** (two layers):
- `wallet.cpp`: skip the cache warm-up when `IsLocked()`. The cached value is unused at that point; spending keys are derived lazily at spend time with the wallet unlocked.
- `keyman.cpp`: `GetSpendingKeyForOutput` / `GetSpendingKeyForOutputWithCache` return `false` instead of throwing when encryption keys exist and the wallet is locked. Callers already treat `false` as "cannot derive".

A locked wallet keeps full watch-wallet behavior: output detection and amount recovery run off the view key (stored in the clear by design) and are unaffected.

**Test**: new unit test `blsct_keyman_tests/locked_wallet_spending_key_unavailable_no_throw` covers detection + amount recovery while locked, non-throwing key derivation failure while locked, and key derivation after unlock matching the pre-encryption key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)