### PR TITLE
Cold staking usability: owner visibility, redelegation, compounding, operator tooling

### DIFF
--- a/doc/cold-staking.md
+++ b/doc/cold-staking.md
@@ -33,9 +33,13 @@ staking exploits exactly this split:
 3. The operator runs a wallet-less staker:
 
    ```
-   navio-staker -delegated -delegationkey=<hex> \
-       [-operatoraddress=<addr> -operatorfee=<bps>] [-delegationrefresh=<sec>]
+   navio-staker -delegated -delegationkeyfile=<path> \
+       [-operatoraddress=<addr> -operatorfee=<bps>] [-delegationrefresh=<sec>] \
+       [-statsfile=<path>]
    ```
+
+   (`-delegationkey=<hex>` is also accepted, but a key on the command line is
+   visible to other users in the process list; prefer `-delegationkeyfile`.)
 
    The staker periodically scans the chain's staked outputs
    (`liststakedcommitmentsdata` RPC), trial-decrypts each delegation payload,
@@ -72,10 +76,21 @@ Important caveats:
   stakes already delegated with identical parameters. A delegation is
   therefore never silently revoked or extended by an unrelated stake
   operation.
-- Rewards accumulate in the owner's wallet as ordinary outputs; re-staking
-  them requires the owner to run `delegatestake` again (the spend key never
-  leaves the owner's machine, so compounding cannot be automated by the
-  operator).
+- Rewards accumulate in the owner's wallet as ordinary outputs; the spend key
+  never leaves the owner's machine, so compounding cannot be automated by the
+  operator. The owner can run `compounddelegations` periodically (e.g. from
+  cron) to fold accumulated rewards back into the delegation.
+- **Owners can audit their delegations from the chain alone.**
+  `listdelegations` recovers every active delegation (delegate key, reward
+  address, amount) from the on-chain payloads, and — when the reward address
+  belongs to the wallet — sums the coinbase rewards received on it, so an
+  owner can check the operator is honoring the reward address before deciding
+  to revoke. `getbalances` reports the delegated portion of the staked balance
+  separately (`delegated_staked_commitment_balance`).
+- **Changing operator or reward address does not interrupt staking.**
+  `redelegatestake` spends the delegated commitments directly into a new
+  staked output carrying the new delegation payload, so the stake never
+  leaves the staking set (no unlock/re-lock gap).
 
 ## RPC / tool reference
 
@@ -83,12 +98,26 @@ Important caveats:
   RPC; locks `amount` and delegates block production. The delegation is bound
   to a fresh commitment (no consolidation), so each call delegates exactly the
   requested amount.
+- `listdelegations` — wallet RPC; lists the wallet's active delegations with
+  the delegate key, reward address, amount and (for wallet-owned reward
+  addresses) the coinbase rewards received.
+- `redelegatestake from_delegate_pubkey delegate_pubkey [reward_address]
+  [verbose]` — wallet RPC; moves existing delegations to a new delegate
+  and/or reward address in a single transaction, without leaving the staking
+  set.
+- `compounddelegations [delegate_pubkey] [min_amount]` — wallet RPC; folds the
+  wallet's spendable balance (minus a fee margin) into an existing delegation.
+  Intended to be run periodically to compound rewards.
 - `liststakedcommitmentsdata` — node RPC; lists all unspent staked-commitment
-  outputs with their predicate data. Public information; used by operators to
-  discover delegations.
+  outputs with their predicate data, creation height and confirmations. Public
+  information; used by operators to discover delegations. The scan is cached
+  per chain tip, so several polling operators only cost one UTXO iteration
+  per block.
 - `getblocktemplate {"coinbasedest": A, "coinbasefeedest": B, "coinbasefeebps": N}`
   — the template's coinbase pays `N/10000` of the reward to `B` and the rest
   to `A`.
 - `navio-staker -gendelegationkey` — generate an operator key pair.
-- `navio-staker -delegated -delegationkey=<hex>` — run as a delegation
-  operator; no wallet required on the staking machine.
+- `navio-staker -delegated -delegationkeyfile=<path>` — run as a delegation
+  operator; no wallet required on the staking machine. With `-statsfile=<path>`
+  the staker maintains a JSON file of per-delegation accounting: blocks
+  accepted/rejected per delegation, last block hash/time and reward address.

--- a/doc/cold-staking.md
+++ b/doc/cold-staking.md
@@ -101,6 +101,10 @@ Important caveats:
 - `listdelegations` — wallet RPC; lists the wallet's active delegations with
   the delegate key, reward address, amount and (for wallet-owned reward
   addresses) the coinbase rewards received.
+- `liststakingrewards` — wallet RPC; lists the wallet's coinbase rewards
+  grouped by receiving address, flagging which addresses belong to an active
+  delegation — so both delegated and own (non-delegated) staking rewards can
+  be tracked from one place.
 - `redelegatestake from_delegate_pubkey delegate_pubkey [reward_address]
   [verbose]` — wallet RPC; moves existing delegations to a new delegate
   and/or reward address in a single transaction, without leaving the staking

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -1219,8 +1219,14 @@ RPCHelpMan delegatestake()
                     throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_reward).original);
                 }
                 rewardAddress = EncodeDestination(*op_reward);
-            } else if (!IsValidDestination(DecodeDestination(rewardAddress))) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid reward_address");
+            } else {
+                const CTxDestination reward_dest = DecodeDestination(rewardAddress);
+                if (!IsValidDestination(reward_dest)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid reward_address");
+                }
+                // Store the canonical encoding so later lookups (rewards
+                // tracking, delegation-identity grouping) compare equal.
+                rewardAddress = EncodeDestination(reward_dest);
             }
 
             UniValue address_amounts(UniValue::VOBJ);
@@ -1326,6 +1332,14 @@ struct WalletDelegation {
 //! the owner section of each delegation payload is decrypted with the same
 //! per-output nonce the wallet already uses to recover amounts, so this needs
 //! no wallet-side metadata and survives a restore from seed.
+//!
+//! Iterates the wallet's own output maps rather than going through
+//! AvailableCoins: the delegation view must describe the chain, so it must not
+//! inherit coin selection's spending policy (only_spendable would hide the
+//! list from a view-key-only auditing wallet, skip_locked would make it
+//! disagree with staked_commitment_balance, which is lock-unaware). This also
+//! keeps callers like getbalances at the cost of a map walk, the same class
+//! as the existing balance computations, instead of a coin-selection pass.
 static std::vector<WalletDelegation> GetWalletDelegations(const wallet::CWallet& wallet, blsct::KeyMan* blsct_km) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     AssertLockHeld(wallet.cs_wallet);
@@ -1340,47 +1354,45 @@ static std::vector<WalletDelegation> GetWalletDelegations(const wallet::CWallet&
         return ret;
     }
 
-    wallet::CoinFilterParams coins_params;
-    coins_params.min_amount = 0;
-    coins_params.only_blsct = true;
-    coins_params.include_staked_commitment = true;
-    coins_params.min_sum_amount = MAX_MONEY;
-
-    const bool is_blsct_storage = wallet.IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE);
-    auto availableCoins = is_blsct_storage ? AvailableBlsctCoins(wallet, nullptr, coins_params) : AvailableCoins(wallet, nullptr, std::nullopt, coins_params);
-
-    for (const wallet::COutput& output : availableCoins.All()) {
-        CTxOut out;
-        CAmount amount{0};
-        bool isStakedCommitment = false;
-
-        if (is_blsct_storage) {
-            const auto wout = wallet.GetWalletOutput(output.outpoint);
-            if (wout == nullptr) continue;
-            out = *(wout->out);
-            amount = wout->blsctRecoveryData.amount;
-            isStakedCommitment = wout->fStakedCommitment;
-        } else {
-            const auto wtx = wallet.GetWalletTxFromOutpoint(output.outpoint);
-            if (wtx == nullptr) continue;
-            const auto txout_iter = std::find_if(wtx->tx->vout.begin(), wtx->tx->vout.end(), [&](const CTxOut& o) { return o.GetHash() == output.outpoint.hash; });
-            if (txout_iter == wtx->tx->vout.end()) continue;
-            out = *txout_iter;
-            amount = wtx->GetBLSCTRecoveryData(output.outpoint).amount;
-            isStakedCommitment = out.IsStakedCommitment();
-        }
-
-        if (!isStakedCommitment || out.predicate.empty()) continue;
-
+    const auto consider = [&](const uint256& outhash, const CTxOut& out, const CAmount amount, const int depth) {
+        if (out.predicate.empty()) return;
         try {
             const auto parsed = blsct::ParsePredicate(out.predicate);
-            if (!parsed.IsDataPredicate() || !blsct::delegation::IsDelegationData(parsed.GetData())) continue;
+            if (!parsed.IsDataPredicate() || !blsct::delegation::IsDelegationData(parsed.GetData())) return;
             const auto nonce = blsct::CalculateNonce(out.blsctData.blindingKey, viewKey);
-            const auto request = blsct::delegation::RecoverOwnerInfo(parsed.GetData(), nonce);
-            if (!request.has_value()) continue;
-            ret.push_back({output.outpoint.hash, amount, output.depth, *request});
+            auto request = blsct::delegation::RecoverOwnerInfo(parsed.GetData(), nonce);
+            if (!request.has_value()) return;
+            // Canonicalise the reward address: the payload stores whatever
+            // string the delegator passed, and downstream lookups (rewards
+            // maps, IsMine) compare encoded destinations. Any valid spelling
+            // of the same address must match.
+            const CTxDestination dest = DecodeDestination(request->rewardAddress);
+            if (IsValidDestination(dest)) request->rewardAddress = EncodeDestination(dest);
+            ret.push_back({outhash, amount, depth, *request});
         } catch (const std::exception&) {
-            continue;
+        }
+    };
+
+    if (wallet.IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
+        for (const auto& [outpoint, wout] : wallet.mapOutputs) {
+            if (!wout.fStakedCommitment) continue;
+            if (wallet.IsSpent(outpoint) || wout.IsSpent()) continue;
+            if (!(wallet.IsMine(*wout.out) & wallet::ISMINE_STAKED_COMMITMENT_BLSCT)) continue;
+            const int depth = wallet.GetOutputDepthInMainChain(wout);
+            if (depth < 0) continue;
+            consider(outpoint.hash, *wout.out, wout.blsctRecoveryData.amount, depth);
+        }
+    } else {
+        for (const auto& [txid, wtx] : wallet.mapWallet) {
+            const int depth = wallet.GetTxDepthInMainChain(wtx);
+            if (depth < 0) continue;
+            for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
+                const CTxOut& out = wtx.tx->vout[i];
+                if (!out.IsStakedCommitment()) continue;
+                if (wallet.IsSpent(COutPoint(out.GetHash()))) continue;
+                if (!(wallet.IsMine(out) & wallet::ISMINE_STAKED_COMMITMENT_BLSCT)) continue;
+                consider(out.GetHash(), out, wtx.GetBLSCTRecoveryData(i).amount, depth);
+            }
         }
     }
 
@@ -1411,10 +1423,14 @@ static std::map<std::string, CoinbaseRewards> GetCoinbaseRewardsByAddress(const 
         acc.lastHeight = std::max(acc.lastHeight, tip_height - depth + 1);
     };
 
