### PR TITLE
wallet: return the recipient output hash from BLSCT sends

### DIFF
--- a/src/blsct/external_api/blsct.cpp
+++ b/src/blsct/external_api/blsct.cpp
@@ -787,7 +787,7 @@ BlsctCTxRetVal* build_ctx(
 
     // move the ctx to newly created ctx in heap
     CMutableTransaction* ctx_in_heap = new (std::nothrow) CMutableTransaction;
-    *ctx_in_heap = std::move(maybe_ctx.value());
+    *ctx_in_heap = std::move(maybe_ctx->tx);
 
     rv->result = BLSCT_SUCCESS;
     rv->ctx = static_cast<void*>(ctx_in_heap);

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -114,13 +114,15 @@ UniValue SendTransaction(wallet::CWallet& wallet, const blsct::CreateTransaction
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Not enough funds available");
     }
 
-    const CTransactionRef& tx = MakeTransactionRef(res.value());
+    const CTransactionRef& tx = MakeTransactionRef(res->tx);
 
     // Store any wallet-local comment/comment_to on the sender's CWalletTx so
     // listtransactions surfaces them (WalletTxToJSON emits every mapValue key).
     // This is separate from the on-chain BLSCT memo, which the recipient sees.
     wallet.CommitTransaction(tx, std::move(mapValue), /*orderForm=*/{});
-    std::string outputHash = tx->vout[0].GetHash().GetHex();
+    // The factory reports which output pays the destination: vout is shuffled
+    // for privacy, so the recipient is not at any fixed position.
+    std::string outputHash = res->recipientOutputHash.GetHex();
     if (verbose) {
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("outputHash", outputHash);
@@ -1362,7 +1364,7 @@ RPCHelpMan consolidate()
                 auto res = blsct::TxFactory::CreateConsolidationTransaction(pwallet.get(), blsct_km, dest, max_inputs, fee_rate);
                 if (!res) break; // fewer than two small outputs remain to merge
 
-                const CTransactionRef tx = MakeTransactionRef(res.value());
+                const CTransactionRef tx = MakeTransactionRef(res->tx);
                 wallet::mapValue_t map_value;
                 pwallet->CommitTransaction(tx, std::move(map_value), /*orderForm=*/{});
                 txids.push_back(tx->GetHash().GetHex());

--- a/src/blsct/wallet/txfactory.cpp
+++ b/src/blsct/wallet/txfactory.cpp
@@ -102,7 +102,7 @@ bool TxFactory::AddInput(wallet::CWallet* wallet, const COutPoint& outpoint, con
     return true;
 }
 
-std::optional<CMutableTransaction>
+std::optional<BuiltTransaction>
 TxFactory::BuildTx()
 {
     return TxFactoryBase::BuildTx(
@@ -113,7 +113,7 @@ TxFactory::BuildTx()
         Params().GetConsensus().nBLSCTDefaultFee);
 }
 
-std::optional<CMutableTransaction> TxFactory::CreateTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, CreateTransactionData transactionData)
+std::optional<BuiltTransaction> TxFactory::CreateTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, CreateTransactionData transactionData)
 {
     LOCK(wallet->cs_wallet);
 
@@ -294,7 +294,7 @@ void TxFactory::AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_
     }
 }
 
-std::optional<CMutableTransaction> TxFactory::CreateConsolidationTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const blsct::DoublePublicKey& destination, const size_t& maxInputs, const CAmount& nBLSCTDefaultFee)
+std::optional<BuiltTransaction> TxFactory::CreateConsolidationTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const blsct::DoublePublicKey& destination, const size_t& maxInputs, const CAmount& nBLSCTDefaultFee)
 {
     AssertLockHeld(wallet->cs_wallet);
 

--- a/src/blsct/wallet/txfactory.h
+++ b/src/blsct/wallet/txfactory.h
@@ -29,14 +29,14 @@ public:
 
     bool AddInput(wallet::CWallet* wallet, const COutPoint& outpoint, const bool& stakedCommitment = false, const bool& rbf = false) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
     bool AddInput(const CCoinsViewCache& cache, const COutPoint& outpoint, const bool& stakedCommitment = false, const bool& rbf = false);
-    std::optional<CMutableTransaction> BuildTx();
-    static std::optional<CMutableTransaction> CreateTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, CreateTransactionData transactionData);
+    std::optional<BuiltTransaction> BuildTx();
+    static std::optional<BuiltTransaction> CreateTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, CreateTransactionData transactionData);
     // Build one transaction that merges up to `maxInputs` of the wallet's
     // smallest spendable outputs into a single output paid to `destination`
     // (fee taken from the consolidated amount). Returns std::nullopt when there
     // are fewer than two small outputs to merge. Used by the `consolidate` RPC
     // and the staker's optional auto-consolidation.
-    static std::optional<CMutableTransaction> CreateConsolidationTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const blsct::DoublePublicKey& destination, const size_t& maxInputs, const CAmount& nBLSCTDefaultFee) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
+    static std::optional<BuiltTransaction> CreateConsolidationTransaction(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const blsct::DoublePublicKey& destination, const size_t& maxInputs, const CAmount& nBLSCTDefaultFee) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
     static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const wallet::CoinFilterParams& coins_params, std::vector<InputCandidates>& inputCandidates, const CAmount& nAmountLimit) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
     static void AddAvailableCoins(wallet::CWallet* wallet, blsct::KeyMan* blsct_km, const TokenId& token_id, const CreateTransactionType& type, std::vector<InputCandidates>& inputCandidates, const CAmount& nAmountLimit, const bool& consolidateStakedCommitments = true) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
 };

