### PR TITLE
rpc: answer gettxfromoutputhash from the UTXO set

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -44,6 +44,7 @@
 
 #include <numeric>
 #include <cstdint>
+#include <optional>
 
 #include <univalue.h>
 
@@ -1953,12 +1954,56 @@ RPCHelpMan descriptorprocesspsbt()
     };
 }
 
+//! Everything gettxfromoutputhash needs from a block index entry, copied out
+//! under cs_main so the block itself can be read from disk with the lock
+//! released.
+struct OutputHashBlockRef {
+    FlatFilePos pos;
+    uint256 hash;
+    int height;
+    const CBlockIndex* prev;
+};
+
+//! Copy out the block index fields the output-hash search needs. Throws if the
+//! block's data has been pruned: the output may well be in that block, and
+//! answering "not found" would be a wrong answer rather than a missing one.
+static OutputHashBlockRef GetOutputHashBlockRef(node::BlockManager& blockman, const CBlockIndex& index)
+{
+    LOCK(cs_main);
+    if (blockman.IsBlockPruned(index)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Output hash not found in unpruned blocks (pruned data)");
+    }
+    return {index.GetBlockPos(), index.GetBlockHash(), index.nHeight, index.pprev};
+}
+
+//! Describe where output_hash sits in an already-read block, or nullopt if the
+//! block does not contain it.
+static std::optional<UniValue> FindOutputHashInBlock(const CBlock& block, const uint256& output_hash, const uint256& block_hash, int confirmations)
+{
+    for (const auto& tx : block.vtx) {
+        for (size_t i = 0; i < tx->vout.size(); i++) {
+            if (tx->vout[i].GetHash() == output_hash) {
+                UniValue result(UniValue::VOBJ);
+                result.pushKV("txid", tx->GetHash().GetHex());
+                result.pushKV("vout", (int)i);
+                result.pushKV("blockhash", block_hash.GetHex());
+                result.pushKV("confirmations", confirmations);
+                return result;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
 static RPCHelpMan gettxfromoutputhash()
 {
     return RPCHelpMan{
         "gettxfromoutputhash",
         "\nReturns the transaction hash that contains the specified output hash.\n"
-        "\nThis command searches through the blockchain and mempool to find which transaction contains an output with the given hash.\n",
+        "\nThis command searches through the blockchain and mempool to find which transaction contains an output with the given hash.\n"
+        "\nAn output that is still unspent is answered from the UTXO set, which names its block directly. An output already spent in a\n"
+        "block is no longer in the UTXO set, so it is looked up by scanning the chain backwards from the tip, which is expensive.\n"
+        "\nOn a pruned node the scan fails once it reaches a block whose data was pruned, rather than reporting the output as missing.\n",
         {
             {"outputhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hash of the output to search for"},
             {"include_mempool", RPCArg::Type::BOOL, RPCArg::Default{true}, "Include mempool transactions in the search"},
@@ -1983,9 +2028,6 @@ static RPCHelpMan gettxfromoutputhash()
                 g_txindex->BlockUntilSyncedToCurrentChain();
             }
 
-            LOCK(cs_main);
-            Chainstate& active_chainstate = chainman.ActiveChainstate();
-
             // First, search in mempool if requested
             if (include_mempool && node.mempool) {
                 LOCK(node.mempool->cs);
@@ -2003,26 +2045,50 @@ static RPCHelpMan gettxfromoutputhash()
                 }
             }
 
-            // Search in blockchain by iterating over blocks.
+            // An outpoint on this chain is the bare output hash, so the UTXO set
+            // can name the block that created any output not yet spent in a
+            // block: Coin::nHeight is that block's height. Reading just that one
+            // block answers the common lookup without touching the rest of the
+            // chain. An output spent only by a mempool transaction is still in
+            // CoinsTip, so it is covered here too.
+            const CBlockIndex* coin_block{nullptr};
+            const CBlockIndex* scan_tip{nullptr};
+            int tip_height{0};
+            {
+                LOCK(cs_main);
+                Chainstate& active_chainstate = chainman.ActiveChainstate();
+                scan_tip = active_chainstate.m_chain.Tip();
+                tip_height = active_chainstate.m_chain.Height();
+                Coin coin;
+                if (active_chainstate.CoinsTip().GetCoin(COutPoint(output_hash), coin)) {
+                    coin_block = active_chainstate.m_chain[coin.nHeight];
+                }
+            }
 
-            const CBlockIndex* pindex = active_chainstate.m_chain.Tip();
-            while (pindex) {
+            if (coin_block) {
+                const OutputHashBlockRef ref{GetOutputHashBlockRef(chainman.m_blockman, *coin_block)};
                 CBlock block;
-                if (chainman.m_blockman.ReadBlockFromDisk(block, *pindex)) {
-                    for (const auto& tx : block.vtx) {
-                        for (size_t i = 0; i < tx->vout.size(); i++) {
-                            if (tx->vout[i].GetHash() == output_hash) {
-                                UniValue result(UniValue::VOBJ);
-                                result.pushKV("txid", tx->GetHash().GetHex());
-                                result.pushKV("vout", (int)i);
-                                result.pushKV("blockhash", pindex->GetBlockHash().GetHex());
-                                result.pushKV("confirmations", 1 + active_chainstate.m_chain.Height() - pindex->nHeight);
-                                return result;
-                            }
-                        }
+                if (chainman.m_blockman.ReadBlockFromDisk(block, ref.pos)) {
+                    if (auto result{FindOutputHashInBlock(block, output_hash, ref.hash, 1 + tip_height - ref.height)}) {
+                        return *result;
                     }
                 }
-                pindex = pindex->pprev;
+            }
+
+            // Otherwise the output was spent in a block and is gone from the UTXO
+            // set, so fall back to walking the chain backwards from the tip
+            // captured above. cs_main is taken per block to resolve that block's
+            // position on disk and dropped again before the read, so the scan
+            // never holds the lock across disk I/O.
+            for (const CBlockIndex* pindex = scan_tip; pindex != nullptr;) {
+                const OutputHashBlockRef ref{GetOutputHashBlockRef(chainman.m_blockman, *pindex)};
+                CBlock block;
+                if (chainman.m_blockman.ReadBlockFromDisk(block, ref.pos)) {
+                    if (auto result{FindOutputHashInBlock(block, output_hash, ref.hash, 1 + tip_height - ref.height)}) {
+                        return *result;
+                    }
+                }
+                pindex = ref.prev;
             }
 
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Output hash not found in blockchain or mempool");

--- a/test/functional/rpc_gettxfromoutputhash.py
+++ b/test/functional/rpc_gettxfromoutputhash.py
@@ -9,12 +9,22 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.wallet import MiniWallet
 
+NOT_FOUND_ERROR = "Output hash not found in blockchain or mempool"
+PRUNED_ERROR = "Output hash not found in unpruned blocks (pruned data)"
+
+# Height the pruning node is asked to prune up to, and the height its chain is
+# mined to first. pruneblockchain() refuses to prune within 288 blocks of the
+# tip, and -fastprune keeps the block files small enough that a regtest chain
+# spans several of them, so pruning actually unlinks something.
+PRUNE_HEIGHT = 600
+PRUNED_NODE_CHAIN_HEIGHT = 800
+
 
 class GetTxFromOutputHashTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 1
+        self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [["-txindex"]]
+        self.extra_args = [["-txindex"], ["-fastprune", "-prune=1"]]
 
     def run_test(self):
         node = self.nodes[0]
@@ -23,62 +33,109 @@ class GetTxFromOutputHashTest(BitcoinTestFramework):
         # Generate some blocks to have a base
         self.generate(wallet, 101)
 
-        # Create a transaction with outputs
-        tx_result = wallet.send_self_transfer(from_node=node)
-        txid = tx_result['txid']
+        # MiniWallet reports the output hash of a created output as the utxo's
+        # 'txid' (an outpoint on this chain is a bare output hash) and the
+        # containing transaction's hash as 'transaction_txid'.
+        tx_a = wallet.send_self_transfer(from_node=node)
+        block_a = self.generate(wallet, 1)[0]
+        self.generate(wallet, 5)
+        output_hash_a = tx_a['new_utxo']['txid']
 
-        # Mine a block to confirm the transaction
-        self.generate(wallet, 1)
-
-        # Get the transaction details to find an output hash
-        tx_details = node.getrawtransaction(txid, True)
-
-        # Find the first output and get its hash
-        first_output = tx_details['vout'][0]
-        output_hash = first_output['hash']
-
-        # Test the new RPC command
-        result = node.gettxfromoutputhash(output_hash)
-
-        # Verify the result
-        assert_equal(result['txid'], txid)
+        self.log.info("Confirmed, unspent output resolves from the UTXO set")
+        result = node.gettxfromoutputhash(output_hash_a)
+        assert_equal(result['txid'], tx_a['txid'])
         assert_equal(result['vout'], 0)
-        assert_equal(result['confirmations'], 1)  # Should be confirmed
-        assert 'blockhash' in result
+        assert_equal(result['blockhash'], block_a)
+        assert_equal(result['confirmations'], 6)
 
-        # Test with a non-existent output hash
-        fake_hash = "0000000000000000000000000000000000000000000000000000000000000000"
-        assert_raises_rpc_error(
-            -5,  # RPC_INVALID_ADDRESS_OR_KEY
-            "Output hash not found in blockchain or mempool",
-            node.gettxfromoutputhash,
-            fake_hash
-        )
+        self.log.info("Confirmed, confirmed-spent output still resolves")
+        # Spending output A in a block removes it from the UTXO set, so this
+        # lookup can only be answered by the backwards scan over the chain.
+        tx_b = wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_a['new_utxo'])
+        block_b = self.generate(wallet, 1)[0]
+        output_hash_b = tx_b['new_utxo']['txid']
 
-        # Test with mempool transaction
-        # Create a new transaction but don't mine it
-        mempool_tx_result = wallet.send_self_transfer(from_node=node)
-        mempool_txid = mempool_tx_result['txid']
+        spent_result = node.gettxfromoutputhash(output_hash_a)
+        assert_equal(spent_result['txid'], tx_a['txid'])
+        assert_equal(spent_result['vout'], 0)
+        assert_equal(spent_result['blockhash'], block_a)
+        assert_equal(spent_result['confirmations'], 7)
 
-        # Get the transaction details
-        mempool_tx_details = node.getrawtransaction(mempool_txid, True)
-        mempool_output_hash = mempool_tx_details['vout'][0]['hash']
+        result_b = node.gettxfromoutputhash(output_hash_b)
+        assert_equal(result_b['txid'], tx_b['txid'])
+        assert_equal(result_b['blockhash'], block_b)
+        assert_equal(result_b['confirmations'], 1)
 
-        # Test finding the mempool transaction
-        mempool_result = node.gettxfromoutputhash(mempool_output_hash)
-        assert_equal(mempool_result['txid'], mempool_txid)
+        self.log.info("Output spent only in the mempool still resolves to its block")
+        # Output B stays in the UTXO set while its spend is unconfirmed, so it
+        # must still report the block that created it.
+        tx_c = wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_b['new_utxo'])
+        output_hash_c = tx_c['new_utxo']['txid']
+
+        result_b = node.gettxfromoutputhash(output_hash_b)
+        assert_equal(result_b['txid'], tx_b['txid'])
+        assert_equal(result_b['blockhash'], block_b)
+        assert_equal(result_b['confirmations'], 1)
+
+        self.log.info("Mempool output resolves with zero confirmations")
+        mempool_result = node.gettxfromoutputhash(output_hash_c)
+        assert_equal(mempool_result['txid'], tx_c['txid'])
         assert_equal(mempool_result['vout'], 0)
-        assert_equal(mempool_result['confirmations'], 0)  # Should be unconfirmed
+        assert_equal(mempool_result['confirmations'], 0)
         assert 'blockhash' not in mempool_result
 
         # Test with include_mempool=false
         assert_raises_rpc_error(
             -5,  # RPC_INVALID_ADDRESS_OR_KEY
-            "Output hash not found in blockchain or mempool",
+            NOT_FOUND_ERROR,
             node.gettxfromoutputhash,
-            mempool_output_hash,
+            output_hash_c,
             False  # include_mempool=False
         )
+
+        self.log.info("Unknown output hash is reported as not found")
+        fake_hash = "0000000000000000000000000000000000000000000000000000000000000000"
+        assert_raises_rpc_error(
+            -5,  # RPC_INVALID_ADDRESS_OR_KEY
+            NOT_FOUND_ERROR,
+            node.gettxfromoutputhash,
+            fake_hash
+        )
+
+        self.test_pruned_node(wallet, output_hash_a, output_hash_b)
+
+    def test_pruned_node(self, wallet, spent_output_hash, unspent_output_hash):
+        self.log.info("Pruned blocks are reported as pruned, not as not found")
+        node = self.nodes[0]
+        pruned_node = self.nodes[1]
+
+        while node.getblockcount() < PRUNED_NODE_CHAIN_HEIGHT:
+            self.generate(wallet, min(250, PRUNED_NODE_CHAIN_HEIGHT - node.getblockcount()))
+
+        # pruneblockchain() unlinks whole block files, so it stops at the file
+        # boundary below the requested height and reports where it got to.
+        assert pruned_node.pruneblockchain(PRUNE_HEIGHT) > 0
+        # Confirm the blocks holding the two outputs really were pruned away,
+        # otherwise the assertions below would pass on unpruned blocks.
+        for output_hash in (spent_output_hash, unspent_output_hash):
+            blockhash = node.gettxfromoutputhash(output_hash)['blockhash']
+            assert_raises_rpc_error(-1, "Block not available (pruned data)",
+                                    pruned_node.getblock, blockhash)
+
+        # A spent output reaches the pruned blocks through the backwards scan,
+        # an unspent one through its UTXO set entry. Neither may claim the
+        # output does not exist.
+        assert_raises_rpc_error(-1, PRUNED_ERROR, pruned_node.gettxfromoutputhash, spent_output_hash)
+        assert_raises_rpc_error(-1, PRUNED_ERROR, pruned_node.gettxfromoutputhash, unspent_output_hash)
+
+        self.log.info("Pruned node still resolves outputs in the blocks it kept")
+        tx = wallet.send_self_transfer(from_node=node)
+        blockhash = self.generate(wallet, 1)[0]
+        result = pruned_node.gettxfromoutputhash(tx['new_utxo']['txid'])
+        assert_equal(result['txid'], tx['txid'])
+        assert_equal(result['vout'], 0)
+        assert_equal(result['blockhash'], blockhash)
+        assert_equal(result['confirmations'], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## The bug

`gettxfromoutputhash` took `LOCK(cs_main)` for its whole body and then, when the
mempool pass missed, walked the chain from the tip to genesis calling
`ReadBlockFromDisk` on **every** block — with the lock still held.

1. **Availability.** It is not a hidden command. Asking for a hash that does not
   exist makes the node read the entire block directory while holding `cs_main`,
   stalling validation and every other `cs_main` RPC for the duration.
2. **Silent wrong answer when pruned.** A block whose data was pruned simply
   failed to read and the scan moved on, so the RPC reported
   "Output hash not found in blockchain or mempool" for outputs that do exist —
   indistinguishable from a genuine miss.

This RPC matters more here than its Bitcoin ancestry suggests: an outpoint on
this chain is a bare output hash with no vout index, and a submitted txid does
not survive confirmation once the staker aggregates transactions, so resolving
an output hash is the normal way to locate money.

## The fix

**Fast path from the UTXO set.** Because the outpoint *is* the output hash,
`CoinsTip().GetCoin(COutPoint(outputhash), coin)` answers directly for any
output not yet spent in a block, and `coin.nHeight` names the block that created
it. Reading that one block replaces the whole scan. An output spent only by a
mempool transaction is still in `CoinsTip`, so it is covered too.

**The fallback no longer holds `cs_main` across disk I/O.** Only an output
already spent in a block gets there. The loop takes `cs_main` per block purely to
copy out that block's `FlatFilePos`/hash/height/`pprev`, releases it, then reads
from disk — the same shape `GetTransaction()` uses in `node/transaction.cpp`.
The walk follows `pprev` from a tip captured once, so a concurrent reorg cannot
splice two branches into one traversal.

**Pruned blocks are reported as pruned.** Hitting a block without `BLOCK_HAVE_DATA`
now raises a distinct error rather than continuing and eventually claiming the
output does not exist.

## Measured effect

Regtest, 20 repetitions, median:

| lookup | before | after |
| --- | --- | --- |
| unspent output from block 102, tip 1000 | 3.7 ms | 0.1 ms |
| unspent output from block 102, tip 10000 | 37.1 ms | 0.1 ms |
| nonexistent hash, tip 1000 | 4.0 ms | 3.5 ms |
| nonexistent hash, tip 10000 | 39.0 ms | 35.2 ms |

## What this does *not* fix

A lookup for a hash that exists nowhere is **still O(chain)** with unbounded disk
I/O — the change is that it no longer holds `cs_main` while doing it. Bounding
that properly needs an output-hash index (the same shape as `txindex`), which is
a bigger piece of work; `src/test/fuzz/rpc.cpp` already skips this RPC for the
same reason. Happy to follow up with the index if you want it.

## Behaviour change worth reviewing

On a **pruned** node, a lookup that reaches pruned blocks now fails with
`RPC_MISC_ERROR` "Output hash not found in unpruned blocks (pruned data)" where
it previously returned the `-5` not-found error. That is the point of the change,
but it is an observable difference for any caller that keys on `-5`.

## Tests

`test/functional/rpc_gettxfromoutputhash.py` (rewritten, now 2 nodes — one
`-txindex`, one `-fastprune -prune=1`):

- confirmed **unspent** output resolves with the right txid, vout, blockhash and
  confirmations (the fast path);
- confirmed **spent** output still resolves (guards the fallback — the main
  regression risk here);
- output spent **only in the mempool** still resolves to its block;
- mempool output resolves with `confirmations: 0` and no blockhash;
- `include_mempool=false` and unknown-hash errors unchanged;
- **pruned node** raises the pruned error for both a spent and an unspent output,
  after proving with `getblock` that those blocks really were unlinked, and still
  resolves outputs in the blocks it kept.

Each assertion was watched go red against a deliberately broken build and green
again after restoring — the pruned check disabled gives
`AssertionError: Unexpected JSONRPC error code -5`, an off-by-one in the fast
path's confirmations gives `AssertionError: not(5 == 6)`, and seeding the
fallback with a null index gives `Output hash not found in blockchain or mempool (-5)`.

Also green locally: `feature_pruning.py`, `wallet_basic.py`, `wallet_groups.py`,
`wallet_avoid_mixing_output_types.py`, `wallet_avoidreuse.py`,
`wallet_spend_unconfirmed.py`, `feature_csv_activation.py`, `rpc_help.py`,
`ctest -R rpc`.

One caveat on the fast path: which block it picks is not observable through the
RPC. Pointing it at the wrong height makes the lookup fall through to the scan,
which returns the same correct answer — so the timing numbers above, plus the
confirmations assertion, are what show the fast path is actually taken.