+    // Same ownership rule on both storage paths: every coinbase output the
+    // wallet recognises as its own counts, watch-only included, so a
+    // view-key-only auditing wallet sees the same totals as the full wallet.
     if (wallet.IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
         for (const auto& entry : wallet.mapOutputs) {
             const wallet::CWalletOutput& wout = entry.second;
             if (!wout.fCoinbase) continue;
+            if (wallet.IsMine(*wout.out) == wallet::ISMINE_NO) continue;
             const int depth = wallet.GetOutputDepthInMainChain(wout);
             if (depth < 1) continue;
             add(*wout.out, wout.blsctRecoveryData.amount, depth);
@@ -1427,7 +1443,7 @@ static std::map<std::string, CoinbaseRewards> GetCoinbaseRewardsByAddress(const 
             if (depth < 1) continue;
             for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
                 const CTxOut& out = wtx.tx->vout[i];
-                if (!(wallet.IsMine(out) & wallet::ISMINE_SPENDABLE_BLSCT)) continue;
+                if (wallet.IsMine(out) == wallet::ISMINE_NO) continue;
                 add(out, wtx.GetBLSCTRecoveryData(i).amount, depth);
             }
         }
@@ -1641,10 +1657,16 @@ RPCHelpMan redelegatestake()
                 if (!(d.request.delegateKey == fromKey)) continue;
                 fromIds.insert(d.request.GetId());
                 fromRewardAddresses.insert(d.request.rewardAddress);
-                if (d.depth >= 1) movedAmount += d.amount;
+                movedAmount += d.amount;
             }
             if (fromIds.empty()) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "No stakes are delegated to from_delegate_pubkey");
+            }
+            // The moved commitments are the sole funding of the new staked
+            // output; fail with a clear error instead of a generic factory
+            // failure if they cannot satisfy the consensus minimum.
+            if (movedAmount < Params().GetConsensus().nPePoSMinStakeAmount) {
+                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("The delegated amount being moved (%s) is below the minimum stake of %s", FormatMoney(movedAmount), FormatMoney(Params().GetConsensus().nPePoSMinStakeAmount)));
             }
 
             std::string rewardAddress = request.params[2].isNull() ? "" : request.params[2].get_str();
@@ -1653,8 +1675,12 @@ RPCHelpMan redelegatestake()
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "The delegations being moved use different reward addresses; pass reward_address explicitly");
                 }
                 rewardAddress = *fromRewardAddresses.begin();
-            } else if (!IsValidDestination(DecodeDestination(rewardAddress))) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid reward_address");
+            } else {
+                const CTxDestination reward_dest = DecodeDestination(rewardAddress);
+                if (!IsValidDestination(reward_dest)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid reward_address");
+                }
+                rewardAddress = EncodeDestination(reward_dest);
             }
 
             auto op_dest = pwallet->GetNewDestination(OutputType::BLSCT_STAKE, "Delegated Stake");