--- a/src/blsct/wallet/txfactory_base.cpp
+++ b/src/blsct/wallet/txfactory_base.cpp
@@ -107,7 +107,7 @@ void TxFactoryBase::AddOutput(const Scalar& tokenKey, const SubAddress& destinat
     vOutputs[token_id].push_back(out);
 }
 
-std::optional<CMutableTransaction>
+std::optional<BuiltTransaction>
 TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CAmount& minStake, const CreateTransactionType& type, const bool& fSubtractedFee, const CAmount& nBLSCTDefaultFee)
 {
     this->tx = CMutableTransaction();
@@ -236,6 +236,7 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
 
             mapChange[amounts.first] = nFromInputs - amounts.second.nFromOutputs - tokenFee;
         }
+        std::optional<uint256> firstChangeOutputHash;
         for (auto& change : mapChange) {
             if (change.second == 0) continue;
 
@@ -252,11 +253,34 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
 
             tx.vout.push_back(changeOutput.out);
             txSigs.push_back(PrivateKey(changeOutput.blindingKey).Sign(changeOutput.out.GetHash()));
+
+            if (!firstChangeOutputHash) firstChangeOutputHash = changeOutput.out.GetHash();
         }
         if (sffaOut) {
             tx.vout.push_back(sffaOut->out);
             txSigs.push_back(PrivateKey(sffaOut->blindingKey).Sign(sffaOut->out.GetHash()));
         }
+
+        // Which output pays the destination this transaction was built for.
+        // The vout order is randomised on the way out, so record it here while
+        // the build order is still known:
+        //  - a subtract-fee-from-amount send pays through sffaOut, which is
+        //    appended after the change output rather than first;
+        //  - otherwise it is the first output AddOutput queued, i.e. what
+        //    pre-shuffle vout[0] used to be;
+        //  - a full unstake queues no output at all -- the unlocked funds come
+        //    back as the "Stake Unlock" change output -- so fall back to the
+        //    first change output of this pass.
+        // The fee output is appended after all three and is never a candidate.
+        std::optional<uint256> recipientOutputHash;
+        if (sffaOut) {
+            recipientOutputHash = sffaOut->out.GetHash();
+        } else if (!this->tx.vout.empty()) {
+            recipientOutputHash = this->tx.vout[0].GetHash();
+        } else {
+            recipientOutputHash = firstChangeOutputHash;
+        }
+
         CTxOut fee_out{nAmounts[TokenId()].nFromFee, CScript(OP_RETURN)};
 
         auto feeKey = blsct::PrivateKey(MclScalar::Rand());
@@ -270,6 +294,11 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
 
         const CAmount required_fee = GetTransactionWeight(CTransaction(tx)) * nBLSCTDefaultFee;
         if (nAmounts[TokenId()].nFromFee == required_fee) {
+            // Every output was consumed by the fee, so there is no output to
+            // hand back as the payment. Nothing builds that shape today; fail
+            // rather than return a handle that points at the fee output.
+            if (!recipientOutputHash) return std::nullopt;
+
             // Randomise input and output ordering so the on-chain transaction
             // does not leak the wallet's coin-selection order (e.g. that earlier
             // inputs correspond to larger outputs, or the change position). The
@@ -282,7 +311,7 @@ TxFactoryBase::BuildTx(const blsct::DoublePublicKey& changeDestination, const CA
             std::mt19937_64 rng(seed);
             std::shuffle(tx.vin.begin(), tx.vin.end(), rng);
             std::shuffle(tx.vout.begin(), tx.vout.end(), rng);
-            return tx;
+            return BuiltTransaction{tx, *recipientOutputHash};
         }
         nAmounts[TokenId()].nFromFee = required_fee;
     }
@@ -305,7 +334,7 @@ bool TxFactoryBase::AddInput(const CAmount& amount, const MclScalar& gamma, cons
     return true;
 }
 
