### PR TITLE
blsct: add deriveblsctonetimekey RPC for external destinations

### DIFF
--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -3144,6 +3144,86 @@ RPCHelpMan deriveblsctspendingkey()
     };
 }
 
+RPCHelpMan deriveblsctonetimekey()
+{
+    return RPCHelpMan{
+        "deriveblsctonetimekey",
+        "\nStateless derivation of the one-time key material for a BLSCT output sent to an\n"
+        "externally constructed destination (view point V = view_key*G1, spend point S).\n"
+        "An output created for such a destination carries ephemeralKey = b*G1 (b = the\n"
+        "sender's blinding key) and one-time spending key S + H(b*V)*G1. Given the private\n"
+        "view scalar and the output's ephemeral key this returns the shared point\n"
+        "b*V (the recovery nonce for getblsctrecoverydatawithnonce), the derived scalar\n"
+        "tweak H(b*V) with its public point, and the expected view tag. If the private\n"
+        "spend scalar is also provided, the full one-time private spending key\n"
+        "spend_key + H(b*V) is returned, suitable for the spending_key input field of\n"
+        "createblsctrawtransaction.\n"
+        "Wallet keys are not consulted: intended for jointly derived destinations (e.g.\n"
+        "atomic-swap outputs locked to a combined key) that no wallet owns.\n",
+        {
+            {"view_key", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The 32-byte private view scalar (hex) of the destination"},
+            {"ephemeral_key", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The 48-byte ephemeral key (hex) of the output (blsctData.ephemeralKey)"},
+            {"spend_key", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The 32-byte private spend scalar (hex) of the destination; when given, the full one-time private key is returned"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::STR_HEX, "nonce", "The shared point b*V as a 48-byte public key (hex); recovery nonce for getblsctrecoverydatawithnonce"},
+                                              {RPCResult::Type::NUM, "view_tag", "The view tag matching this output"},
+                                              {RPCResult::Type::STR_HEX, "tweak", "The derived scalar H(b*V) (32-byte hex)"},
+                                              {RPCResult::Type::STR_HEX, "tweak_point", "H(b*V)*G1 (48-byte hex); the output's spending key must equal S + tweak_point"},
+                                              {RPCResult::Type::STR_HEX, "one_time_key", /*optional=*/true, "spend_key + H(b*V) (32-byte hex); only when spend_key was provided"},
+                                          }},
+        RPCExamples{
+            HelpExampleCli("deriveblsctonetimekey", "\"<view scalar hex>\" \"<ephemeral key hex>\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            auto view_key_bytes = ParseHex(request.params[0].get_str());
+            if (view_key_bytes.size() != 32) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "View key must be 32 bytes (64 hex characters)");
+            }
+            Scalar viewKey(view_key_bytes);
+            if (viewKey.IsZero()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "View key must not be zero");
+            }
+
+            auto ephemeral_key_bytes = ParseHex(request.params[1].get_str());
+            if (ephemeral_key_bytes.size() != blsct::PublicKey::SIZE) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Ephemeral key must be 48 bytes (96 hex characters)");
+            }
+            blsct::PublicKey ephemeral_pubkey(ephemeral_key_bytes);
+            if (!ephemeral_pubkey.IsValid()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid ephemeral public key");
+            }
+
+            // b*V, computed from the claimant's side: view_key * (b*G1)
+            MclG1Point nonce = ephemeral_pubkey.GetG1Point() * viewKey;
+            Scalar tweak(nonce.GetHashWithSalt(0));
+
+            HashWriter hash{};
+            hash << nonce;
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("nonce", HexStr(blsct::PublicKey(nonce).GetVch()));
+            result.pushKV("view_tag", hash.GetHash().GetUint64(0) & 0xFFFF);
+            result.pushKV("tweak", HexStr(tweak.GetVch()));
+            result.pushKV("tweak_point", HexStr(blsct::PrivateKey(tweak).GetPublicKey().GetVch()));
+
+            if (!request.params[2].isNull() && !request.params[2].get_str().empty()) {
+                auto spend_key_bytes = ParseHex(request.params[2].get_str());
+                if (spend_key_bytes.size() != 32) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Spend key must be 32 bytes (64 hex characters)");
+                }
+                Scalar spendKey(spend_key_bytes);
+                if (spendKey.IsZero()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Spend key must not be zero");
+                }
+                result.pushKV("one_time_key", HexStr((spendKey + tweak).GetVch()));
+            }
+
+            return result;
+        },
+    };
+}
+
 RPCHelpMan getblsctoutput()
 {
     return RPCHelpMan{
@@ -3245,6 +3325,7 @@ Span<const CRPCCommand> GetBLSCTWalletRPCCommands()
         {"blsct", &signblsmessage},
         {"blsct", &verifyblsmessage},
         {"blsct", &deriveblsctspendingkey},
+        {"blsct", &deriveblsctonetimekey},
         {"blsct", &getblsctoutput},
     };
     return commands;

--- a/src/test/blsct/wallet/keyman_tests.cpp
+++ b/src/test/blsct/wallet/keyman_tests.cpp
@@ -195,4 +195,50 @@ BOOST_FIXTURE_TEST_CASE(locked_wallet_spending_key_unavailable_no_throw, Testing
     BOOST_CHECK(key_after.GetScalar() == key_before.GetScalar());
 }
 
+// Locks down the one-time key derivation the deriveblsctonetimekey RPC exposes
+// for externally constructed destinations (e.g. adaptor-swap outputs locked to
+// a combined key that no wallet owns). An output paid to destination (V, S)
+// with blinding key b carries ephemeralKey = b*G1 and one-time spending key
+// S + H(b*V)*G1; the claimant, holding the view scalar v and the combined
+// spend scalar s, must reconstruct the same key material from on-chain data
+// alone: nonce = v*ephemeralKey, tweak = H(nonce), private key = s + tweak.
+BOOST_FIXTURE_TEST_CASE(external_destination_one_time_key_derivation, TestingSetup)
+{
+    const MclScalar v(uint256(uint64_t{0x1111}));  // shared view scalar
+    const MclScalar s1(uint256(uint64_t{0x2222})); // party 1 spend share
+    const MclScalar s2(uint256(uint64_t{0x3333})); // party 2 spend share
+    const auto V = blsct::PrivateKey(v).GetPoint();
+    const auto S = blsct::PrivateKey(s1).GetPoint() + blsct::PrivateKey(s2).GetPoint();
+    const blsct::DoublePublicKey dest(V, S);
+
+    const MclScalar blindingKey(uint256(uint64_t{0x4444})); // sender-side only
+    auto unsigned_output = blsct::CreateOutput(dest, 42 * COIN, "", TokenId(), blindingKey);
+    const CTxOut& txout = unsigned_output.out;
+
+    // Claimant side: everything below uses only (v, s1+s2) and on-chain data.
+    const MclG1Point nonce = txout.blsctData.ephemeralKey * v;
+    const MclScalar tweak(nonce.GetHashWithSalt(0));
+
+    // tweak_point lets a claimant verify the output key by point addition.
+    BOOST_CHECK(txout.blsctData.spendingKey == S + blsct::PrivateKey(tweak).GetPoint());
+
+    // The full one-time private key signs for the output's spending key.
+    const MclScalar one_time = s1 + s2 + tweak;
+    BOOST_CHECK(blsct::PrivateKey(one_time).GetPoint() == txout.blsctData.spendingKey);
+
+    // The view tag computed from the reconstructed nonce matches the output.
+    HashWriter hasher{};
+    hasher << nonce;
+    BOOST_CHECK_EQUAL(hasher.GetHash().GetUint64(0) & 0xFFFF, txout.blsctData.viewTag);
+
+    // The same nonce opens the range proof (amount recovery path).
+    auto wallet = MakeBLSCTWallet(m_node.chain.get());
+    LOCK(wallet->cs_wallet);
+    auto km = wallet->GetOrCreateBLSCTKeyMan();
+    auto recovered = km->RecoverOutputsWithNonce({txout}, nonce);
+    BOOST_REQUIRE(recovered.is_completed);
+    BOOST_REQUIRE(!recovered.amounts.empty());
+    BOOST_CHECK_EQUAL(recovered.amounts[0].amount, 42 * COIN);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds the last missing node-side piece for scriptless adaptor-signature swaps on BasicSwap (Navio in the Monero role: coins locked to a combined key `P_L + P_F` as a completely standard BLSCT payment, indistinguishable on-chain from any other output).

### What

New wallet-namespace RPC:

```
deriveblsctonetimekey "view_key" "ephemeral_key" ( "spend_key" )
```

Stateless derivation of one-time key material for an output sent to an externally constructed destination `(V = v·G1, S)`:

- `nonce` — the shared point `b·V`, computed claimant-side as `v · ephemeralKey`; drops straight into `getblsctrecoverydatawithnonce` for amount/gamma recovery
- `view_tag` — expected view tag for output matching
- `tweak` / `tweak_point` — `H(b·V)` and `H(b·V)·G1`, letting a verifier check the output's one-time spending key equals `S + tweak_point` by point addition
- `one_time_key` — `spend_key + H(b·V)` (only when `spend_key` given), usable directly as the `spending_key` input field of `createblsctrawtransaction`

Unlike `deriveblsctspendingkey` it consults no wallet keys, so it works for jointly derived destinations no wallet owns — the swap case, where the spend scalar is a key-share sum reconstructed after the counterparty's share is revealed on the other chain.

### Why no other changes are needed

The rest of the swap flow is already covered by existing RPCs: `createblsctrawtransaction` (per-output `blinding_key`, per-input `spending_key`/`gamma`/`value`), `signblsctrawtransaction`, `getblsctrecoverydatawithnonce`, `deriveblsctnonce`, `getblsctoutput`. This RPC only exposes derivation math (`GenerateKeys` inverse) that would otherwise require reimplementing mcl's `GetHashWithSalt` outside the node.

### Test

New unit test `blsct_keyman_tests/external_destination_one_time_key_derivation` pins the math to `CreateOutput`: reconstructs one-time public key, private key, view tag, and recovers the amount from `(view scalar, spend shares, on-chain output)` alone. Also smoke-tested the RPC on regtest (scalar addition and idempotence verified).

No consensus changes; RPC-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)