@@ -1694,7 +1720,7 @@ RPCHelpMan compounddelegations()
             wallet::HELP_REQUIRING_PASSPHRASE,
         {
             {"delegate_pubkey", RPCArg::Type::STR_HEX, RPCArg::Default{""}, "The delegation to compound into. May be omitted when the wallet has exactly one delegation identity."},
-            {"min_amount", RPCArg::Type::AMOUNT, RPCArg::Default{1}, "Do nothing (return null) while the spendable balance is below this amount."},
+            {"min_amount", RPCArg::Type::AMOUNT, RPCArg::Default{1}, "Do nothing (return null) while the spendable balance is below this amount. Independently of it, 1 NAV of the spendable balance is always held back as a fee margin."},
         },
         {
             RPCResult{"if there was something to compound",
@@ -1741,15 +1767,18 @@ RPCHelpMan compounddelegations()
 
             const CAmount min_amount = request.params[1].isNull() ? COIN : AmountFromValue(request.params[1]);
 
-            // Compound the spendable balance minus a fee margin: the fee is
-            // paid from spendable coins on top of the staked amount, and input
-            // selection gathers up to (amount + 1 NAV) to cover it. Sum both
-            // balance paths like getbalances does: in BLSCT output-storage
-            // mode outputs whose CWalletTx is alive are counted by
-            // GetBalance, the rest by GetBlsctBalance.
+            // Held back from the compounded amount so the transaction fee can
+            // be paid from spendable coins: input selection gathers up to
+            // (amount + COMPOUND_FEE_MARGIN) to cover amount + fee.
+            constexpr CAmount COMPOUND_FEE_MARGIN{COIN};
+
+            // Sum both balance paths like getbalances does: in BLSCT
+            // output-storage mode outputs whose CWalletTx is alive are counted
+            // by GetBalance, the rest by GetBlsctBalance.
             const CAmount spendable = wallet::GetBalance(*pwallet).m_mine_trusted + wallet::GetBlsctBalance(*pwallet).m_mine_trusted;
-            const CAmount amount = spendable - COIN;
-            if (amount < min_amount || amount <= 0) return UniValue::VNULL;
+            if (spendable < min_amount) return UniValue::VNULL;
+            const CAmount amount = spendable - COMPOUND_FEE_MARGIN;
+            if (amount <= 0) return UniValue::VNULL;
 
             auto op_dest = pwallet->GetNewDestination(OutputType::BLSCT_STAKE, "Delegated Stake");
             if (!op_dest) {

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -29,6 +29,7 @@
 #include <validation.h>
 #include <wallet/receive.h>
 #include <wallet/rpc/util.h>
+#include <wallet/spend.h>
 #include <wallet/wallet.h>
 #include <limits>
 #include <optional>
@@ -1307,6 +1308,385 @@ RPCHelpMan stakeunlock()
             EnsureWalletIsUnlocked(*pwallet);
 
             return blsct::SendTransaction(*pwallet, transactionData, verbose);
+        },
+    };
+}
+
+//! One delegated staked output of this wallet, with the delegation parameters
+//! recovered from the on-chain payload's owner section.
+struct WalletDelegation {
+    uint256 outhash;
+    CAmount amount{0};
+    int depth{0};
+    blsct::delegation::DelegationRequest request;
+};
+
+//! Recover every delegated staked output of the wallet (unspent, any depth)
+//! together with its delegation parameters. Works purely from the chain data:
+//! the owner section of each delegation payload is decrypted with the same
+//! per-output nonce the wallet already uses to recover amounts, so this needs
+//! no wallet-side metadata and survives a restore from seed.
+static std::vector<WalletDelegation> GetWalletDelegations(const wallet::CWallet& wallet, blsct::KeyMan* blsct_km) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    std::vector<WalletDelegation> ret;
+
+    // A non-BLSCT wallet still has a KeyMan object but no view key; it cannot
+    // hold delegations either.
+    MclScalar viewKey;
+    try {
+        viewKey = blsct_km->GetPrivateViewKey().GetScalar();
+    } catch (const std::exception&) {
+        return ret;
+    }
+
+    wallet::CoinFilterParams coins_params;
+    coins_params.min_amount = 0;
+    coins_params.only_blsct = true;
+    coins_params.include_staked_commitment = true;
+    coins_params.min_sum_amount = MAX_MONEY;
+
+    const bool is_blsct_storage = wallet.IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE);
+    auto availableCoins = is_blsct_storage ? AvailableBlsctCoins(wallet, nullptr, coins_params) : AvailableCoins(wallet, nullptr, std::nullopt, coins_params);
+
+    for (const wallet::COutput& output : availableCoins.All()) {
+        CTxOut out;
+        CAmount amount{0};
+        bool isStakedCommitment = false;
+
+        if (is_blsct_storage) {
+            const auto wout = wallet.GetWalletOutput(output.outpoint);
+            if (wout == nullptr) continue;
+            out = *(wout->out);
+            amount = wout->blsctRecoveryData.amount;
+            isStakedCommitment = wout->fStakedCommitment;
+        } else {
+            const auto wtx = wallet.GetWalletTxFromOutpoint(output.outpoint);
+            if (wtx == nullptr) continue;
+            const auto txout_iter = std::find_if(wtx->tx->vout.begin(), wtx->tx->vout.end(), [&](const CTxOut& o) { return o.GetHash() == output.outpoint.hash; });
+            if (txout_iter == wtx->tx->vout.end()) continue;
+            out = *txout_iter;
+            amount = wtx->GetBLSCTRecoveryData(output.outpoint).amount;
+            isStakedCommitment = out.IsStakedCommitment();
+        }
+
+        if (!isStakedCommitment || out.predicate.empty()) continue;
+
+        try {
+            const auto parsed = blsct::ParsePredicate(out.predicate);
+            if (!parsed.IsDataPredicate() || !blsct::delegation::IsDelegationData(parsed.GetData())) continue;
+            const auto nonce = blsct::CalculateNonce(out.blsctData.blindingKey, viewKey);
+            const auto request = blsct::delegation::RecoverOwnerInfo(parsed.GetData(), nonce);
+            if (!request.has_value()) continue;
+            ret.push_back({output.outpoint.hash, amount, output.depth, *request});
+        } catch (const std::exception&) {
+            continue;
+        }
+    }
+
+    return ret;
+}
+
+CAmount blsct::GetDelegatedStakedBalance(const wallet::CWallet& wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    auto blsct_km = wallet.GetBLSCTKeyMan();
+    if (blsct_km == nullptr) return 0;
+    CAmount total{0};
+    for (const auto& d : GetWalletDelegations(wallet, blsct_km)) {
+        if (d.depth >= 1) total += d.amount;
+    }
+    return total;
+}
+
+RPCHelpMan listdelegations()
+{
+    return RPCHelpMan{
+        "listdelegations",
+        "\nList this wallet's active stake delegations: every unspent staked output that\n"
+        "carries a delegation payload, with the delegate key and reward address recovered\n"
+        "from the chain. When a delegation's reward address belongs to this wallet, the\n"
+        "coinbase rewards received on it are summed so the owner can check the delegate\n"
+        "is honoring the reward address.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::ARR,
+            "",
+            "",
+            {{RPCResult::Type::OBJ, "", "", {
+                 {RPCResult::Type::STR_HEX, "outhash", "The hash identifying the staked output."},
+                 {RPCResult::Type::STR_AMOUNT, "amount", "The delegated amount."},
+                 {RPCResult::Type::NUM, "confirmations", "The number of confirmations of the staked output."},
+                 {RPCResult::Type::STR_HEX, "delegate_pubkey", "The delegate's G1 delegation public key."},
+                 {RPCResult::Type::STR, "reward_address", "The address the delegate is asked to pay block rewards to."},
+                 {RPCResult::Type::BOOL, "reward_address_is_mine", "Whether the reward address belongs to this wallet."},
+                 {RPCResult::Type::STR_AMOUNT, "rewards_received", /*optional=*/true, "Total coinbase rewards received on the reward address (only when it belongs to this wallet)."},
+                 {RPCResult::Type::NUM, "rewards_count", /*optional=*/true, "Number of coinbase outputs received on the reward address (only when it belongs to this wallet)."},
+             }}},
+        },
+        RPCExamples{HelpExampleCli("listdelegations", "") + HelpExampleRpc("listdelegations", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<wallet::CWallet> const pwallet = wallet::GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            LOCK(pwallet->cs_wallet);
+
+            auto blsct_km = pwallet->GetBLSCTKeyMan();
+            if (blsct_km == nullptr) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "This wallet does not have BLSCT keys");
+            }
+
+            const auto delegations = GetWalletDelegations(*pwallet, blsct_km);
+
+            // Sum the wallet's coinbase receipts per destination address once,
+            // then attribute them to any delegation whose reward address is
+            // ours. This is what lets an owner audit "is my operator actually
+            // paying the reward address it was given".
+            std::map<std::string, std::pair<CAmount, int>> coinbase_by_address;
+            const auto addCoinbase = [&](const CTxOut& out, const CAmount amount) {
+                if (!out.HasBLSCTRangeProof()) return;
+                const CTxDestination dest = blsct_km->GetDestination(out);
+                if (std::holds_alternative<CNoDestination>(dest)) return;
+                auto& acc = coinbase_by_address[EncodeDestination(dest)];
+                acc.first += amount;
+                acc.second += 1;
+            };
+            if (pwallet->IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
+                for (const auto& entry : pwallet->mapOutputs) {
+                    const wallet::CWalletOutput& wout = entry.second;
+                    if (!wout.fCoinbase) continue;
+                    if (pwallet->GetOutputDepthInMainChain(wout) < 1) continue;
+                    addCoinbase(*wout.out, wout.blsctRecoveryData.amount);
+                }
+            } else {
+                for (const auto& entry : pwallet->mapWallet) {
+                    const wallet::CWalletTx& wtx = entry.second;
+                    if (!wtx.IsCoinBase()) continue;
+                    if (pwallet->GetTxDepthInMainChain(wtx) < 1) continue;
+                    for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
+                        const CTxOut& out = wtx.tx->vout[i];
+                        if (!(pwallet->IsMine(out) & wallet::ISMINE_SPENDABLE_BLSCT)) continue;
+                        addCoinbase(out, wtx.GetBLSCTRecoveryData(i).amount);
+                    }
+                }
+            }
+
+            UniValue result(UniValue::VARR);
+            for (const auto& d : delegations) {
+                UniValue entry(UniValue::VOBJ);
+                entry.pushKV("outhash", d.outhash.GetHex());
+                entry.pushKV("amount", ValueFromAmount(d.amount));
+                entry.pushKV("confirmations", d.depth);
+                entry.pushKV("delegate_pubkey", HexStr(d.request.delegateKey.GetVch()));
+                entry.pushKV("reward_address", d.request.rewardAddress);
+                const auto rewards = coinbase_by_address.find(d.request.rewardAddress);
+                const bool reward_is_mine = pwallet->IsMine(DecodeDestination(d.request.rewardAddress)) != wallet::ISMINE_NO;
+                entry.pushKV("reward_address_is_mine", reward_is_mine);
+                if (reward_is_mine) {
+                    entry.pushKV("rewards_received", ValueFromAmount(rewards != coinbase_by_address.end() ? rewards->second.first : 0));
+                    entry.pushKV("rewards_count", rewards != coinbase_by_address.end() ? rewards->second.second : 0);
+                }
+                result.push_back(entry);
+            }
+            return result;
+        },
+    };
+}
+
+RPCHelpMan redelegatestake()
+{
+    return RPCHelpMan{
+        "redelegatestake",
+        "\nMove existing stake delegations to a different delegate and/or reward address in a\n"
+        "single transaction. The delegated commitments stay staked the whole time: the old\n"
+        "delegated outputs are spent directly into a new staked output carrying the new\n"
+        "delegation payload, so there is no separate unlock/re-lock step and no gap in stake\n"
+        "continuity. Only delegations to from_delegate_pubkey are moved; other stakes are\n"
+        "left untouched.\n" +
+            wallet::HELP_REQUIRING_PASSPHRASE,
+        {
+            {"from_delegate_pubkey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The delegate key the stakes are currently delegated to."},
+            {"delegate_pubkey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The new delegate's 48-byte G1 delegation public key (hex). May equal from_delegate_pubkey to only change the reward address."},
+            {"reward_address", RPCArg::Type::STR, RPCArg::Default{""}, "BLSCT address the new delegate should pay block rewards to. Defaults to the reward address of the delegations being moved."},
+            {"verbose", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, return extra information about the transaction."},
+        },
+        {
+            RPCResult{"if verbose is not set or set to false",
+                      RPCResult::Type::STR_HEX, "outputHash", "The output hash."},
+            RPCResult{
+                "if verbose is set to true",
+                RPCResult::Type::OBJ,
+                "",
+                "",
+                {{RPCResult::Type::STR_HEX, "outputHash", "The output hash."}},
+            },
+        },
+        RPCExamples{
+            "\nMove all stakes delegated to one operator to another\n" + HelpExampleCli("redelegatestake", "\"<old_pubkey_hex>\" \"<new_pubkey_hex>\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<wallet::CWallet> const pwallet = wallet::GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            LOCK(pwallet->cs_wallet);
+
+            auto blsct_km = pwallet->GetBLSCTKeyMan();
+            if (blsct_km == nullptr) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "This wallet does not have BLSCT keys");
+            }
+
+            MclG1Point fromKey;
+            if (!IsHex(request.params[0].get_str()) || !fromKey.SetVch(ParseHex(request.params[0].get_str())) || fromKey.IsZero()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "from_delegate_pubkey is not a valid G1 point");
+            }
+            MclG1Point delegateKey;
+            if (!IsHex(request.params[1].get_str()) || !delegateKey.SetVch(ParseHex(request.params[1].get_str())) || delegateKey.IsZero()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "delegate_pubkey is not a valid G1 point");
+            }
+
+            // Collect the delegations being moved; their ids drive the input
+            // selection and their reward address is the default for the new
+            // delegation.
+            std::set<std::string> fromIds;
+            std::set<std::string> fromRewardAddresses;
+            CAmount movedAmount{0};
+            for (const auto& d : GetWalletDelegations(*pwallet, blsct_km)) {
+                if (!(d.request.delegateKey == fromKey)) continue;
+                fromIds.insert(d.request.GetId());
+                fromRewardAddresses.insert(d.request.rewardAddress);
+                if (d.depth >= 1) movedAmount += d.amount;
+            }
+            if (fromIds.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "No stakes are delegated to from_delegate_pubkey");
+            }
+
+            std::string rewardAddress = request.params[2].isNull() ? "" : request.params[2].get_str();
+            if (rewardAddress.empty()) {
+                if (fromRewardAddresses.size() > 1) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "The delegations being moved use different reward addresses; pass reward_address explicitly");
+                }
+                rewardAddress = *fromRewardAddresses.begin();
+            } else if (!IsValidDestination(DecodeDestination(rewardAddress))) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid reward_address");
+            }
+
+            auto op_dest = pwallet->GetNewDestination(OutputType::BLSCT_STAKE, "Delegated Stake");
+            if (!op_dest) {
+                throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+            }
+
+            const bool verbose{request.params[3].isNull() ? false : request.params[3].get_bool()};
+
+            UniValue address_amounts(UniValue::VOBJ);
+            address_amounts.pushKV(EncodeDestination(*op_dest), ValueFromAmount(0));
+            std::vector<wallet::CBLSCTRecipient> recipients;
+            blsct::ParseBLSCTRecipients(address_amounts, false, "", recipients);
+
+            // nAmount 0: the whole staked value comes from folding the old
+            // delegated commitments in; no spendable coins are staked on top.
+            blsct::CreateTransactionData transactionData(recipients[0].destination, 0, "", TokenId(), blsct::CreateTransactionType::STAKED_COMMITMENT, Params().GetConsensus().nPePoSMinStakeAmount);
+            transactionData.fConsolidateStakedCommitments = true;
+            transactionData.stakeDelegation = blsct::delegation::DelegationRequest{delegateKey, rewardAddress};
+            transactionData.redelegateFromIds = fromIds;
+
+            EnsureWalletIsUnlocked(*pwallet);
+
+            return blsct::SendTransaction(*pwallet, transactionData, verbose);
+        },
+    };
+}
+
+RPCHelpMan compounddelegations()
+{
+    return RPCHelpMan{
+        "compounddelegations",
+        "\nRe-delegate accumulated rewards: fold the wallet's spendable balance (minus a fee\n"
+        "margin) into an existing stake delegation. Block rewards paid to this wallet do not\n"
+        "auto-compound -- the spend key would need to be online for that -- so run this\n"
+        "periodically (e.g. from cron) to keep delegated stake growing.\n" +
+            wallet::HELP_REQUIRING_PASSPHRASE,
+        {
+            {"delegate_pubkey", RPCArg::Type::STR_HEX, RPCArg::Default{""}, "The delegation to compound into. May be omitted when the wallet has exactly one delegation identity."},
+            {"min_amount", RPCArg::Type::AMOUNT, RPCArg::Default{1}, "Do nothing (return null) while the spendable balance is below this amount."},
+        },
+        {
+            RPCResult{"if there was something to compound",
+                      RPCResult::Type::STR_HEX, "outputHash", "The output hash of the compounding transaction."},
+            RPCResult{"if the spendable balance is below min_amount",
+                      RPCResult::Type::NONE, "", ""},
+        },
+        RPCExamples{HelpExampleCli("compounddelegations", "") + HelpExampleRpc("compounddelegations", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<wallet::CWallet> const pwallet = wallet::GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            LOCK(pwallet->cs_wallet);
+
+            auto blsct_km = pwallet->GetBLSCTKeyMan();
+            if (blsct_km == nullptr) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "This wallet does not have BLSCT keys");
+            }
+
+            std::optional<MclG1Point> filterKey;
+            if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
+                MclG1Point key;
+                if (!IsHex(request.params[0].get_str()) || !key.SetVch(ParseHex(request.params[0].get_str())) || key.IsZero()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "delegate_pubkey is not a valid G1 point");
+                }
+                filterKey = key;
+            }
+
+            // Identify the delegation to compound into.
+            std::map<std::string, blsct::delegation::DelegationRequest> groups;
+            for (const auto& d : GetWalletDelegations(*pwallet, blsct_km)) {
+                if (filterKey.has_value() && !(d.request.delegateKey == *filterKey)) continue;
+                groups.emplace(d.request.GetId(), d.request);
+            }
+            if (groups.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, filterKey.has_value() ? "No stakes are delegated to delegate_pubkey" : "This wallet has no stake delegations");
+            }
+            if (groups.size() > 1) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "This wallet has several delegation identities; pass delegate_pubkey (and use redelegatestake to unify reward addresses)");
+            }
+            const blsct::delegation::DelegationRequest target = groups.begin()->second;
+
+            const CAmount min_amount = request.params[1].isNull() ? COIN : AmountFromValue(request.params[1]);
+
+            // Compound the spendable balance minus a fee margin: the fee is
+            // paid from spendable coins on top of the staked amount, and input
+            // selection gathers up to (amount + 1 NAV) to cover it. Sum both
+            // balance paths like getbalances does: in BLSCT output-storage
+            // mode outputs whose CWalletTx is alive are counted by
+            // GetBalance, the rest by GetBlsctBalance.
+            const CAmount spendable = wallet::GetBalance(*pwallet).m_mine_trusted + wallet::GetBlsctBalance(*pwallet).m_mine_trusted;
+            const CAmount amount = spendable - COIN;
+            if (amount < min_amount || amount <= 0) return UniValue::VNULL;
+
+            auto op_dest = pwallet->GetNewDestination(OutputType::BLSCT_STAKE, "Delegated Stake");
+            if (!op_dest) {
+                throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+            }
+
+            UniValue address_amounts(UniValue::VOBJ);
+            address_amounts.pushKV(EncodeDestination(*op_dest), ValueFromAmount(amount));
+            std::vector<wallet::CBLSCTRecipient> recipients;
+            blsct::ParseBLSCTRecipients(address_amounts, false, "", recipients);
+
+            blsct::CreateTransactionData transactionData(recipients[0].destination, recipients[0].nAmount, recipients[0].sMemo, TokenId(), blsct::CreateTransactionType::STAKED_COMMITMENT, Params().GetConsensus().nPePoSMinStakeAmount);
+            // Fold into the existing delegated commitment so the wallet keeps
+            // one output per delegation instead of accumulating a new one per
+            // compounding run.
+            transactionData.fConsolidateStakedCommitments = true;
+            transactionData.stakeDelegation = target;
+
+            EnsureWalletIsUnlocked(*pwallet);
+
+            return blsct::SendTransaction(*pwallet, transactionData, false);
         },
     };
 }