-std::optional<CMutableTransaction> TxFactoryBase::CreateTransaction(const std::vector<InputCandidates>& inputCandidates, const CreateTransactionData& transactionData)
+std::optional<BuiltTransaction> TxFactoryBase::CreateTransaction(const std::vector<InputCandidates>& inputCandidates, const CreateTransactionData& transactionData)
 {
     auto tx = blsct::TxFactoryBase();
 

--- a/src/blsct/wallet/txfactory_base.h
+++ b/src/blsct/wallet/txfactory_base.h
@@ -109,6 +109,15 @@ struct CreateTransactionData {
     CreateTransactionData(const blsct::TokenInfo& tokenInfo, const uint64_t& nftId, const SubAddress& destination, const std::map<std::string, std::string>& nftMetadata) : type(TX_MINT_TOKEN), tokenInfo(tokenInfo), destination(destination), token_id(TokenId(tokenInfo.publicKey.GetHash(), nftId)), nftMetadata(nftMetadata) {}
 };
 
+// A transaction built by the factory together with the hash of the output that
+// pays the destination it was built for. BuildTx randomises output order before
+// returning, so the recipient cannot be recovered positionally by the caller;
+// it is recorded here while the build order is still known.
+struct BuiltTransaction {
+    CMutableTransaction tx;
+    uint256 recipientOutputHash;
+};
+
 struct InputCandidates {
     CAmount amount;
     MclScalar gamma;
@@ -163,8 +172,8 @@ public:
     // Mint NFT
     void AddOutput(const Scalar& tokenKey, const SubAddress& destination, const blsct::PublicKey& tokenPublicKey, const uint64_t& nftId, const std::map<std::string, std::string>& nftMetadata);
     bool AddInput(const CAmount& amount, const MclScalar& gamma, const blsct::PrivateKey& spendingKey, const TokenId& token_id, const COutPoint& outpoint, const bool& stakedCommitment = false, const bool& rbf = false);
-    std::optional<CMutableTransaction> BuildTx(const blsct::DoublePublicKey& changeDestination, const CAmount& minStake = 0, const CreateTransactionType& type = NORMAL, const bool& fSubtractedFee = false, const CAmount& nBLSCTDefaultFee = ::BLSCT_DEFAULT_FEE);
-    static std::optional<CMutableTransaction> CreateTransaction(const std::vector<InputCandidates>& inputCandidates, const CreateTransactionData& transactionData);
+    std::optional<BuiltTransaction> BuildTx(const blsct::DoublePublicKey& changeDestination, const CAmount& minStake = 0, const CreateTransactionType& type = NORMAL, const bool& fSubtractedFee = false, const CAmount& nBLSCTDefaultFee = ::BLSCT_DEFAULT_FEE);
+    static std::optional<BuiltTransaction> CreateTransaction(const std::vector<InputCandidates>& inputCandidates, const CreateTransactionData& transactionData);
 };
 
 } // namespace blsct

--- a/src/test/blsct/wallet/chain_tests.cpp
+++ b/src/test/blsct/wallet/chain_tests.cpp
@@ -48,7 +48,7 @@ BOOST_FIXTURE_TEST_CASE(SyncTest, TestBLSCTChain100Setup)
 
     BOOST_CHECK(tx != std::nullopt);
 
-    auto block = CreateAndProcessBlock({tx.value()}, walletDestination);
+    auto block = CreateAndProcessBlock({tx->tx}, walletDestination);
 
     BOOST_CHECK(SyncBLSCTWallet(wallet, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain())));
 

--- a/src/test/blsct/wallet/txfactory_tests.cpp
+++ b/src/test/blsct/wallet/txfactory_tests.cpp
@@ -23,6 +23,14 @@ static CAmount GetFeeValue(const CTransaction& tx)
     return 0;
 }
 
+static std::optional<size_t> FindOutputIndex(const CMutableTransaction& tx, const uint256& outputHash)
+{
+    for (size_t i = 0; i < tx.vout.size(); ++i) {
+        if (tx.vout[i].GetHash() == outputHash) return i;
+    }
+    return std::nullopt;
+}
+
 BOOST_FIXTURE_TEST_CASE(ismine_test, TestingSetup)
 {
     auto wallet = std::make_unique<wallet::CWallet>(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase());
@@ -91,8 +99,8 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_test, TestingSetup)
     auto finalTx = tx.BuildTx();
 
     BOOST_CHECK(finalTx.has_value());
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
-    const CAmount fee = GetFeeValue(CTransaction(finalTx.value()));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
+    const CAmount fee = GetFeeValue(CTransaction(finalTx->tx));
     const CAmount expected_change = 1000 * COIN - 900 * COIN - fee;
     BOOST_REQUIRE(fee > 0);
 
@@ -101,7 +109,7 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_test, TestingSetup)
     // Wallet does not have the coins available yet
     BOOST_CHECK(blsct::TxFactory::CreateTransaction(wallet, wallet->GetOrCreateBLSCTKeyMan(), blsct::CreateTransactionData{recvAddress, 900 * COIN, "test"}) == std::nullopt);
 
-    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
 
     for (auto& res : result.amounts) {
         if (res.message == "Change" && res.amount == expected_change) fFoundChange = true;
@@ -109,7 +117,7 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_test, TestingSetup)
 
     BOOST_CHECK(fFoundChange);
 
-    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx.value()));
+    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx->tx));
 
     // Wallet does not have the coins available yet (not confirmed in block)
     BOOST_CHECK(blsct::TxFactory::CreateTransaction(wallet, wallet->GetOrCreateBLSCTKeyMan(), blsct::CreateTransactionData{recvAddress, 900 * COIN, "test"}) == std::nullopt);
@@ -156,9 +164,9 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_test, TestingSetup)
     auto finalTx = tx.BuildTx();
 
     BOOST_REQUIRE(finalTx.has_value());
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
 
-    const CAmount fee = GetFeeValue(CTransaction(finalTx.value()));
+    const CAmount fee = GetFeeValue(CTransaction(finalTx->tx));
     BOOST_REQUIRE(fee > 0);
 
     // subtract-fee semantics: the recipient bears the fee (receives
@@ -166,7 +174,7 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_test, TestingSetup)
     // independent of the fee -- i.e. the wallet spends exactly the requested
     // amount. (Without the flag the recipient would receive the full 900 and
     // the change would be 100 - fee.)
