### PR TITLE
wallet: fix two BLSCT balance-reporting inconsistencies

### DIFF
--- a/src/blsct/wallet/keyman.cpp
+++ b/src/blsct/wallet/keyman.cpp
@@ -1454,6 +1454,12 @@ bool KeyMan::AddWatchOnly(const CScript& script, const std::optional<blsct::Publ
     return true;
 }
 
+bool KeyMan::HaveWatchOnly() const
+{
+    LOCK(cs_KeyStore);
+    return !setWatchOnly.empty();
+}
+
 void KeyMan::LoadWatchOnly(const CScript& script)
 {
     LOCK(cs_KeyStore);

--- a/src/blsct/wallet/keyman.h
+++ b/src/blsct/wallet/keyman.h
@@ -289,6 +289,8 @@ public:
 
     /** Watch-only script management */
     bool AddWatchOnly(const CScript& script, const std::optional<blsct::PublicKey>& recovery_nonce = std::nullopt);
+    //! Whether any script is watched (e.g. imported with importblsctscript).
+    bool HaveWatchOnly() const;
     void LoadWatchOnly(const CScript& script);
     void LoadWatchOnlyRecoveryNonce(const CScript& script, const blsct::PublicKey& nonce);
     std::optional<blsct::PublicKey> GetWatchOnlyRecoveryNonce(const CScript& script) const;

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -462,11 +462,19 @@ RPCHelpMan getblsctbalance()
                         if (!txout.tokenId.IsNull()) continue;
                         if (pwallet->IsSpent(COutPoint(txout.GetHash()))) continue;
                         const wallet::isminetype mine = pwallet->IsMine(txout);
-                        const bool is_signable = (mine & (wallet::ISMINE_SPENDABLE_BLSCT | wallet::ISMINE_STAKED_COMMITMENT_BLSCT)) != 0;
+                        // Bucket exactly as wallet::GetBlsctBalance() does for
+                        // output-storage wallets: it credits
+                        // ISMINE_STAKED_COMMITMENT_BLSCT to
+                        // m_mine_staked_commitment and never to m_mine_trusted,
+                        // because a staked commitment cannot be spent until
+                        // `stakeunlock` releases it. Counting it here would
+                        // report the same coins as available or not depending
+                        // only on WALLET_FLAG_BLSCT_OUTPUT_STORAGE.
+                        const bool is_spendable = (mine & wallet::ISMINE_SPENDABLE_BLSCT) != 0;
                         const bool is_watchonly = (mine & wallet::ISMINE_WATCH_ONLY) != 0;
-                        if (!is_signable && !is_watchonly) continue;
+                        if (!is_spendable && !is_watchonly) continue;
                         const CAmount amount = wtx.GetBLSCTRecoveryData(i).amount;
-                        if (is_signable) {
+                        if (is_spendable) {
                             mine_trusted += amount;
                         } else if (is_watchonly) {
                             watchonly_trusted += amount;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -177,10 +177,13 @@ public:
     bool haveWatchOnly() override
     {
         auto spk_man = m_wallet->GetLegacyScriptPubKeyMan();
-        if (spk_man) {
-            return spk_man->HaveWatchOnly();
+        if (spk_man && spk_man->HaveWatchOnly()) {
+            return true;
         }
-        return false;
+        // BLSCT wallets have no legacy ScriptPubKeyMan; their watch-only
+        // scripts (importblsctscript) live in blsct::KeyMan.
+        auto blsct_km = m_wallet->GetBLSCTKeyMan();
+        return blsct_km && blsct_km->HaveWatchOnly();
     };
     bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::optional<AddressPurpose>& purpose) override
     {

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -575,12 +575,18 @@ RPCHelpMan getbalances()
                 }
                 balances.pushKV("mine", balances_mine);
             }
+            // Watch-only material comes in two flavours: legacy scripts held by
+            // the LegacyScriptPubKeyMan, and BLSCT scripts imported with
+            // importblsctscript, which a BLSCT wallet keeps in blsct::KeyMan
+            // (it has no legacy ScriptPubKeyMan at all). Either one earns the
+            // section, and the amounts are the sum of both.
             auto spk_man = wallet.GetLegacyScriptPubKeyMan();
-            if (spk_man && spk_man->HaveWatchOnly()) {
+            auto blsct_km = wallet.GetBLSCTKeyMan();
+            if ((spk_man && spk_man->HaveWatchOnly()) || (blsct_km && blsct_km->HaveWatchOnly())) {
                 UniValue balances_watchonly{UniValue::VOBJ};
-                balances_watchonly.pushKV("trusted", ValueFromAmount(bal.m_watchonly_trusted));
-                balances_watchonly.pushKV("untrusted_pending", ValueFromAmount(bal.m_watchonly_untrusted_pending));
-                balances_watchonly.pushKV("immature", ValueFromAmount(bal.m_watchonly_immature));
+                balances_watchonly.pushKV("trusted", ValueFromAmount(bal.m_watchonly_trusted + blsct_bal.m_watchonly_trusted));
+                balances_watchonly.pushKV("untrusted_pending", ValueFromAmount(bal.m_watchonly_untrusted_pending + blsct_bal.m_watchonly_untrusted_pending));
+                balances_watchonly.pushKV("immature", ValueFromAmount(bal.m_watchonly_immature + blsct_bal.m_watchonly_immature));
                 balances.pushKV("watchonly", balances_watchonly);
             }
 

--- a/test/functional/blsct_balance_storage_parity.py
+++ b/test/functional/blsct_balance_storage_parity.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""getblsctbalance must exclude staked commitments, whatever the storage flag.
+
+`stakelock`ed funds cannot be spent until `stakeunlock` releases them, so they
+belong in getbalances().mine.staked_commitment_balance and must not show up as
+available balance. wallet::GetBlsctBalance() buckets them that way for wallets
+carrying WALLET_FLAG_BLSCT_OUTPUT_STORAGE; getblsctbalance serves wallets
+without the flag from its own mapWallet walk, which has to agree.
+
+The two wallets exercised here hold the same coins and differ only in the
+storage flag, which is an on-disk representation choice: getbalances must
+report the identical numbers for both.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than
+
+FUND_AMOUNT = Decimal("500.00000000")
+# blsctregtest requires a minimum stake of 100 NAV.
+STAKE_AMOUNT = Decimal("200.00000000")
+
+
+class BlsctBalanceStorageParityTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = 'blsctregtest'
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def generate_blsct_blocks(self, address, num_blocks, batch_size=2):
+        remaining = num_blocks
+        while remaining > 0:
+            to_generate = min(batch_size, remaining)
+            self.generatetoblsctaddress(self.nodes[0], to_generate, address)
+            remaining -= to_generate
+
+    def stake_and_measure(self, storage_output):
+        """Fund a fresh wallet with one output, stake part of it, and return
+        (getblsctbalance, getbalances().mine) once the stake is confirmed."""
+        node = self.nodes[0]
+        name = f"staker_storage_{int(storage_output)}"
+        node.createwallet(wallet_name=name, blsct=True, storage_output=storage_output)
+        wallet = node.get_wallet_rpc(name)
+        addr = wallet.getnewaddress(label="", address_type="blsct")
+
+        self.miner.sendtoblsctaddress(addr, FUND_AMOUNT)
+        self.generate_blsct_blocks(self.miner_addr, 1)
+        # A single unspent output of a known size, so both wallets under test
+        # build the identical stakelock transaction.
+        assert_equal(Decimal(str(wallet.getbalance())), FUND_AMOUNT)
+        assert_equal(Decimal(str(wallet.getblsctbalance())), FUND_AMOUNT)
+
+        wallet.stakelock(STAKE_AMOUNT)
+        self.generate_blsct_blocks(self.miner_addr, 1)
+
+        mine = wallet.getbalances()["mine"]
+        blsct_balance = Decimal(str(wallet.getblsctbalance()))
+        self.log.info(
+            f"storage_output={storage_output}: getblsctbalance={blsct_balance} "
+            f"trusted={mine['trusted']} staked={mine['staked_commitment_balance']}")
+
+        staked = Decimal(str(mine["staked_commitment_balance"]))
+        trusted = Decimal(str(mine["trusted"]))
+
+        assert_equal(staked, STAKE_AMOUNT)
+        # Everything that is left, minus the stakelock fee, is the available
+        # balance; the staked commitment is locked and is not part of it.
+        assert_greater_than(FUND_AMOUNT - STAKE_AMOUNT, trusted)
+        assert_greater_than(trusted, FUND_AMOUNT - STAKE_AMOUNT - Decimal("1"))
+        # getblsctbalance reports available balance, so it can never exceed the
+        # trusted bucket, and in particular must not carry the staked amount.
+        assert_greater_than(trusted + Decimal("0.00000001"), blsct_balance)
+
+        if not storage_output:
+            # Without the storage flag getblsctbalance walks mapWallet itself;
+            # that walk must bucket staked commitments exactly as
+            # wallet::GetBlsctBalance() does, i.e. out of the available balance.
+            #
+            # The storage_output=True wallet is deliberately not held to this
+            # equality: wallet::GetBlsctBalance() skips every mapOutputs entry
+            # whose CWalletTx is confirmed or in the mempool (getbalances counts
+            # those through GetBalance), so getblsctbalance loses the change of
+            # any locally-created BLSCT transaction - a separate defect from the
+            # bucketing this test pins.
+            assert_equal(blsct_balance, trusted)
+
+        return blsct_balance, mine
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # A separate miner wallet owns every coinbase, so the wallets under
+        # test hold exactly what this test sends them.
+        node.createwallet(wallet_name="miner", blsct=True)
+        self.miner = node.get_wallet_rpc("miner")
+        self.miner_addr = self.miner.getnewaddress(label="", address_type="blsct")
+        self.generate_blsct_blocks(self.miner_addr, 101)
+
+        self.log.info("Staking on a wallet without WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
+        _, mine_no_storage = self.stake_and_measure(False)
+
+        self.log.info("Staking on a wallet with WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
+        _, mine_storage = self.stake_and_measure(True)
+
+        self.log.info("The storage flag must not change any getbalances amount")
+        for key in ("trusted", "staked_commitment_balance",
+                    "pending_staked_commitment_balance", "untrusted_pending",
+                    "immature"):
+            assert_equal(Decimal(str(mine_no_storage[key])),
+                         Decimal(str(mine_storage[key])))
+
+
+if __name__ == '__main__':
+    BlsctBalanceStorageParityTest(__file__).main()

--- a/test/functional/blsct_watchonly_balances.py
+++ b/test/functional/blsct_watchonly_balances.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""getbalances must report BLSCT watch-only balances.
+
+A BLSCT wallet has no legacy ScriptPubKeyMan, so the scripts it watches through
+`importblsctscript` (the HTLC / audit path) live in blsct::KeyMan instead. The
+`watchonly` object of getbalances has to appear for those wallets too, and has
+to carry the BLSCT watch-only amounts - otherwise it contradicts
+`getbalance include_watchonly=true`, which counts them.
+"""
+
+import hashlib
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.messages import COIN
+from test_framework.util import assert_equal
+
+HTLC_AMOUNT_SATS = 1 * COIN
+BLINDING_KEY = "5e" * 32
+
+
+class BlsctWatchonlyBalancesTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = 'blsctregtest'
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def generate_blsct_blocks(self, address, num_blocks, batch_size=2):
+        remaining = num_blocks
+        while remaining > 0:
+            to_generate = min(batch_size, remaining)
+            self.generatetoblsctaddress(self.nodes[0], to_generate, address)
+            remaining -= to_generate
+
+    def assert_watchonly_consistent(self, wallet, expected_trusted):
+        """The watchonly section must exist and must account for exactly the
+        difference `getbalance include_watchonly=true` reports."""
+        balances = wallet.getbalances()
+        assert "watchonly" in balances, (
+            "getbalances must emit a watchonly object for a wallet holding "
+            "BLSCT watch-only scripts")
+        watchonly = balances["watchonly"]
+        trusted = Decimal(str(watchonly["trusted"]))
+        assert_equal(trusted, expected_trusted)
+        assert_equal(Decimal(str(watchonly["untrusted_pending"])), Decimal(0))
+        assert_equal(Decimal(str(watchonly["immature"])), Decimal(0))
+
+        signable = Decimal(str(wallet.getbalance()))
+        with_watchonly = Decimal(str(wallet.getbalance("*", 0, True)))
+        assert_equal(with_watchonly - signable, trusted)
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.createwallet(wallet_name="miner", blsct=True)
+        miner = node.get_wallet_rpc("miner")
+        self.miner_addr = miner.getnewaddress(label="", address_type="blsct")
+        self.generate_blsct_blocks(self.miner_addr, 101)
+
+        node.createwallet(wallet_name="funder", blsct=True)
+        # The watcher stores outputs, so the amount it recovers for a watched
+        # script through the registered nonce is retained and reported.
+        node.createwallet(wallet_name="watcher", blsct=True, storage_output=True)
+        funder = node.get_wallet_rpc("funder")
+        watcher = node.get_wallet_rpc("watcher")
+        funder_addr = funder.getnewaddress(label="", address_type="blsct")
+        watcher_addr = watcher.getnewaddress(label="", address_type="blsct")
+
+        miner.sendtoblsctaddress(funder_addr, 10)
+        self.generate_blsct_blocks(self.miner_addr, 1)
+
+        self.log.info("A wallet watching nothing gets no watchonly section")
+        assert "watchonly" not in watcher.getbalances()
+
+        self.log.info("An imported script with no funds still gets a zero section")
+        raw_import = watcher.importblsctscript({"type": "raw", "script": "51"}, False)
+        assert_equal(raw_import["success"], True)
+        self.assert_watchonly_consistent(watcher, Decimal(0))
+
+        self.log.info("A funded imported script is reported in the watchonly section")
+        descriptor = {
+            "type": "atomic_swap",
+            "address_a": funder_addr,
+            "address_b": watcher_addr,
+            "hash": hashlib.sha256(bytes([0x5e] * 32)).hexdigest(),
+            "locktime": node.getblockcount() + 50,
+            "blinding_key": BLINDING_KEY,
+        }
+        htlc_import = watcher.importblsctscript(descriptor, False)
+        assert_equal(htlc_import["success"], True)
+        # Still nothing on chain paying that script.
+        self.assert_watchonly_consistent(watcher, Decimal(0))
+
+        # The output is blinded to address_a (the funder), so the watcher can
+        # only see it via the script it imported, and can only recover its
+        # amount via the nonce importblsctscript registered alongside.
+        outputs = [{
+            "address": funder_addr,
+            "script": htlc_import["script"],
+            "amount": HTLC_AMOUNT_SATS,
+            "blinding_key": BLINDING_KEY,
+        }]
+        raw = funder.createblsctrawtransaction([], outputs)
+        funded = funder.fundblsctrawtransaction(raw)
+        signed = funder.signblsctrawtransaction(funded)
+        node.sendrawtransaction(signed)
+        self.generate_blsct_blocks(self.miner_addr, 1)
+
+        watched = [u for u in watcher.listblsctunspent()
+                   if u.get("scriptPubKey") == htlc_import["script"]]
+        assert_equal(len(watched), 1)
+        assert_equal(watched[0].get("watchonly"), True)
+
+        self.assert_watchonly_consistent(
+            watcher, Decimal(HTLC_AMOUNT_SATS) / Decimal(COIN))
+
+
+if __name__ == '__main__':
+    BlsctWatchonlyBalancesTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -350,6 +350,7 @@ BASE_SCRIPTS = [
     'p2p_dandelionpp_probing.py',
     'blsct_staking.py',
     'blsct_stake_no_consolidate.py',
+    'blsct_balance_storage_parity.py',
     'blsct_cold_staking.py',
     'blsct_listtransactions_stake.py',
     'blsct_imported_wallet_history.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -364,6 +364,7 @@ BASE_SCRIPTS = [
     'blsct_token.py',
     'blsct_nft.py',
     'blsct_htlc.py',
+    'blsct_watchonly_balances.py',
     'blsct_setblsctseed.py',
     'blsct_spend_rpc_guards.py',
     'blsct_script_validation.py',


### PR DESCRIPTION
Two commits, two independent defects, both of the shape "two balance RPCs
disagree about the same wallet".

## 1. `getblsctbalance` counts locked stake as spendable (non-storage wallets)

`getblsctbalance` has two paths: wallets with `WALLET_FLAG_BLSCT_OUTPUT_STORAGE`
call `wallet::GetBlsctBalance()`, wallets without it fall back to walking
`mapWallet` inline. The fallback credited
`ISMINE_SPENDABLE_BLSCT | ISMINE_STAKED_COMMITMENT_BLSCT` to the available
balance. The helper it stands in for does the opposite: staked commitments go to
`m_mine_staked_commitment`, never to `m_mine_trusted`, because they cannot be
spent until `stakeunlock` releases them.

So the same wallet with the same coins reported staked value as available or not
depending only on the storage flag. Measured on a 500 NAV wallet with 200 staked:

```
getblsctbalance = 499.99587750
getbalances().mine.trusted = 299.99587750   staked_commitment_balance = 200.00000000
```

A caller sizing a spend from `getblsctbalance` gets "Not enough funds available".

Fixed by bucketing the fallback the same way, with a comment tying the two paths
together.

## 2. `getbalances` never reports BLSCT watch-only balances

The `watchonly` object was gated on `GetLegacyScriptPubKeyMan()->HaveWatchOnly()`
and built from the transparent balance alone — `blsct_bal.m_watchonly_*` was
computed and dropped.

A BLSCT wallet has no legacy `ScriptPubKeyMan`, so a wallet whose only watch-only
material came from `importblsctscript` (the documented HTLC / audit path) got no
`watchonly` section at all — while `getbalance ... include_watchonly=true` on the
same wallet *did* count those coins. The two commands contradicted each other.

`blsct::KeyMan` already tracks the imported scripts in `setWatchOnly` but exposed
only a per-script `IsMine`, so it gains a `HaveWatchOnly()` predicate.
`getbalances` now emits the section for either kind of watch-only material and
sums both. `interfaces::Wallet::haveWatchOnly()` had the identical one-line shape
and is fixed alongside.

The predicate is "any script is watched", deliberately not "the watch-only
balance is non-zero": a script holding nothing must still produce a zero section,
exactly as the legacy path does.

## Tests

- `test/functional/blsct_balance_storage_parity.py` (new) — funds a BLSCT wallet,
  `stakelock`s part of it, and asserts `getblsctbalance` excludes the staked
  amount and agrees with `getbalances().mine.trusted`, for both storage modes,
  plus a full cross-mode comparison of the `mine` dict as a drift guard.
- `test/functional/blsct_watchonly_balances.py` (new) — asserts the `watchonly`
  section exists for a wallet holding an imported BLSCT script, including the
  zero-balance case before it is funded, and that its `trusted` matches the
  amount `getbalance(include_watchonly=true)` accounts for.

Both were watched go red against the unfixed code and green again after
restoring:

```
AssertionError: not(499.99587750 == 299.99587750)
AssertionError: getbalances must emit a watchonly object for a wallet holding BLSCT watch-only scripts
```

and, with the gate fixed but the BLSCT amounts left out of the sum:

```
AssertionError: not(0E-8 == 1)
```

Also green locally: `blsct_output_storage.py`, `blsct_import_scriptpubkeys.py`,
`blsct_htlc.py`, `blsct_staking.py`, `blsct_stake_no_consolidate.py`,
`blsct_getbalanceforaddress.py`, `blsct_listtransactions_stake.py`,
`wallet_basic.py`, and `ctest -R "blsct|wallet"` 13/13.

## Two further defects found while doing this — NOT fixed here

Reporting rather than coding around them:

1. **`getblsctbalance` returns 0 on an output-storage wallet after any local
   send.** `GetBlsctBalance()` deliberately skips every `mapOutputs` entry whose
   matching `CWalletTx` is confirmed or in the mempool — correct for
   `getbalances`, which counts those through `GetBalance()`, but
   `getblsctbalance`'s storage path returns *only*
   `GetBlsctBalance().m_mine_trusted`. So the change of any locally-created BLSCT
   transaction vanishes from that RPC: in the new parity test the storage wallet
   reports `0E-8` where the non-storage one reports `299.99587750`. Output
   storage is the default for BLSCT wallets, so this affects the normal
   configuration. It needs the `GetBalance` side folded in without picking up
   transparent credit, which is a larger change than either fix here — the
   parity test documents the current asymmetry rather than asserting it away.

2. **Watch-only BLSCT amounts read as 0 on non-storage wallets.**
   `OutputGetCredit(const CTxOut&)` re-derives the amount with the wallet's own
   view key instead of using the `CWalletTx::blsctRecoveryData` that
   `AddToWallet` populated from the registered watch-only nonce. The new
   watch-only test therefore uses `storage_output=True`, so the asserted number
   is non-zero and the assertion has teeth.