@@ -3394,6 +3774,9 @@ Span<const CRPCCommand> GetBLSCTWalletRPCCommands()
         {"blsct", &stakelock},
         {"blsct", &delegatestake},
         {"blsct", &stakeunlock},
+        {"blsct", &listdelegations},
+        {"blsct", &redelegatestake},
+        {"blsct", &compounddelegations},
         {"blsct", &consolidate},
         {"blsct", &setblsctseed},
         {"blsct", &createblsctbalanceproof},

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -1387,6 +1387,55 @@ static std::vector<WalletDelegation> GetWalletDelegations(const wallet::CWallet&
     return ret;
 }
 
+//! Per-address totals of the wallet's confirmed coinbase (staking reward)
+//! receipts.
+struct CoinbaseRewards {
+    CAmount amount{0};
+    int count{0};
+    int lastHeight{0};
+};
+
+static std::map<std::string, CoinbaseRewards> GetCoinbaseRewardsByAddress(const wallet::CWallet& wallet, blsct::KeyMan* blsct_km) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    std::map<std::string, CoinbaseRewards> ret;
+
+    const int tip_height = wallet.GetLastBlockHeight();
+    const auto add = [&](const CTxOut& out, const CAmount amount, const int depth) {
+        if (!out.HasBLSCTRangeProof()) return;
+        const CTxDestination dest = blsct_km->GetDestination(out);
+        if (std::holds_alternative<CNoDestination>(dest)) return;
+        auto& acc = ret[EncodeDestination(dest)];
+        acc.amount += amount;
+        acc.count += 1;
+        acc.lastHeight = std::max(acc.lastHeight, tip_height - depth + 1);
+    };
+
+    if (wallet.IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
+        for (const auto& entry : wallet.mapOutputs) {
+            const wallet::CWalletOutput& wout = entry.second;
+            if (!wout.fCoinbase) continue;
+            const int depth = wallet.GetOutputDepthInMainChain(wout);
+            if (depth < 1) continue;
+            add(*wout.out, wout.blsctRecoveryData.amount, depth);
+        }
+    } else {
+        for (const auto& entry : wallet.mapWallet) {
+            const wallet::CWalletTx& wtx = entry.second;
+            if (!wtx.IsCoinBase()) continue;
+            const int depth = wallet.GetTxDepthInMainChain(wtx);
+            if (depth < 1) continue;
+            for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
+                const CTxOut& out = wtx.tx->vout[i];
+                if (!(wallet.IsMine(out) & wallet::ISMINE_SPENDABLE_BLSCT)) continue;
+                add(out, wtx.GetBLSCTRecoveryData(i).amount, depth);
+            }
+        }
+    }
+
+    return ret;
+}
+
 CAmount blsct::GetDelegatedStakedBalance(const wallet::CWallet& wallet)
 {
     AssertLockHeld(wallet.cs_wallet);
@@ -1444,34 +1493,7 @@ RPCHelpMan listdelegations()
             // then attribute them to any delegation whose reward address is
             // ours. This is what lets an owner audit "is my operator actually
             // paying the reward address it was given".
-            std::map<std::string, std::pair<CAmount, int>> coinbase_by_address;
-            const auto addCoinbase = [&](const CTxOut& out, const CAmount amount) {
-                if (!out.HasBLSCTRangeProof()) return;
-                const CTxDestination dest = blsct_km->GetDestination(out);
-                if (std::holds_alternative<CNoDestination>(dest)) return;
-                auto& acc = coinbase_by_address[EncodeDestination(dest)];
-                acc.first += amount;
-                acc.second += 1;
-            };
-            if (pwallet->IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
-                for (const auto& entry : pwallet->mapOutputs) {
-                    const wallet::CWalletOutput& wout = entry.second;
-                    if (!wout.fCoinbase) continue;
-                    if (pwallet->GetOutputDepthInMainChain(wout) < 1) continue;
-                    addCoinbase(*wout.out, wout.blsctRecoveryData.amount);
-                }
-            } else {
-                for (const auto& entry : pwallet->mapWallet) {
-                    const wallet::CWalletTx& wtx = entry.second;
-                    if (!wtx.IsCoinBase()) continue;
-                    if (pwallet->GetTxDepthInMainChain(wtx) < 1) continue;
-                    for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
-                        const CTxOut& out = wtx.tx->vout[i];
-                        if (!(pwallet->IsMine(out) & wallet::ISMINE_SPENDABLE_BLSCT)) continue;
-                        addCoinbase(out, wtx.GetBLSCTRecoveryData(i).amount);
-                    }
-                }
-            }
+            const auto coinbase_by_address = GetCoinbaseRewardsByAddress(*pwallet, blsct_km);
 
             UniValue result(UniValue::VARR);
             for (const auto& d : delegations) {
@@ -1485,9 +1507,71 @@ RPCHelpMan listdelegations()
                 const bool reward_is_mine = pwallet->IsMine(DecodeDestination(d.request.rewardAddress)) != wallet::ISMINE_NO;
                 entry.pushKV("reward_address_is_mine", reward_is_mine);
                 if (reward_is_mine) {
-                    entry.pushKV("rewards_received", ValueFromAmount(rewards != coinbase_by_address.end() ? rewards->second.first : 0));
-                    entry.pushKV("rewards_count", rewards != coinbase_by_address.end() ? rewards->second.second : 0);
+                    entry.pushKV("rewards_received", ValueFromAmount(rewards != coinbase_by_address.end() ? rewards->second.amount : 0));
+                    entry.pushKV("rewards_count", rewards != coinbase_by_address.end() ? rewards->second.count : 0);
                 }
+                result.push_back(entry);
+            }
+            return result;
+        },
+    };
+}
+
+RPCHelpMan liststakingrewards()
+{
+    return RPCHelpMan{
+        "liststakingrewards",
+        "\nList the coinbase (staking) rewards this wallet has received, grouped by the\n"
+        "address they were paid to. Entries whose address is the reward address of an\n"
+        "active delegation are flagged from_delegation; the remaining entries are the\n"
+        "wallet's own (non-delegated) staking rewards, e.g. from running navio-staker\n"
+        "with this wallet.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::ARR,
+            "",
+            "",
+            {{RPCResult::Type::OBJ, "", "", {
+                 {RPCResult::Type::STR, "address", "The address the rewards were paid to."},
+                 {RPCResult::Type::BOOL, "from_delegation", "Whether the address is the reward address of an active delegation."},
+                 {RPCResult::Type::STR_AMOUNT, "amount", "Total rewards received on the address."},
+                 {RPCResult::Type::NUM, "count", "Number of coinbase outputs received on the address."},
+                 {RPCResult::Type::NUM, "last_height", "Height of the most recent reward."},
+             }}},
+        },
+        RPCExamples{HelpExampleCli("liststakingrewards", "") + HelpExampleRpc("liststakingrewards", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<wallet::CWallet> const pwallet = wallet::GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            LOCK(pwallet->cs_wallet);
+
+            auto blsct_km = pwallet->GetBLSCTKeyMan();
+            if (blsct_km == nullptr) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "This wallet does not have BLSCT keys");
+            }
+
+            std::set<std::string> delegation_reward_addresses;
+            for (const auto& d : GetWalletDelegations(*pwallet, blsct_km)) {
+                delegation_reward_addresses.insert(d.request.rewardAddress);
+            }
+
+            const auto coinbase_by_address = GetCoinbaseRewardsByAddress(*pwallet, blsct_km);
+
+            // Largest earner first.
+            std::vector<std::pair<std::string, CoinbaseRewards>> sorted{coinbase_by_address.begin(), coinbase_by_address.end()};
+            std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) { return a.second.amount > b.second.amount; });
+
+            UniValue result(UniValue::VARR);
+            for (const auto& [address, rewards] : sorted) {
+                UniValue entry(UniValue::VOBJ);
+                entry.pushKV("address", address);
+                entry.pushKV("from_delegation", delegation_reward_addresses.contains(address));
+                entry.pushKV("amount", ValueFromAmount(rewards.amount));
+                entry.pushKV("count", rewards.count);
+                entry.pushKV("last_height", rewards.lastHeight);
                 result.push_back(entry);
             }
             return result;
@@ -3775,6 +3859,7 @@ Span<const CRPCCommand> GetBLSCTWalletRPCCommands()
         {"blsct", &delegatestake},
         {"blsct", &stakeunlock},
         {"blsct", &listdelegations},
+        {"blsct", &liststakingrewards},
         {"blsct", &redelegatestake},
         {"blsct", &compounddelegations},
         {"blsct", &consolidate},