-    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
     bool foundRecipient = false;
     bool foundChange = false;
     for (auto& res : result.amounts) {
@@ -228,12 +236,12 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_sendmax_test, TestingSetup
     auto finalTx = tx.BuildTx();
 
     BOOST_REQUIRE(finalTx.has_value());
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
 
-    const CAmount fee = GetFeeValue(CTransaction(finalTx.value()));
+    const CAmount fee = GetFeeValue(CTransaction(finalTx->tx));
     BOOST_REQUIRE(fee > 0);
 
-    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
     bool foundRecipient = false;
     for (auto& res : result.amounts) {
         if (res.message == "test") {
@@ -244,6 +252,132 @@ BOOST_FIXTURE_TEST_CASE(createtransaction_subtractfee_sendmax_test, TestingSetup
         BOOST_CHECK(res.message != "Change");
     }
     BOOST_CHECK(foundRecipient);
+}
+
+// BuildTx randomises vout order, so the recipient output sits at no fixed
+// position. The factory must say which output pays the destination: callers
+// hand that hash out as the payment handle, and pointing it at the change --
+// or at the fee output, which block aggregation merges away and which
+// therefore never appears on chain -- silently tracks the wrong money.
+BOOST_FIXTURE_TEST_CASE(buildtx_reports_recipient_output_test, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    CCoinsViewDB base{{.path = "test_recipient", .cache_bytes = 1 << 23, .memory_only = true}, {}};
+
+    auto wallet = std::make_unique<wallet::CWallet>(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase());
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_CHECK(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    auto recvAddress = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+
+    const auto txid = Txid::FromUint256(InsecureRand256());
+    COutPoint outpoint{txid};
+
+    Coin coin;
+    auto out = blsct::CreateOutput(recvAddress, 1000 * COIN, "test");
+    coin.nHeight = 1;
+    coin.out = out.out;
+
+    auto tx = blsct::TxFactory(blsct_km);
+
+    {
+        CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+        coins_view_cache.SetBestBlock(InsecureRand256());
+        coins_view_cache.AddCoin(outpoint, std::move(coin), true);
+        BOOST_CHECK(coins_view_cache.Flush());
+    }
+
+    CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+    BOOST_CHECK(tx.AddInput(coins_view_cache, outpoint));
+
+    tx.AddOutput(recvAddress, 900 * COIN, "memo-to-recipient");
+
+    auto finalTx = tx.BuildTx();
+    BOOST_REQUIRE(finalTx.has_value());
+
+    // The reported hash must belong to this transaction, and never to the fee
+    // output.
+    const auto recipientIndex = FindOutputIndex(finalTx->tx, finalTx->recipientOutputHash);
+    BOOST_REQUIRE(recipientIndex.has_value());
+    BOOST_CHECK(!finalTx->tx.vout[*recipientIndex].scriptPubKey.IsFee());
+
+    // It is the output carrying the recipient's memo and the requested amount
+    // -- not the "Change" output.
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
+    bool checkedRecipient = false;
+    for (auto& res : result.amounts) {
+        if (res.id != *recipientIndex) continue;
+        checkedRecipient = true;
+        BOOST_CHECK_EQUAL(res.message, "memo-to-recipient");
+        BOOST_CHECK_EQUAL(res.amount, 900 * COIN);
+    }
+    BOOST_CHECK(checkedRecipient);
+}
+
+// Same guarantee with subtractfeefromamount, where the recipient output is
+// built last and appended AFTER the change output: the recipient was not even
+// at pre-shuffle vout[0], so a positional recovery reports the change output
+// every time.
+BOOST_FIXTURE_TEST_CASE(buildtx_reports_recipient_output_subtractfee_test, TestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    CCoinsViewDB base{{.path = "test_recipient_sffa", .cache_bytes = 1 << 23, .memory_only = true}, {}};
+
+    auto wallet = std::make_unique<wallet::CWallet>(m_node.chain.get(), "", wallet::CreateMockableWalletDatabase());
+    wallet->InitWalletFlags(wallet::WALLET_FLAG_BLSCT);
+
+    LOCK(wallet->cs_wallet);
+    auto blsct_km = wallet->GetOrCreateBLSCTKeyMan();
+    BOOST_CHECK(blsct_km->SetupGeneration({}, blsct::IMPORT_MASTER_KEY, true));
+
+    auto recvAddress = std::get<blsct::DoublePublicKey>(blsct_km->GetNewDestination(0).value());
+
+    const auto txid = Txid::FromUint256(InsecureRand256());
+    COutPoint outpoint{txid};
+
+    Coin coin;
+    auto out = blsct::CreateOutput(recvAddress, 1000 * COIN, "test");
+    coin.nHeight = 1;
+    coin.out = out.out;
+
+    auto tx = blsct::TxFactory(blsct_km);
+
+    {
+        CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+        coins_view_cache.SetBestBlock(InsecureRand256());
+        coins_view_cache.AddCoin(outpoint, std::move(coin), true);
+        BOOST_CHECK(coins_view_cache.Flush());
+    }
+
+    CCoinsViewCache coins_view_cache{&base, /*deterministic=*/true};
+    BOOST_CHECK(tx.AddInput(coins_view_cache, outpoint));
+
+    tx.AddOutput(recvAddress, 900 * COIN, "memo-to-recipient", TokenId(), blsct::NORMAL, 0, /*fSubtractFeeFromAmount=*/true);
+
+    auto finalTx = tx.BuildTx();
+    BOOST_REQUIRE(finalTx.has_value());
+
+    const CAmount fee = GetFeeValue(CTransaction(finalTx->tx));
+    BOOST_REQUIRE(fee > 0);
+
+    const auto recipientIndex = FindOutputIndex(finalTx->tx, finalTx->recipientOutputHash);
+    BOOST_REQUIRE(recipientIndex.has_value());
+    BOOST_CHECK(!finalTx->tx.vout[*recipientIndex].scriptPubKey.IsFee());
+
+    // The recipient bears the fee, so it is the output holding (amount - fee).
+    // The change output holds the full 100 COIN and must not be reported.
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
+    bool checkedRecipient = false;
+    for (auto& res : result.amounts) {
+        if (res.id != *recipientIndex) continue;
+        checkedRecipient = true;
+        BOOST_CHECK_EQUAL(res.message, "memo-to-recipient");
+        BOOST_CHECK_EQUAL(res.amount, 900 * COIN - fee);
+    }
+    BOOST_CHECK(checkedRecipient);
 }
 
 BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
@@ -286,15 +420,15 @@ BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
     TxValidationState tx_state;
 
     BOOST_CHECK(finalTx.has_value());
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
-    const CAmount first_fee = GetFeeValue(CTransaction(finalTx.value()));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
+    const CAmount first_fee = GetFeeValue(CTransaction(finalTx->tx));
     const CAmount expected_change = 1000 * COIN - 900 * COIN - first_fee;
     BOOST_REQUIRE(first_fee > 0);
 
     bool fFoundChange = false;
     uint32_t nChangePosition = 0;
 
-    auto result = blsct_km->RecoverOutputs(finalTx.value().vout);
+    auto result = blsct_km->RecoverOutputs(finalTx->tx.vout);
 
     for (auto& res : result.amounts) {
         if (res.message == "Change" && res.amount == expected_change) {
@@ -305,9 +439,9 @@ BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
 
     BOOST_CHECK(fFoundChange);
 
-    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx.value()));
+    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx->tx));
 
-    auto wtx = wallet->GetWalletTx(finalTx.value().GetHash());
+    auto wtx = wallet->GetWalletTx(finalTx->tx.GetHash());
     BOOST_CHECK(wtx != nullptr);
 
     fFoundChange = false;
@@ -319,10 +453,10 @@ BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
     BOOST_CHECK(fFoundChange);
 
     auto tx2 = blsct::TxFactory(blsct_km);
-    auto outpoint2 = COutPoint(finalTx.value().vout[nChangePosition].GetHash());
+    auto outpoint2 = COutPoint(finalTx->tx.vout[nChangePosition].GetHash());
     Coin coin2;
     coin2.nHeight = 1;
-    coin2.out = finalTx.value().vout[nChangePosition];
+    coin2.out = finalTx->tx.vout[nChangePosition];
     coins_view_cache.AddCoin(outpoint2, std::move(coin2), true);
 
     BOOST_CHECK(tx2.AddInput(coins_view_cache, outpoint2));
@@ -332,12 +466,12 @@ BOOST_FIXTURE_TEST_CASE(addinput_test, TestingSetup)
 
     auto finalTx2 = tx2.BuildTx();
     BOOST_REQUIRE(finalTx2.has_value());
-    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx2.value()));
-    const CAmount second_fee = GetFeeValue(CTransaction(finalTx2.value()));
+    wallet->transactionAddedToMempool(MakeTransactionRef(finalTx2->tx));
+    const CAmount second_fee = GetFeeValue(CTransaction(finalTx2->tx));
     BOOST_REQUIRE(second_fee > 0);
 