--- a/src/blsct/wallet/rpc.h
+++ b/src/blsct/wallet/rpc.h
@@ -15,9 +15,9 @@ typedef std::multimap<int64_t, CWalletOutput*> OutputItems;
 } // namespace wallet
 
 namespace blsct {
-//! Sum of the wallet's confirmed staked commitments that carry a stake-delegation
-//! payload. Requires wallet.cs_wallet.
-CAmount GetDelegatedStakedBalance(const wallet::CWallet& wallet);
+//! Sum of the wallet's confirmed staked commitments that carry a
+//! stake-delegation payload.
+CAmount GetDelegatedStakedBalance(const wallet::CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose, wallet::mapValue_t mapValue = {});
 CScript BuildHTLCScript(
     const std::vector<unsigned char>& hash_bytes,

--- a/src/blsct/wallet/rpc.h
+++ b/src/blsct/wallet/rpc.h
@@ -15,6 +15,9 @@ typedef std::multimap<int64_t, CWalletOutput*> OutputItems;
 } // namespace wallet
 
 namespace blsct {
+//! Sum of the wallet's confirmed staked commitments that carry a stake-delegation
+//! payload. Requires wallet.cs_wallet.
+CAmount GetDelegatedStakedBalance(const wallet::CWallet& wallet);
 UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransactionData& transactionData, const bool& verbose, wallet::mapValue_t mapValue = {});
 CScript BuildHTLCScript(
     const std::vector<unsigned char>& hash_bytes,

--- a/src/blsct/wallet/txfactory_base.cpp
+++ b/src/blsct/wallet/txfactory_base.cpp
@@ -323,7 +323,11 @@ std::optional<CMutableTransaction> TxFactoryBase::CreateTransaction(const std::v
             if (output.is_staked_commitment) {
                 // With consolidation disabled, leave existing commitments
                 // untouched so this stakelock yields a separate commitment.
-                if (!transactionData.fConsolidateStakedCommitments || output.delegation != delegationId)
+                // A redelegation additionally folds the commitments of the
+                // identities it is moving away from.
+                const bool matches = output.delegation == delegationId ||
+                                     transactionData.redelegateFromIds.contains(output.delegation);
+                if (!transactionData.fConsolidateStakedCommitments || !matches)
                     continue;
                 inputFromStakedCommitments += output.amount;
             }

--- a/src/blsct/wallet/txfactory_base.h
+++ b/src/blsct/wallet/txfactory_base.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 
 #include <optional>
+#include <set>
 
 namespace blsct {
 // Maximum number of inputs the factory will put in a single transaction. Each
@@ -62,6 +63,13 @@ struct CreateTransactionData {
     // can stake it without any wallet keys. Only meaningful for
     // STAKED_COMMITMENT transactions.
     std::optional<delegation::DelegationRequest> stakeDelegation{std::nullopt};
+
+    // When non-empty (redelegatestake), staked commitments whose delegation
+    // identity is in this set are folded into the new staked output in
+    // addition to those matching stakeDelegation's identity — this is what
+    // moves a delegation to a new delegate or reward address in a single
+    // transaction, without ever leaving the staking set.
+    std::set<std::string> redelegateFromIds{};
 
     Scalar tokenKey;
     std::map<std::string, std::string> nftMetadata;

--- a/src/navio-staker.cpp
+++ b/src/navio-staker.cpp
@@ -31,7 +31,9 @@
 #include <univalue.h>
 #include <util/chaintype.h>
 #include <util/exception.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/time.h>
 #include <util/translation.h>
 
@@ -39,7 +41,9 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <fstream>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -97,7 +101,9 @@ static void SetupCliArgs(ArgsManager& argsman)
     argsman.AddArg("-autoconsolidate", "Periodically merge the wallet's small outputs (e.g. accumulated staking rewards) into fewer larger ones, so they remain spendable in a single transaction (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-autoconsolidateinterval=<seconds>", "How often to run auto-consolidation when -autoconsolidate is enabled (default: 3600)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-delegated", "Run in delegated (cold-staking operator) mode: stake third-party delegations discovered on-chain instead of a local wallet's outputs. No wallet is needed on this machine (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-delegationkey=<hex>", "The operator's delegation private key as a 32-byte hex scalar. Required with -delegated. Generate one with -gendelegationkey", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::OPTIONS);
+    argsman.AddArg("-delegationkey=<hex>", "The operator's delegation private key as a 32-byte hex scalar. Required with -delegated (alternatively use -delegationkeyfile). Generate one with -gendelegationkey", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::OPTIONS);
+    argsman.AddArg("-delegationkeyfile=<path>", "Read the operator's delegation private key from the first line of <path> instead of passing it with -delegationkey, which is visible to other users in the process list", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-statsfile=<path>", "In -delegated mode, write per-delegation accounting (blocks produced per delegation, last block, reward address) as JSON to <path> after every accepted block and delegation refresh", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-gendelegationkey", "Generate a new delegation key pair, print it and exit. Publish the public key so wallet owners can delegate to you with delegatestake", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-operatoraddress=<address>", "BLSCT address that receives the -operatorfee share of delegated block rewards", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-operatorfee=<bps>", "Operator fee taken from delegated block rewards, in basis points [0, 10000] (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -541,9 +547,21 @@ void Setup()
     fDelegated = gArgs.GetBoolArg("-delegated", false);
 
     if (fDelegated) {
-        const std::string keyHex = gArgs.GetArg("-delegationkey", "");
+        std::string keyHex = gArgs.GetArg("-delegationkey", "");
+        const std::string keyFile = gArgs.GetArg("-delegationkeyfile", "");
+        if (!keyHex.empty() && !keyFile.empty()) {
+            throw std::runtime_error("-delegationkey and -delegationkeyfile are mutually exclusive");
+        }
+        if (!keyFile.empty()) {
+            std::ifstream file{fs::PathFromString(keyFile)};
+            if (!file) {
+                throw std::runtime_error(strprintf("Could not open -delegationkeyfile %s", keyFile));
+            }
+            std::getline(file, keyHex);
+            keyHex = TrimString(keyHex);
+        }
         if (!IsHex(keyHex) || keyHex.size() != 64) {
-            throw std::runtime_error("-delegated requires -delegationkey=<32-byte hex scalar> (generate one with -gendelegationkey)");
+            throw std::runtime_error("-delegated requires -delegationkey=<32-byte hex scalar> or -delegationkeyfile=<path> (generate a key with -gendelegationkey)");
         }
         delegationPrivKey.SetVch(ParseHex(keyHex));
         if (delegationPrivKey.IsZero()) {
@@ -788,7 +806,66 @@ std::vector<StakedCommitment> GetStakedCommitments(const std::unique_ptr<BaseReq
 struct DelegatedCommitment {
     StakedCommitment staked;
     std::string rewardAddress;
+    std::string outhash;
+    int confirmations{0};
 };
+
+//! Per-delegation block accounting, keyed by the staked output hash. Survives
+//! delegation refreshes (a delegation that disappears from the chain keeps its
+//! historical stats for the session) and is dumped to -statsfile as JSON so an
+//! operator can account which delegations produced which blocks.
+struct DelegationStats {
+    std::string commitment;
+    std::string rewardAddress;
+    CAmount value{0};
+    int64_t blocksAccepted{0};
+    int64_t blocksRejected{0};
+    std::string lastBlockHash;
+    int64_t lastBlockTime{0};
+};
+static std::map<std::string, DelegationStats> delegationStats;
+
+//! Atomically (write + rename) dump the per-delegation stats to -statsfile.
+static void WriteDelegationStats()
+{
+    const std::string path = gArgs.GetArg("-statsfile", "");
+    if (path.empty()) return;
+
+    UniValue root(UniValue::VOBJ);
+    root.pushKV("operator_fee_bps", operatorFeeBps);
+    if (!operatorAddress.empty()) root.pushKV("operator_address", operatorAddress);
+    UniValue arr(UniValue::VARR);
+    for (const auto& [outhash, s] : delegationStats) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("outhash", outhash);
+        entry.pushKV("commitment", s.commitment);
+        entry.pushKV("reward_address", s.rewardAddress);
+        entry.pushKV("value", s.value);
+        entry.pushKV("blocks_accepted", s.blocksAccepted);
+        entry.pushKV("blocks_rejected", s.blocksRejected);
+        if (!s.lastBlockHash.empty()) {
+            entry.pushKV("last_block_hash", s.lastBlockHash);
+            entry.pushKV("last_block_time", s.lastBlockTime);
+        }
+        arr.push_back(entry);
+    }
+    root.pushKV("delegations", arr);
+
+    const fs::path target = fs::PathFromString(path);
+    const fs::path tmp = fs::PathFromString(path + ".tmp");
+    std::ofstream file{tmp, std::ios::trunc};
+    if (!file) {
+        LogPrintf("%s: Could not open -statsfile %s for writing\n", __func__, path);
+        return;
+    }
+    file << root.write(2) << "\n";
+    file.close();
+    std::error_code ec;
+    fs::rename(tmp, target, ec);
+    if (ec) {
+        LogPrintf("%s: Could not rename %s into place: %s\n", __func__, fs::PathToString(tmp), ec.message());
+    }
+}
 
 //! Wallet endpoint to route RPCs through: none in delegated mode, where no
 //! wallet exists on this machine (node-level RPCs work on the base endpoint).
@@ -848,11 +925,30 @@ std::vector<DelegatedCommitment> GetDelegatedCommitments(const std::unique_ptr<B
                 continue;
             }
 
-            ret.push_back({StakedCommitment{point, value, gamma}, info->rewardAddress});
+            // height/confirmations were added to liststakedcommitmentsdata
+            // later; tolerate their absence so the staker still works against
+            // an older node.
+            const UniValue& conf_val = obj.find_value("confirmations");
+            const int confirmations = conf_val.isNum() ? conf_val.getInt<int>() : 0;
+            const std::string outhash = obj.find_value("outhash").get_str();
+
+            ret.push_back({StakedCommitment{point, value, gamma}, info->rewardAddress, outhash, confirmations});
+
+            auto& stats = delegationStats[outhash];
+            stats.commitment = obj.find_value("commitment").get_str();
+            stats.rewardAddress = info->rewardAddress;
+            stats.value = info->value;
         } catch (const std::exception& e) {
             LogPrintf("%s: Skipping malformed staked commitment entry: %s\n", __func__, e.what());
         }
     }
+
+    // Oldest (most confirmed) first: a just-created commitment may not be
+    // eligible for the current slot yet, so preferring seasoned commitments
+    // avoids burning the per-slot proposal attempt on fresh ones.
+    std::sort(ret.begin(), ret.end(), [](const DelegatedCommitment& a, const DelegatedCommitment& b) {
+        return a.confirmations > b.confirmations;
+    });
 
     return ret;
 }
@@ -1033,12 +1129,17 @@ void Loop()
             CBlock proposal;
             CAmount nTotalMoney = 0;
             bool found = false;
+            // Which delegation produced the accepted proposal (delegated mode
+            // only); points into `delegations`, which is stable for the rest
+            // of this loop iteration.
+            const DelegatedCommitment* producing = nullptr;
 
             if (fDelegated) {
                 if (Ticks<std::chrono::seconds>(SteadyClock::now() - last_delegation_refresh) >= delegation_refresh_interval) {
                     last_delegation_refresh = SteadyClock::now();
                     delegations = GetDelegatedCommitments(rh);
                     LogPrintf("%s: Tracking %d delegated commitment(s).\n", __func__, (int)delegations.size());
+                    WriteDelegationStats();
                 }
 
                 for (auto& it : delegations) {
@@ -1048,8 +1149,10 @@ void Loop()
                         auto candidate = GetBlockProposal(rh, it.staked, it.rewardAddress);
 
                         found = candidate.has_value();
-                        if (found)
+                        if (found) {
                             proposal = candidate.value();
+                            producing = &it;
+                        }
                     }
                 }
             } else {
@@ -1080,6 +1183,19 @@ void Loop()
                         last_update = SteadyClock::now();
                     }
                     LogPrintf("%s: [%s] Found block %s (%s%s). Current difficulty: %s\n", __func__, walletName, proposal.GetHash().ToString(), result_submit.isNull() ? "ACCEPTED" : "REJECTED: ", result_submit.isNull() ? "" : reply_submit.write(0, 0), currentDifficulty.ToString());
+
+                    if (producing != nullptr) {
+                        auto& stats = delegationStats[producing->outhash];
+                        if (result_submit.isNull()) {
+                            stats.blocksAccepted++;
+                            stats.lastBlockHash = proposal.GetHash().ToString();
+                            stats.lastBlockTime = GetTime();
+                        } else {
+                            stats.blocksRejected++;
+                        }
+                        LogPrintf("%s: Block %s staked with delegation %s (reward address %s): %d block(s) accepted, %d rejected this session.\n", __func__, proposal.GetHash().ToString(), producing->outhash, producing->rewardAddress, (int)stats.blocksAccepted, (int)stats.blocksRejected);
+                        WriteDelegationStats();
+                    }
 
                     auto elapsed = Ticks<std::chrono::minutes>(SteadyClock::now() - start);
 

--- a/src/navio-staker.cpp
+++ b/src/navio-staker.cpp
@@ -840,7 +840,7 @@ static void WriteDelegationStats()
         entry.pushKV("outhash", outhash);
         entry.pushKV("commitment", s.commitment);
         entry.pushKV("reward_address", s.rewardAddress);
-        entry.pushKV("value", s.value);
+        entry.pushKV("value", ValueFromAmount(s.value));
         entry.pushKV("blocks_accepted", s.blocksAccepted);
         entry.pushKV("blocks_rejected", s.blocksRejected);
         if (!s.lastBlockHash.empty()) {
@@ -1139,6 +1139,17 @@ void Loop()
                     last_delegation_refresh = SteadyClock::now();
                     delegations = GetDelegatedCommitments(rh);
                     LogPrintf("%s: Tracking %d delegated commitment(s).\n", __func__, (int)delegations.size());
+                    // Drop stats entries whose delegation is gone from the
+                    // chain and that never produced a block: compounding
+                    // owners re-create their delegated output on every run,
+                    // so without pruning the map (and the stats file) grows
+                    // by one dead entry per compounding round.
+                    std::set<std::string> tracked;
+                    for (const auto& d : delegations)
+                        tracked.insert(d.outhash);
+                    std::erase_if(delegationStats, [&](const auto& item) {
+                        return !tracked.contains(item.first) && item.second.blocksAccepted == 0 && item.second.blocksRejected == 0;
+                    });
                     WriteDelegationStats();
                 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2135,6 +2135,13 @@ static RPCHelpMan liststakedcommitmentsdata()
             // delegated-staking operators typically poll this on an interval;
             // without the cache each of them would pay a full UTXO iteration
             // every few minutes.
+            //
+            // Function-local statics are per-process, not per-chainman: an
+            // in-process embedder running several ChainstateManagers could be
+            // served one manager's scan for the other when tip hashes match.
+            // naviod runs a single chainman, and RPC handlers resolve it from
+            // one NodeContext, so this stays a deliberate simplification; move
+            // the cache onto NodeContext if that ever changes.
             static Mutex cache_mutex;
             static uint256 cache_tip GUARDED_BY(cache_mutex);
             static UniValue cache_result GUARDED_BY(cache_mutex){UniValue::VARR};

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2107,9 +2107,11 @@ static RPCHelpMan liststakedcommitmentsdata()
     return RPCHelpMan{
         "liststakedcommitmentsdata",
         "\nScan the UTXO set and return every unspent staked-commitment output together with\n"
-        "its outpoint and attached predicate data (if any). All returned data is public.\n"
-        "Third-party stakers use this to discover stake delegations addressed to them.\n"
-        "This call iterates the whole UTXO set and may take a while.\n",
+        "its outpoint, creation height and attached predicate data (if any). All returned data\n"
+        "is public. Third-party stakers use this to discover stake delegations addressed to\n"
+        "them. The scan iterates the whole UTXO set and may take a while; its result is cached\n"
+        "per chain tip, so repeated calls at the same tip (e.g. several polling operators) only\n"
+        "pay the scan once.\n",
         {},
         RPCResult{
             RPCResult::Type::ARR,
@@ -2119,6 +2121,8 @@ static RPCHelpMan liststakedcommitmentsdata()
                  {RPCResult::Type::STR_HEX, "commitment", "The staked Pedersen commitment (G1 point)."},
                  {RPCResult::Type::STR_HEX, "outhash", "The hash identifying the staked output."},
                  {RPCResult::Type::STR_HEX, "predicate", "The output's predicate data (empty if none)."},
+                 {RPCResult::Type::NUM, "height", "The height of the block containing the output."},
+                 {RPCResult::Type::NUM, "confirmations", "The number of confirmations of the output."},
              }}},
         },
         RPCExamples{HelpExampleCli("liststakedcommitmentsdata", "") + HelpExampleRpc("liststakedcommitmentsdata", "")},
@@ -2126,10 +2130,28 @@ static RPCHelpMan liststakedcommitmentsdata()
             NodeContext& node = EnsureAnyNodeContext(request.context);
             ChainstateManager& chainman = EnsureChainman(node);
 
+            // The UTXO set only changes when the chain tip does, so one scan
+            // result is valid for every call made at the same tip. Several
+            // delegated-staking operators typically poll this on an interval;
+            // without the cache each of them would pay a full UTXO iteration
+            // every few minutes.
+            static Mutex cache_mutex;
+            static uint256 cache_tip GUARDED_BY(cache_mutex);
+            static UniValue cache_result GUARDED_BY(cache_mutex){UniValue::VARR};
+
+            uint256 tip_hash;
+            int tip_height;
             std::unique_ptr<CCoinsViewCursor> pcursor;
             {
                 LOCK(::cs_main);
                 Chainstate& active_chainstate = chainman.ActiveChainstate();
+                const CBlockIndex* tip = CHECK_NONFATAL(active_chainstate.m_chain.Tip());
+                tip_hash = tip->GetBlockHash();
+                tip_height = tip->nHeight;
+                {
+                    LOCK(cache_mutex);
+                    if (cache_tip == tip_hash) return cache_result;
+                }
                 active_chainstate.ForceFlushStateToDisk();
                 pcursor = CHECK_NONFATAL(active_chainstate.CoinsDB().Cursor());
             }
@@ -2153,10 +2175,18 @@ static RPCHelpMan liststakedcommitmentsdata()
                         entry.pushKV("commitment", HexStr(coin.out.blsctData.rangeProof.Vs[0].GetVch()));
                         entry.pushKV("outhash", key.hash.GetHex());
                         entry.pushKV("predicate", HexStr(coin.out.predicate));
+                        entry.pushKV("height", static_cast<int>(coin.nHeight));
+                        entry.pushKV("confirmations", tip_height - static_cast<int>(coin.nHeight) + 1);
                         result.push_back(entry);
                     }
                 }
                 pcursor->Next();
+            }
+
+            {
+                LOCK(cache_mutex);
+                cache_tip = tip_hash;
+                cache_result = result;
             }
 
             return result;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -68,6 +68,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "delegatestake", 3, "verbose" },
     { "stakeunlock", 0, "amount" },
     { "stakeunlock", 1, "verbose" },
+    { "redelegatestake", 3, "verbose" },
+    { "compounddelegations", 1, "min_amount" },
     { "consolidate", 0, "max_txs" },
     { "consolidate", 1, "max_inputs" },
     { "getreceivedbyaddress", 1, "minconf" },

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <blsct/wallet/rpc.h>
 #include <core_io.h>
 #include <hash.h>
 #include <key_io.h>
@@ -533,6 +534,7 @@ RPCHelpMan getbalances()
                                               {RPCResult::Type::OBJ, "mine", "balances from outputs that the wallet can sign", {
                                                                                                                                    {RPCResult::Type::STR_AMOUNT, "trusted", "trusted balance (outputs created by the wallet or confirmed outputs)"},
                                                                                                                                    {RPCResult::Type::STR_AMOUNT, "staked_commitment_balance", "staked commitment balance with at least one confirmation"},
+                                                                                                                                   {RPCResult::Type::STR_AMOUNT, "delegated_staked_commitment_balance", "portion of staked_commitment_balance whose block production is delegated to a third-party staker"},
                                                                                                                                    {RPCResult::Type::STR_AMOUNT, "pending_staked_commitment_balance", "trusted staked commitment from transactions that are in the mempool only"},
                                                                                                                                    {RPCResult::Type::STR_AMOUNT, "untrusted_pending", "untrusted pending balance (outputs created by others that are in the mempool)"},
                                                                                                                                    {RPCResult::Type::STR_AMOUNT, "immature", "balance from immature coinbase outputs"},
@@ -564,6 +566,7 @@ RPCHelpMan getbalances()
                 UniValue balances_mine{UniValue::VOBJ};
                 balances_mine.pushKV("trusted", ValueFromAmount(bal.m_mine_trusted + blsct_bal.m_mine_trusted));
                 balances_mine.pushKV("staked_commitment_balance", ValueFromAmount(bal.m_mine_staked_commitment + blsct_bal.m_mine_staked_commitment));
+                balances_mine.pushKV("delegated_staked_commitment_balance", ValueFromAmount(blsct::GetDelegatedStakedBalance(wallet)));
                 balances_mine.pushKV("pending_staked_commitment_balance", ValueFromAmount(bal.m_mine_pending_staked_commitment + blsct_bal.m_mine_pending_staked_commitment));
                 balances_mine.pushKV("untrusted_pending", ValueFromAmount(bal.m_mine_untrusted_pending + blsct_bal.m_mine_untrusted_pending));
                 balances_mine.pushKV("immature", ValueFromAmount(bal.m_mine_immature + blsct_bal.m_mine_immature));

--- a/test/functional/blsct_cold_staking.py
+++ b/test/functional/blsct_cold_staking.py
@@ -18,6 +18,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
 )
 
@@ -121,8 +122,8 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         self.log.info("Testing delegatestake and the on-chain payload")
 
         reward_address = owner.getnewaddress(label="rewards", address_type="blsct")
-        txid = owner.delegatestake(self.min_stake, operator_pub, reward_address)
-        assert_equal(len(txid), 64)
+        out_hash = owner.delegatestake(self.min_stake, operator_pub, reward_address)
+        assert_equal(len(out_hash), 64)
         self.generatetoblsctaddress(node, 1, owner_address)
 
         entries = node.liststakedcommitmentsdata()
@@ -139,8 +140,9 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         assert_equal(entry["height"] + entry["confirmations"] - 1, tip_height)
         assert_greater_than(entry["confirmations"], 0)
 
-        # The scan result is cached per tip: a second call at the same tip
-        # must return the identical result (and not pay a second UTXO scan).
+        # Smoke test: a repeated call at the same tip returns the identical
+        # result. (This holds with or without the per-tip cache — the cache
+        # itself is not observable from here.)
         assert_equal(node.liststakedcommitmentsdata(), entries)
 
         # The owner's wallet still tracks it as its own staked commitment.
@@ -168,8 +170,8 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         balances = owner.getbalances()["mine"]
         assert_equal(balances["delegated_staked_commitment_balance"], Decimal(self.min_stake))
         # The delegated stake is part of (not additional to) the staked total.
-        assert_greater_than(balances["staked_commitment_balance"] + 1,
-                            balances["delegated_staked_commitment_balance"])
+        assert_greater_than_or_equal(balances["staked_commitment_balance"],
+                                     balances["delegated_staked_commitment_balance"])
 
     def test_delegated_staker_tracking(self, node, operator_priv):
         self.log.info("Testing that a delegated staker decrypts and tracks the delegation")
@@ -286,8 +288,8 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         # Move the stake delegated to other_operator over to operator_pub,
         # unifying it with the existing delegation (same delegate + reward
         # address). The commitments never leave the staking set.
-        txid = owner.redelegatestake(other_operator_pub, operator_pub, reward_address)
-        assert_equal(len(txid), 64)
+        out_hash = owner.redelegatestake(other_operator_pub, operator_pub, reward_address)
+        assert_equal(len(out_hash), 64)
         self.generatetoblsctaddress(node, 1, owner_address)
 
         delegations = owner.listdelegations()
@@ -313,8 +315,8 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         # Below min_amount: nothing to do.
         assert_equal(owner.compounddelegations(operator_pub, spendable + 100), None)
 
-        txid = owner.compounddelegations()
-        assert_equal(len(txid), 64)
+        out_hash = owner.compounddelegations()
+        assert_equal(len(out_hash), 64)
         self.generatetoblsctaddress(node, 1, owner_address)
 
         delegations = owner.listdelegations()
@@ -427,8 +429,8 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         # Unstake everything: delegated or not, the spend key revokes it all,
         # and the staked set ends up empty.
         staked = owner.getbalances()["mine"]["staked_commitment_balance"]
-        txid = owner.stakeunlock(staked)
-        assert_equal(len(txid), 64)
+        out_hash = owner.stakeunlock(staked)
+        assert_equal(len(out_hash), 64)
         self.generatetoblsctaddress(node, 1, owner_address)
 
         assert_equal(node.liststakedcommitmentsdata(), [])

--- a/test/functional/blsct_cold_staking.py
+++ b/test/functional/blsct_cold_staking.py
@@ -362,6 +362,7 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
 
         height_before = node.getblockcount()
         rewards_before = owner.listdelegations()[0]["rewards_received"]
+        self.e2e_reward_address = reward_address
 
         staker = self.spawn_staker([f"-delegationkey={operator_priv}",
                                     "-operatorfee=1000",
@@ -407,6 +408,19 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         operator_total = operator_balances["immature"] + operator_balances["trusted"] + operator_balances["untrusted_pending"]
         assert_greater_than(operator_total, 0)
 
+        # liststakingrewards tracks both kinds of staking rewards: the
+        # delegated ones (reward address of an active delegation) and the
+        # wallet's own, non-delegated coinbase rewards.
+        rewards = {r["address"]: r for r in owner.liststakingrewards()}
+        delegated_rewards = rewards[reward_address]
+        assert_equal(delegated_rewards["from_delegation"], True)
+        assert_greater_than(delegated_rewards["amount"], 0)
+        assert_greater_than(delegated_rewards["last_height"], height_before)
+        own_rewards = [r for r in rewards.values() if not r["from_delegation"]]
+        assert_greater_than(len(own_rewards), 0)
+        assert_greater_than(own_rewards[0]["amount"], 0)
+        assert_greater_than(own_rewards[0]["count"], 0)
+
     def test_revocation(self, node, owner, owner_address, operator_pub):
         self.log.info("Testing revocation via stakeunlock")
 
@@ -426,6 +440,17 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         owner.delegatestake(self.min_stake, operator_pub)
         self.generatetoblsctaddress(node, 1, owner_address)
         assert_equal(len(owner.listdelegations()), 1)
+
+        # Reward history survives revocation: the rewards earned under the
+        # old (now revoked) delegation are still listed, no longer tied to an
+        # active delegation. The new delegation uses a fresh reward address,
+        # so the old address must not be flagged.
+        new_reward_address = owner.listdelegations()[0]["reward_address"]
+        rewards = {r["address"]: r for r in owner.liststakingrewards()}
+        assert self.e2e_reward_address in rewards
+        assert new_reward_address != self.e2e_reward_address
+        assert_equal(rewards[self.e2e_reward_address]["from_delegation"], False)
+        assert_greater_than(rewards[self.e2e_reward_address]["amount"], 0)
 
 
 if __name__ == "__main__":

--- a/test/functional/blsct_cold_staking.py
+++ b/test/functional/blsct_cold_staking.py
@@ -4,14 +4,20 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 """Test delegated cold staking: delegatestake RPC, on-chain delegation payload,
-liststakedcommitmentsdata scan, fee-split block templates and revocation."""
+liststakedcommitmentsdata scan, owner-side visibility (listdelegations,
+delegated balances), redelegation, reward compounding, fee-split block
+templates, end-to-end delegated block production and revocation."""
 
+import json
 import os.path
 import subprocess
+
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 
@@ -49,6 +55,32 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         assert priv and pub, f"unexpected -gendelegationkey output: {out}"
         return priv, pub
 
+    def spawn_staker(self, extra_args):
+        args = [
+            self.staker_path(),
+            f"-datadir={self.nodes[0].datadir_path}",
+            "-delegated",
+            "-delegationrefresh=1",
+            "-rpcwait",
+            "-printtoconsole=1",
+            "-nodebuglogfile",
+        ] + extra_args
+        return subprocess.Popen(args, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True)
+
+    def wait_for_staker_line(self, staker, needles, max_lines=600):
+        """Read staker stdout until a line containing any needle appears.
+        Returns the matching needle or None."""
+        for _ in range(max_lines):
+            line = staker.stdout.readline()
+            if not line:
+                return None
+            self.log.debug(f"staker: {line.rstrip()}")
+            for needle in needles:
+                if needle in line:
+                    return needle
+        return None
+
     def run_test(self):
         node = self.nodes[0]
         self.min_stake = 100
@@ -63,10 +95,15 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
 
         self.test_argument_validation(owner, operator_pub)
         outhash, reward_address = self.test_delegatestake(node, owner, owner_address, operator_pub)
+        self.test_owner_visibility(node, owner, operator_pub, reward_address)
         self.test_delegated_staker_tracking(node, operator_priv)
-        self.test_consolidation_grouping(node, owner, owner_address, operator_pub, reward_address)
+        self.test_wrong_key_sees_nothing(node)
+        other_operator_pub = self.test_consolidation_grouping(node, owner, owner_address, operator_pub, reward_address)
+        self.test_redelegation(node, owner, owner_address, operator_pub, other_operator_pub, reward_address)
+        self.test_compounding(node, owner, owner_address, operator_pub, reward_address)
         self.test_fee_split_template(node, owner)
-        self.test_revocation(node, owner, owner_address)
+        self.test_delegated_block_production(node, owner, operator_priv, reward_address)
+        self.test_revocation(node, owner, owner_address, operator_pub)
 
     def test_argument_validation(self, owner, operator_pub):
         self.log.info("Testing delegatestake argument validation")
@@ -97,6 +134,15 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         assert DELEGATION_MAGIC_HEX in entry["predicate"], entry["predicate"]
         assert_equal(len(entry["commitment"]), 96)  # compressed G1 point
 
+        # Height/confirmations let an operator judge output maturity.
+        tip_height = node.getblockcount()
+        assert_equal(entry["height"] + entry["confirmations"] - 1, tip_height)
+        assert_greater_than(entry["confirmations"], 0)
+
+        # The scan result is cached per tip: a second call at the same tip
+        # must return the identical result (and not pay a second UTXO scan).
+        assert_equal(node.liststakedcommitmentsdata(), entries)
+
         # The owner's wallet still tracks it as its own staked commitment.
         own = owner.liststakedcommitments()
         assert_equal(len(own), 1)
@@ -104,34 +150,71 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
 
         return entry["outhash"], reward_address
 
+    def test_owner_visibility(self, node, owner, operator_pub, reward_address):
+        self.log.info("Testing listdelegations and delegated balance reporting")
+
+        delegations = owner.listdelegations()
+        assert_equal(len(delegations), 1)
+        d = delegations[0]
+        assert_equal(d["amount"], Decimal(self.min_stake))
+        assert_equal(d["delegate_pubkey"], operator_pub)
+        assert_equal(d["reward_address"], reward_address)
+        assert_equal(d["reward_address_is_mine"], True)
+        assert_greater_than(d["confirmations"], 0)
+        # No delegated block has been produced yet.
+        assert_equal(d["rewards_received"], 0)
+        assert_equal(d["rewards_count"], 0)
+
+        balances = owner.getbalances()["mine"]
+        assert_equal(balances["delegated_staked_commitment_balance"], Decimal(self.min_stake))
+        # The delegated stake is part of (not additional to) the staked total.
+        assert_greater_than(balances["staked_commitment_balance"] + 1,
+                            balances["delegated_staked_commitment_balance"])
+
     def test_delegated_staker_tracking(self, node, operator_priv):
         self.log.info("Testing that a delegated staker decrypts and tracks the delegation")
 
-        # No -chain argument: the node's navio.conf inside datadir already
-        # selects blsctregtest, and the staker rejects setting both.
-        args = [
-            self.staker_path(),
-            f"-datadir={self.nodes[0].datadir_path}",
-            "-delegated",
-            f"-delegationkey={operator_priv}",
-            "-delegationrefresh=1",
-            "-rpcwait",
-            "-printtoconsole=1",
-            "-nodebuglogfile",
-        ]
-        staker = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT, text=True)
+        # Pass the key via -delegationkeyfile (the recommended way: a key on
+        # the command line is visible in the process list) and request a
+        # stats file.
+        keyfile = os.path.join(self.options.tmpdir, "delegation.key")
+        with open(keyfile, "w", encoding="utf8") as f:
+            f.write(operator_priv + "\n")
+        self.statsfile = os.path.join(self.options.tmpdir, "delegation-stats.json")
+
+        staker = self.spawn_staker([f"-delegationkeyfile={keyfile}",
+                                    f"-statsfile={self.statsfile}"])
         try:
-            tracked = False
-            for _ in range(600):
-                line = staker.stdout.readline()
-                if not line:
-                    break
-                self.log.debug(f"staker: {line.rstrip()}")
-                if "Tracking 1 delegated commitment(s)" in line:
-                    tracked = True
-                    break
-            assert tracked, "delegated staker did not report the delegation"
+            found = self.wait_for_staker_line(staker, ["Tracking 1 delegated commitment(s)"])
+            assert found, "delegated staker did not report the delegation"
+            # The stats file is written right after the "Tracking" log line;
+            # don't race the kill against it.
+            self.wait_until(lambda: os.path.exists(self.statsfile))
+        finally:
+            staker.kill()
+            staker.wait()
+
+        # The stats file was written on the delegation refresh and lists the
+        # delegation with no blocks yet.
+        with open(self.statsfile, encoding="utf8") as f:
+            stats = json.load(f)
+        assert_equal(len(stats["delegations"]), 1)
+        assert_equal(stats["delegations"][0]["blocks_accepted"], 0)
+
+        # Both key sources must not be combined.
+        proc = subprocess.run([self.staker_path(), f"-datadir={self.nodes[0].datadir_path}",
+                               "-delegated", "-delegationkey=00", f"-delegationkeyfile={keyfile}"],
+                              capture_output=True, text=True)
+        assert proc.returncode != 0
+        assert "mutually exclusive" in proc.stderr + proc.stdout
+
+    def test_wrong_key_sees_nothing(self, node):
+        self.log.info("Testing that an operator with a different key sees no delegations")
+        wrong_priv, _ = self.gen_delegation_key()
+        staker = self.spawn_staker([f"-delegationkey={wrong_priv}"])
+        try:
+            found = self.wait_for_staker_line(staker, ["Tracking 0 delegated commitment(s)"])
+            assert found, "staker with an unrelated key should track zero delegations"
         finally:
             staker.kill()
             staker.wait()
@@ -189,6 +272,59 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
         # + 1 other-delegation).
         own = owner.liststakedcommitments()
         assert_equal(len(own), 3)
+        assert_equal(len(owner.listdelegations()), 2)
+
+        return other_operator_pub
+
+    def test_redelegation(self, node, owner, owner_address, operator_pub, other_operator_pub, reward_address):
+        self.log.info("Testing redelegatestake (operator swap in one transaction)")
+
+        _, unused_pub = self.gen_delegation_key()
+        assert_raises_rpc_error(-8, "No stakes are delegated to from_delegate_pubkey",
+                                owner.redelegatestake, unused_pub, operator_pub)
+
+        # Move the stake delegated to other_operator over to operator_pub,
+        # unifying it with the existing delegation (same delegate + reward
+        # address). The commitments never leave the staking set.
+        txid = owner.redelegatestake(other_operator_pub, operator_pub, reward_address)
+        assert_equal(len(txid), 64)
+        self.generatetoblsctaddress(node, 1, owner_address)
+
+        delegations = owner.listdelegations()
+        assert_equal(len(delegations), 1)
+        assert_equal(delegations[0]["delegate_pubkey"], operator_pub)
+        assert_equal(delegations[0]["reward_address"], reward_address)
+        # 2 x min_stake previously under operator_pub + 1 x min_stake moved.
+        assert_equal(delegations[0]["amount"], Decimal(3 * self.min_stake))
+
+        # The plain stake was not folded into the redelegation.
+        entries = node.liststakedcommitmentsdata()
+        plain = [e for e in entries if not e["predicate"]]
+        delegated = [e for e in entries if e["predicate"]]
+        assert_equal((len(plain), len(delegated)), (1, 1))
+
+    def test_compounding(self, node, owner, owner_address, operator_pub, reward_address):
+        self.log.info("Testing compounddelegations")
+
+        before = owner.listdelegations()[0]["amount"]
+        spendable = owner.getbalances()["mine"]["trusted"]
+        assert_greater_than(spendable, 2)
+
+        # Below min_amount: nothing to do.
+        assert_equal(owner.compounddelegations(operator_pub, spendable + 100), None)
+
+        txid = owner.compounddelegations()
+        assert_equal(len(txid), 64)
+        self.generatetoblsctaddress(node, 1, owner_address)
+
+        delegations = owner.listdelegations()
+        assert_equal(len(delegations), 1)
+        assert_greater_than(delegations[0]["amount"], before)
+        assert_equal(delegations[0]["delegate_pubkey"], operator_pub)
+        assert_equal(delegations[0]["reward_address"], reward_address)
+
+        balances = owner.getbalances()["mine"]
+        assert_equal(balances["delegated_staked_commitment_balance"], delegations[0]["amount"])
 
     def test_fee_split_template(self, node, owner):
         self.log.info("Testing getblocktemplate operator fee split parameters")
@@ -214,17 +350,82 @@ class NavioBlsctColdStakingTest(BitcoinTestFramework):
                                 {"rules": [""], "coinbasedest": owner_addr,
                                  "coinbasefeedest": operator_addr})
 
-    def test_revocation(self, node, owner, owner_address):
+    def test_delegated_block_production(self, node, owner, operator_priv, reward_address):
+        """End to end: a wallet-less operator staker produces an accepted
+        block with the delegated stake; the reward lands at the owner's reward
+        address and the operator fee output at the operator's address."""
+        self.log.info("Testing end-to-end delegated block production with an operator fee")
+
+        node.createwallet(wallet_name="operator", blsct=True)
+        operator_wallet = node.get_wallet_rpc("operator")
+        operator_addr = operator_wallet.getnewaddress(label="", address_type="blsct")
+
+        height_before = node.getblockcount()
+        rewards_before = owner.listdelegations()[0]["rewards_received"]
+
+        staker = self.spawn_staker([f"-delegationkey={operator_priv}",
+                                    "-operatorfee=1000",
+                                    f"-operatoraddress={operator_addr}",
+                                    f"-statsfile={self.statsfile}"])
+
+        def stats_show_block():
+            try:
+                with open(self.statsfile, encoding="utf8") as f:
+                    stats = json.load(f)
+                return stats["delegations"][0]["blocks_accepted"] > 0
+            except (FileNotFoundError, json.JSONDecodeError, KeyError, IndexError):
+                return False
+
+        try:
+            found = self.wait_for_staker_line(staker, ["(ACCEPTED)"], max_lines=3000)
+            assert found, "delegated staker did not produce an accepted block"
+            # The stats file is updated right after the acceptance log line;
+            # don't race the kill against it.
+            self.wait_until(stats_show_block)
+        finally:
+            staker.kill()
+            staker.wait()
+
+        self.wait_until(lambda: node.getblockcount() > height_before)
+
+        # The per-delegation accounting recorded the produced block.
+        with open(self.statsfile, encoding="utf8") as f:
+            stats = json.load(f)
+        assert_equal(len(stats["delegations"]), 1)
+        assert_greater_than(stats["delegations"][0]["blocks_accepted"], 0)
+        assert stats["delegations"][0]["last_block_hash"]
+
+        # 90% of the reward went to the owner's reward address...
+        owner.keypoolrefill()
+        deleg = owner.listdelegations()[0]
+        assert_greater_than(deleg["rewards_received"], rewards_before)
+        assert_greater_than(deleg["rewards_count"], 0)
+
+        # ...and the 10% operator fee arrived at the operator's own wallet
+        # (as an immature coinbase output).
+        operator_balances = operator_wallet.getbalances()["mine"]
+        operator_total = operator_balances["immature"] + operator_balances["trusted"] + operator_balances["untrusted_pending"]
+        assert_greater_than(operator_total, 0)
+
+    def test_revocation(self, node, owner, owner_address, operator_pub):
         self.log.info("Testing revocation via stakeunlock")
 
-        # Unstake everything (2 plain + 2 same-delegation + 1 other-delegation
-        # commitments of min_stake each): delegated or not, the spend key
-        # revokes it all, and the staked set ends up empty.
-        txid = owner.stakeunlock(5 * self.min_stake)
+        # Unstake everything: delegated or not, the spend key revokes it all,
+        # and the staked set ends up empty.
+        staked = owner.getbalances()["mine"]["staked_commitment_balance"]
+        txid = owner.stakeunlock(staked)
         assert_equal(len(txid), 64)
         self.generatetoblsctaddress(node, 1, owner_address)
 
         assert_equal(node.liststakedcommitmentsdata(), [])
+        assert_equal(owner.listdelegations(), [])
+        assert_equal(owner.getbalances()["mine"]["delegated_staked_commitment_balance"], 0)
+
+        # Delegating again after a revocation works: the delegation died with
+        # the commitment, not with the wallet or the operator key.
+        owner.delegatestake(self.min_stake, operator_pub)
+        self.generatetoblsctaddress(node, 1, owner_address)
+        assert_equal(len(owner.listdelegations()), 1)
 
 
 if __name__ == "__main__":

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -175,6 +175,7 @@ class WalletTest(BitcoinTestFramework):
             # getbalances
             expected_balances_0 = {'mine':      {'immature':          Decimal('0E-8'),
                                                  'staked_commitment_balance': Decimal('0E-8'),
+                                                 'delegated_staked_commitment_balance': Decimal('0E-8'),
                                                  'pending_staked_commitment_balance': Decimal('0E-8'),
                                                  'trusted':           Decimal('9.99'),  # change from node 0's send
                                                  'untrusted_pending': Decimal('60.0')},
@@ -183,6 +184,7 @@ class WalletTest(BitcoinTestFramework):
                                                  'untrusted_pending': Decimal('0E-8')}}
             expected_balances_1 = {'mine':      {'immature':          Decimal('0E-8'),
                                                  'staked_commitment_balance': Decimal('0E-8'),
+                                                 'delegated_staked_commitment_balance': Decimal('0E-8'),
                                                  'pending_staked_commitment_balance': Decimal('0E-8'),
                                                  'trusted':           Decimal('0E-8'),  # node 1's send had an unsafe input
                                                  'untrusted_pending': Decimal('30.0') - fee_node_1}}  # Doesn't include output of node 0's send since it was spent

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -56,6 +56,7 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalances()["mine"], {
           "trusted": 10,
           'staked_commitment_balance': 0,
+          'delegated_staked_commitment_balance': 0,
           'pending_staked_commitment_balance': 0,
           "untrusted_pending": 0,
           "immature": 0,


### PR DESCRIPTION
## Summary

Follow-up to #304, addressing the usability gaps around delegated cold staking. No consensus changes.

### Owner-side visibility
- **`listdelegations` wallet RPC** — recovers every active delegation (delegate key, reward address, amount, confirmations) from the on-chain payloads' owner sections; needs no wallet metadata and survives a restore from seed. When the reward address belongs to the wallet, it also sums the coinbase rewards received on it — the "is my operator honoring the reward address" audit the doc previously asked owners to do by hand.
- **`getbalances`** now reports `delegated_staked_commitment_balance`, the delegated portion of the staked balance.
- **`liststakingrewards` wallet RPC** — the wallet's coinbase rewards grouped by receiving address (total, count, last reward height), flagging addresses that belong to an active delegation — so delegated *and* own (non-delegated) staking rewards are tracked in one place.

### Delegation lifecycle
- **`redelegatestake from_delegate_pubkey delegate_pubkey [reward_address]`** — moves delegations to a new operator and/or reward address in a single transaction. The delegated commitments are spent directly into a new staked output carrying the new payload (`CreateTransactionData::redelegateFromIds`), so the stake never leaves the staking set — no unlock/re-lock gap, no loss of stake continuity.
- **`compounddelegations [delegate_pubkey] [min_amount]`** — folds the wallet's spendable balance (minus a fee margin) into an existing delegation. Auto-compounding is impossible by design (spend key offline), so this is the cron-friendly convenience path.

### Operator scaling / UX
- **`liststakedcommitmentsdata`** results are cached per chain tip — several polling operators now cost one UTXO iteration per block instead of one per call — and each entry carries `height` and `confirmations`.
- **`navio-staker -delegationkeyfile=<path>`** — reads the operator key from a file instead of the command line (where it is visible in `ps`). Mutually exclusive with `-delegationkey`.
- **Per-delegation accounting** — the delegated staker tracks which delegations produced which blocks (accepted/rejected, last block hash/time, reward address), logs it on every produced block and dumps it as JSON to `-statsfile`.
- Delegations are tried most-confirmed-first each slot, so fresh commitments do not burn the proposal attempt while seasoned ones are available.

Not included: zmq push notifications for new delegations — the per-tip cache makes the existing polling effectively free, so the extra surface did not seem warranted yet.

### Tests
- End-to-end block production: a wallet-less operator staker produces an ACCEPTED block on regtest with `-operatorfee=1000`; the test verifies the reward lands at the owner's reward address (`listdelegations` reward tracking goes positive), the 10% fee output arrives at the operator's own wallet, and the stats file records the block.
- Negative coverage: an operator with an unrelated key tracks zero delegations; `redelegatestake` from a key with no delegations errors; delegating again after a full revocation works.
- `wallet_balance.py` expectations updated for the new balance field; `rpc_help` green.

## Testing

- Unit: `delegation_tests` green.
- Functional: `blsct_cold_staking` (extended, 37s), `blsct_staking`, `blsct_stake_no_consolidate`, `blsct_listtransactions_stake`, `rpc_help`, `wallet_balance` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