-    BOOST_CHECK(wallet->GetDebit(CTransaction(finalTx2.value()), wallet::ISMINE_SPENDABLE_BLSCT) == expected_change);
-    BOOST_CHECK(TxGetCredit(*wallet, CTransaction(finalTx2.value()), wallet::ISMINE_SPENDABLE_BLSCT) == expected_change - 50 * COIN - second_fee);
+    BOOST_CHECK(wallet->GetDebit(CTransaction(finalTx2->tx), wallet::ISMINE_SPENDABLE_BLSCT) == expected_change);
+    BOOST_CHECK(TxGetCredit(*wallet, CTransaction(finalTx2->tx), wallet::ISMINE_SPENDABLE_BLSCT) == expected_change - 50 * COIN - second_fee);
 }
 
 BOOST_FIXTURE_TEST_CASE(coin_selection_largest_first_test, TestingSetup)
@@ -395,10 +529,10 @@ BOOST_FIXTURE_TEST_CASE(coin_selection_largest_first_test, TestingSetup)
 
     // Largest-first: the single 1000-COIN input covers 500 + fee, so exactly one
     // input is selected instead of the 20 small ones.
-    BOOST_CHECK_EQUAL(finalTx->vin.size(), 1U);
+    BOOST_CHECK_EQUAL(finalTx->tx.vin.size(), 1U);
 
     TxValidationState tx_state;
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blsct/wallet/validation_tests.cpp
+++ b/src/test/blsct/wallet/validation_tests.cpp
@@ -65,7 +65,7 @@ BOOST_FIXTURE_TEST_CASE(validation_test, TestingSetup)
     TxValidationState tx_state;
 
     BOOST_CHECK(finalTx.has_value());
-    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx.value()), coins_view_cache, tx_state));
+    BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTx->tx), coins_view_cache, tx_state));
 }
 
 BOOST_FIXTURE_TEST_CASE(validation_reward_test, TestingSetup)
@@ -124,7 +124,7 @@ BOOST_FIXTURE_TEST_CASE(validation_reserved_sequence_bits_test, TestingSetup)
 
     // Inject reserved bit 31 into the first input's nSequence.
     // 0x80000001 has bit 31 set and is != SEQUENCE_FINAL (0xFFFFFFFF).
-    CMutableTransaction mtx(finalTxOpt.value());
+    CMutableTransaction mtx(finalTxOpt->tx);
     BOOST_REQUIRE(!mtx.vin.empty());
     mtx.vin[0].nSequence = 0x80000001;
 
@@ -181,11 +181,11 @@ BOOST_FIXTURE_TEST_CASE(validation_min_fee_lowered_fee_rejected_test, TestingSet
     // Sanity: untampered tx verifies (it was built at exactly the minimum).
     {
         TxValidationState tx_state;
-        BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTxOpt.value()), coins_view_cache, tx_state));
+        BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTxOpt->tx), coins_view_cache, tx_state));
     }
 
     // Lower the fee output's nValue by 1 sat without touching tx weight.
-    CMutableTransaction mtx(finalTxOpt.value());
+    CMutableTransaction mtx(finalTxOpt->tx);
     bool found_fee = false;
     for (auto& vout : mtx.vout) {
         if (vout.scriptPubKey.IsFee()) {
@@ -256,8 +256,8 @@ BOOST_FIXTURE_TEST_CASE(validation_min_fee_phantom_output_rejected_test, Testing
     auto phantom = blsct::CreateOutput(attackerAddress, kStolen, "stolen");
 
     // Patch the tx: insert phantom, lower fee by `kStolen`.
-    CMutableTransaction mtx(finalTxOpt.value());
-    BOOST_REQUIRE(GetFeeValue(CTransaction(finalTxOpt.value())) > kStolen);
+    CMutableTransaction mtx(finalTxOpt->tx);
+    BOOST_REQUIRE(GetFeeValue(CTransaction(finalTxOpt->tx)) > kStolen);
     mtx.vout.push_back(phantom.out);
 
     bool found_fee = false;
@@ -327,14 +327,14 @@ BOOST_FIXTURE_TEST_CASE(validation_payfee_on_spendable_output_not_counted_test, 
     // Sanity: untampered tx verifies.
     {
         TxValidationState tx_state;
-        BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTxOpt.value()), coins_view_cache, tx_state));
+        BOOST_CHECK(blsct::VerifyTx(CTransaction(finalTxOpt->tx), coins_view_cache, tx_state));
     }
 
     // Turn the unspendable OP_RETURN fee output into a spendable one while
     // keeping its PayFee predicate and value. With the fix, this output no
     // longer counts toward the fee (IsFee() is now required), so nFee drops to
     // 0 and the min-fee rule rejects the tx.
-    CMutableTransaction mtx(finalTxOpt.value());
+    CMutableTransaction mtx(finalTxOpt->tx);
     bool patched = false;
     for (auto& vout : mtx.vout) {
         if (vout.scriptPubKey.IsFee()) {

--- a/test/functional/blsct_output_storage.py
+++ b/test/functional/blsct_output_storage.py
@@ -12,6 +12,7 @@ reduced compared to transaction mode.
 
 import os
 from decimal import Decimal
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -389,7 +390,18 @@ class NavioBlsctOutputStorageTest(BitcoinTestFramework):
         output_hash = self.wallet_a.sendtoblsctaddress(self_addr, send_amount)
         self.log.info(f"Self-send outputHash: {output_hash}")
 
+        # The returned hash must identify the output that pays the recipient.
+        # The tx factory randomises the vout order to hide the change position,
+        # so a hash taken by position lands on the change output (reporting the
+        # whole change value) or on the fee output (reporting 0) instead.
+        assert_equal(self.wallet_a.getblsctoutput(output_hash)["amount"],
+                     int(send_amount * COIN))
+
         self.generate_blsct_blocks(self.nodes[0], self.addr_a, 1)
+
+        # Same after confirmation.
+        assert_equal(self.wallet_a.getblsctoutput(output_hash)["amount"],
+                     int(send_amount * COIN))
 
         balance_after = self.wallet_a.getbalance()
         self.log.info(f"Balance after self-send: {balance_after}")

--- a/test/functional/blsct_send_outputhash.py
+++ b/test/functional/blsct_send_outputhash.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""The outputHash returned by the BLSCT send RPCs must identify the RECIPIENT.
+
+`TxFactoryBase::BuildTx` shuffles vout before returning (a privacy measure), so
+the recipient output sits at no fixed position. Recovering it positionally --
+`tx->vout[0]` -- returned the change output or the fee output roughly two sends
+out of three. A fee-output handle is worse than merely wrong: when a block
+confirms more than one BLSCT transaction the staker's aggregator replaces the
+per-transaction fee outputs with a single merged one, so that hash never
+appears on chain and `gettxfromoutputhash` can never resolve it.
+
+Ten sends make a positional bug effectively certain to trip here.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than
+
+
+NUM_SENDS = 10
+SEND_AMOUNT = Decimal("1")
+# blsctregtest requires a minimum stake of 100 NAV.
+STAKE_AMOUNT = Decimal("100")
+# The send that pays its own fee out of the amount. With
+# subtractfeefromamount the recipient output is built last and appended AFTER
+# the change output, so it was not even at pre-shuffle vout[0].
+SUBTRACT_FEE_SEND = 3
+
+
+class BlsctSendOutputHashTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "blsctregtest"
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def generate_blsct_blocks(self, node, address, num_blocks):
+        for _ in range(num_blocks):
+            self.generatetoblsctaddress(node, 1, address)
+
+    def run_test(self):
+        self.nodes[0].createwallet(wallet_name="sender", blsct=True, storage_output=True)
+        self.nodes[1].createwallet(wallet_name="receiver", blsct=True, storage_output=True)
+
+        sender = self.nodes[0].get_wallet_rpc("sender")
+        receiver = self.nodes[1].get_wallet_rpc("receiver")
+
+        self.miner_addr = sender.getnewaddress(label="", address_type="blsct")
+        self.generate_blsct_blocks(self.nodes[0], self.miner_addr, 210)
+        self.sync_all()
+
+        self.test_sends(sender, receiver)
+        self.test_stakelock(sender)
+
+    def test_sends(self, sender, receiver):
+        self.log.info(f"{NUM_SENDS} sends: the returned outputHash is the receiver's output")
+
+        for i in range(NUM_SENDS):
+            recv_addr = receiver.getnewaddress(label="", address_type="blsct")
+            subtract_fee = i == SUBTRACT_FEE_SEND
+
+            output_hash = sender.sendtoblsctaddress(
+                recv_addr, SEND_AMOUNT, f"memo-{i}", False, subtract_fee)
+            assert_equal(len(output_hash), 64)
+
+            self.generate_blsct_blocks(self.nodes[0], self.miner_addr, 1)
+            self.sync_all()
+
+            # The handle must resolve on chain. A per-transaction fee output
+            # survives here (one send per block, so nothing is aggregated
+            # away), which is why the ownership check below is what actually
+            # separates the recipient output from the fee and change outputs.
+            location = self.nodes[0].gettxfromoutputhash(output_hash)
+            assert_equal(len(location["txid"]), 64)
+
+            unspent = {u["outid"]: u for u in receiver.listblsctunspent(0, 9999999)}
+            assert output_hash in unspent, (
+                f"send {i} (subtractfeefromamount={subtract_fee}) returned "
+                f"{output_hash}, which is not one of the receiver's outputs: "
+                f"the handle points at the sender's change or at the fee output"
+            )
+
+            entry = unspent[output_hash]
+            assert_equal(entry["address"], recv_addr)
+            amount = Decimal(str(entry["amount"]))
+            if subtract_fee:
+                # The recipient bears the fee, so it receives strictly less
+                # than the requested amount -- but not the change output's
+                # value, which is what a positional recovery would report.
+                assert_greater_than(SEND_AMOUNT, amount)
+                assert_greater_than(amount, SEND_AMOUNT - Decimal("0.1"))
+            else:
+                assert_equal(amount, SEND_AMOUNT)
+
+    def test_stakelock(self, sender):
+        self.log.info("stakelock returns the staked commitment's outid")
+
+        output_hash = sender.stakelock(STAKE_AMOUNT)
+        assert_equal(len(output_hash), 64)
+
+        self.generate_blsct_blocks(self.nodes[0], self.miner_addr, 1)
+        self.sync_all()
+
+        assert_equal(len(self.nodes[0].gettxfromoutputhash(output_hash)["txid"]), 64)
+
+        # liststakedcommitments reports each commitment by its output hash
+        # (the `tx_hash` field is the output id BLSCT outpoints are keyed on).
+        commitments = sender.liststakedcommitments()
+        assert_equal(len(commitments), 1)
+        assert_equal(commitments[0]["tx_hash"], output_hash)
+        assert_equal(Decimal(commitments[0]["amount"]), STAKE_AMOUNT)
+
+
+if __name__ == "__main__":
+    BlsctSendOutputHashTest(__file__).main()

--- a/test/functional/blsct_subtractfee_comment.py
+++ b/test/functional/blsct_subtractfee_comment.py
@@ -18,6 +18,7 @@ B. `comment` / `comment_to` passed to `sendtoaddress` (or `comment_to` to
 
 from decimal import Decimal
 
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than
 
@@ -83,9 +84,18 @@ class BlsctSubtractFeeCommentTest(BitcoinTestFramework):
         # The sendtoblsctaddress subtractfeefromamount arg (positional) behaves
         # identically.
         addr_direct = self.receiver.getnewaddress(label="", address_type="blsct")
-        self.sender.sendtoblsctaddress(addr_direct, amount, "", False, True)
+        output_hash = self.sender.sendtoblsctaddress(addr_direct, amount, "", False, True)
         self.generatetoblsctaddress(self.nodes[0], 1, self.mining_addr)
-        assert_greater_than(amount, self._received(addr_direct))
+        received_direct = self._received(addr_direct)
+        assert_greater_than(amount, received_direct)
+
+        # The returned outputHash must identify the fee-reduced recipient
+        # output. The subtract-fee recipient is only materialised once the fee
+        # fixpoint converges, after the change output has been added, and the
+        # factory then randomises the vout order -- so a hash taken by position
+        # points at the change or fee output instead.
+        assert_equal(self.receiver.getblsctoutput(output_hash)["amount"],
+                     int(received_direct * COIN))
 
     def _find_send_row(self, wallet, comment):
         for e in wallet.listtransactions("*", 1000, 0, True):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -358,6 +358,7 @@ BASE_SCRIPTS = [
     'blsct_unconfirmed_chain_single_utxo.py',
     'blsct_chain_in_one_block.py',
     'blsct_same_block_multi_send.py',
+    'blsct_send_outputhash.py',
     'blsct_aggregated_spend_no_phantom.py',
     'blsct_keypool_restore.py',
     'blsct_getbalanceforaddress.py',


### PR DESCRIPTION
## The bug

`blsct::SendTransaction` returned the payment handle positionally:

```cpp
std::string outputHash = tx->vout[0].GetHash().GetHex();
```

That was correct while `TxFactoryBase::BuildTx` emitted the recipient output
first. It no longer is — `BuildTx` shuffles `vin`/`vout` before returning so the
on-chain transaction does not leak coin-selection order. `vout[0]` is therefore a
uniform pick among the recipient, change and fee outputs:

- a **change**-output handle silently tracks the wrong money;
- a **fee**-output handle can never be resolved at all. When a block confirms
  more than one BLSCT transaction, `AggregateTransactions` drops every
  per-transaction fee output and emits a single merged one, so that hash never
  appears on chain and `gettxfromoutputhash` / `getblsctoutput` fail forever.

There is a second defect on the same line, independent of the shuffle: with
`subtractfeefromamount=true` the recipient output is materialised inside the fee
fixpoint and appended **after** the change output, so `vout[0]` was the change
output every time — before the shuffle existed.

Everything that returns through `SendTransaction` is affected:
`sendtoblsctaddress`, `sendtoaddress` (which forwards to it on BLSCT chains),
`sendtokentoblsctaddress`, `sendnfttoblsctaddress`, `stakelock`, `stakeunlock`,
`delegatestake`, `createtoken`, `createnft`, `minttoken`, `mintnft`.

## The fix

Have the factory say which output pays the destination instead of letting
callers recover it positionally.

`BuildTx` / `CreateTransaction` / `CreateConsolidationTransaction` now return
`std::optional<BuiltTransaction>`:

```cpp
struct BuiltTransaction {
    CMutableTransaction tx;
    uint256 recipientOutputHash;
};
```

`recipientOutputHash` is recorded on the converging pass, **before** the shuffle:

- the subtract-fee recipient (`sffaOut`) when that path is used;
- otherwise the first output `AddOutput` queued — what pre-shuffle `vout[0]`
  used to be;
- otherwise the first change output of that pass, which covers a full unstake
  where no output is queued and the unlocked funds come back as the
  "Stake Unlock" change output.

The fee output is appended after all three and is never a candidate. If none of
the three exists (every input consumed by the fee — nothing builds that shape
today) `BuildTx` fails rather than handing back a fee-output handle.

The shuffle, the fee fixpoint and coin selection are untouched.

## Rationale

The output hash is the identity of money on this chain — `COutPoint` is a bare
`Outid`, there is no `txid:vout`, and a submitted txid does not even survive
confirmation once the staker aggregates. So the handle a send RPC returns is the
only durable reference the caller has to the payment, and it has to be the
recipient's output. Recording it in the factory, where the build order is known,
is the only place the answer exists; any positional recovery downstream is a
guess that the shuffle invalidates.

## Tests

**Unit** (`src/test/blsct/wallet/txfactory_tests.cpp`)

- `buildtx_reports_recipient_output_test` — the reported hash belongs to the
  transaction, is not the fee output, and recovers with the recipient's memo and
  the requested amount.
- `buildtx_reports_recipient_output_subtractfee_test` — same with
  `subtractfeefromamount`, where the recipient carries `amount - fee` and the
  change output must not be reported.

**Functional** (`test/functional/blsct_send_outputhash.py`, new)

Ten sends (one with `subtractfeefromamount`) plus a `stakelock`; each returned
handle must resolve via `gettxfromoutputhash` **and** appear in the receiver's
`listblsctunspent` at the right address and amount. Ten iterations make a
positional bug effectively certain to trip.

Both were watched go red against the old behaviour and green again after
restoring the fix:

```
AssertionError: send 1 (subtractfeefromamount=False) returned ac0132aa045e...,
which is not one of the receiver's outputs: the handle points at the sender's
change or at the fee output
```

```
txfactory_tests.cpp(377): error: in "buildtx_reports_recipient_output_subtractfee_test":
check res.message == "memo-to-recipient" has failed [Change != memo-to-recipient]
```

Local runs: full `blsct_*` functional suite green, `ctest -R blsct` 7/7 green.
