### PR TITLE
wallet: count the wallet's own change in getblsctbalance

### DIFF
--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -436,54 +436,13 @@ RPCHelpMan getblsctbalance()
 
             bool include_watchonly = ParseIncludeWatchonly(request.params[1], *pwallet);
 
-            // GetBlsctBalance only sees outputs stored in mapOutputs, which is
-            // populated only when WALLET_FLAG_BLSCT_OUTPUT_STORAGE is set. For
-            // legacy (e.g. bdb) BLSCT wallets the BLSCT outputs live in
-            // mapWallet, so we have to walk them directly to avoid the RPC
-            // reporting a confusing 0.
-            CAmount mine_trusted = 0;
-            CAmount watchonly_trusted = 0;
+            // BLSCT outputs live in mapWallet, in mapOutputs, or in both
+            // depending on WALLET_FLAG_BLSCT_OUTPUT_STORAGE; the helper walks
+            // both and deduplicates, so this RPC reports the same balance
+            // whichever way the wallet stores them.
+            const auto bal = wallet::GetBlsctTrustedBalance(*pwallet, min_depth);
 
-            if (pwallet->IsWalletFlagSet(wallet::WALLET_FLAG_BLSCT_OUTPUT_STORAGE)) {
-                const auto bal = wallet::GetBlsctBalance(*pwallet, min_depth);
-                mine_trusted = bal.m_mine_trusted;
-                watchonly_trusted = bal.m_watchonly_trusted;
-            } else {
-                std::set<uint256> trusted_parents;
-                for (const auto& entry : pwallet->mapWallet) {
-                    const wallet::CWalletTx& wtx = entry.second;
-                    if (!wallet::CachedTxIsTrusted(*pwallet, wtx, trusted_parents)) continue;
-                    if (pwallet->IsTxImmatureCoinBase(wtx)) continue;
-                    const int depth = pwallet->GetTxDepthInMainChain(wtx);
-                    if (depth < min_depth) continue;
-                    for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
-                        const CTxOut& txout = wtx.tx->vout[i];
-                        if (!txout.HasBLSCTRangeProof()) continue;
-                        if (!txout.tokenId.IsNull()) continue;
-                        if (pwallet->IsSpent(COutPoint(txout.GetHash()))) continue;
-                        const wallet::isminetype mine = pwallet->IsMine(txout);
-                        // Bucket exactly as wallet::GetBlsctBalance() does for
-                        // output-storage wallets: it credits
-                        // ISMINE_STAKED_COMMITMENT_BLSCT to
-                        // m_mine_staked_commitment and never to m_mine_trusted,
-                        // because a staked commitment cannot be spent until
-                        // `stakeunlock` releases it. Counting it here would
-                        // report the same coins as available or not depending
-                        // only on WALLET_FLAG_BLSCT_OUTPUT_STORAGE.
-                        const bool is_spendable = (mine & wallet::ISMINE_SPENDABLE_BLSCT) != 0;
-                        const bool is_watchonly = (mine & wallet::ISMINE_WATCH_ONLY) != 0;
-                        if (!is_spendable && !is_watchonly) continue;
-                        const CAmount amount = wtx.GetBLSCTRecoveryData(i).amount;
-                        if (is_spendable) {
-                            mine_trusted += amount;
-                        } else if (is_watchonly) {
-                            watchonly_trusted += amount;
-                        }
-                    }
-                }
-            }
-
-            return ValueFromAmount(mine_trusted + (include_watchonly ? watchonly_trusted : 0));
+            return ValueFromAmount(bal.m_mine + (include_watchonly ? bal.m_watchonly : 0));
         },
     };
 }

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -585,6 +585,63 @@ Balance GetBlsctBalance(const CWallet& wallet, const int min_depth, const TokenI
     return ret;
 }
 
+//! Credits `amount` to the bucket `mine` selects. ISMINE_STAKED_COMMITMENT_BLSCT
+//! matches neither, which is how staked commitments stay out of the available
+//! balance -- the same bucketing GetBlsctBalance() applies.
+static void AddBlsctTrustedCredit(BlsctTrustedBalance& balance, isminetype mine, CAmount amount)
+{
+    if (mine & ISMINE_SPENDABLE_BLSCT) {
+        balance.m_mine += amount;
+    } else if (mine & ISMINE_WATCH_ONLY) {
+        balance.m_watchonly += amount;
+    }
+}
+
+BlsctTrustedBalance GetBlsctTrustedBalance(const CWallet& wallet, const int min_depth)
+{
+    AssertLockHeld(wallet.cs_wallet);
+    BlsctTrustedBalance ret;
+
+    // Locally-created BLSCT transactions are recorded in mapWallet whatever the
+    // storage mode is, and under output storage that is the only place their
+    // change is fully described (the mapOutputs mirror is deduplicated below).
+    std::set<uint256> trusted_parents;
+    for (const auto& [_, wtx] : wallet.mapWallet) {
+        if (!CachedTxIsTrusted(wallet, wtx, trusted_parents)) continue;
+        if (wallet.IsTxImmatureCoinBase(wtx)) continue;
+        if (wallet.GetTxDepthInMainChain(wtx) < min_depth) continue;
+        for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
+            const CTxOut& txout = wtx.tx->vout[i];
+            if (!txout.HasBLSCTRangeProof()) continue;
+            if (!txout.tokenId.IsNull()) continue;
+            if (wallet.IsSpent(COutPoint(txout.GetHash()))) continue;
+            AddBlsctTrustedCredit(ret, wallet.IsMine(txout), wtx.GetBLSCTRecoveryData(i).amount);
+        }
+    }
+
+    // mapOutputs is populated only under WALLET_FLAG_BLSCT_OUTPUT_STORAGE, where
+    // externally-received outputs never get a CWalletTx at all. Skip an entry
+    // only when its matching CWalletTx is confirmed or in the mempool, since
+    // that means the mapWallet pass above already counted it; an inactive
+    // CWalletTx (e.g. superseded by a staker-aggregated tx with a different
+    // txid) is untrusted there, leaving the mapOutputs entry as the sole record
+    // of the credit. This is the dedup rule GetBlsctBalance() and GetReceived()
+    // (wallet/rpc/coins.cpp) already use.
+    for (const auto& [outpoint, wout] : wallet.mapOutputs) {
+        const CWalletTx* wtx = wallet.GetWalletTxFromOutpoint(outpoint);
+        if (wtx != nullptr && (wtx->isConfirmed() || wtx->InMempool())) continue;
+        if (!wout.fBLSCTOutput) continue;
+        if (!wout.out->tokenId.IsNull()) continue;
+        if (wout.IsSpent()) continue;
+        if (!IsOutputTrusted(wallet, wout)) continue;
+        if (wallet.IsOutputImmatureCoinBase(wout)) continue;
+        if (wallet.GetOutputDepthInMainChain(wout) < min_depth) continue;
+        AddBlsctTrustedCredit(ret, wallet.IsMine(*wout.out), wout.blsctRecoveryData.amount);
+    }
+
+    return ret;
+}
+
 std::vector<StakedCommitmentInfo> GetStakedCommitmentInfo(const CWallet& wallet)
 {
     AssertLockHeld(wallet.cs_wallet);

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -65,6 +65,21 @@ struct Balance {
 Balance GetBalance(const CWallet& wallet, int min_depth = 0, bool avoid_reuse = true, const TokenId& token_id = TokenId());
 Balance GetBlsctBalance(const CWallet& wallet, int min_depth = 0, const TokenId& token_id = TokenId());
 
+/** Trusted, spendable credit backed by BLSCT outputs of the default token.
+ *
+ * GetBalance() and GetBlsctBalance() are two halves of one tally: the former
+ * walks mapWallet, the latter mapOutputs, and getbalance/getbalances/
+ * getwalletinfo add them up. This is the same tally restricted to BLSCT
+ * outputs, for getblsctbalance, whose contract is its name -- transparent
+ * credit that GetBalance() folds in alongside BLSCT credit is left out.
+ * Staked commitments are left out too: they cannot be spent until
+ * `stakeunlock` releases them, so they are not available balance. */
+struct BlsctTrustedBalance {
+    CAmount m_mine{0};
+    CAmount m_watchonly{0};
+};
+BlsctTrustedBalance GetBlsctTrustedBalance(const CWallet& wallet, int min_depth = 0) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet, const TokenId& token_id = TokenId());
 std::set<std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet, const TokenId& token_id = TokenId()) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 

--- a/test/functional/blsct_balance_storage_parity.py
+++ b/test/functional/blsct_balance_storage_parity.py
@@ -2,17 +2,25 @@
 # Copyright (c) 2026 The Navio Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""getblsctbalance must exclude staked commitments, whatever the storage flag.
+"""getblsctbalance must not depend on WALLET_FLAG_BLSCT_OUTPUT_STORAGE.
 
-`stakelock`ed funds cannot be spent until `stakeunlock` releases them, so they
-belong in getbalances().mine.staked_commitment_balance and must not show up as
-available balance. wallet::GetBlsctBalance() buckets them that way for wallets
-carrying WALLET_FLAG_BLSCT_OUTPUT_STORAGE; getblsctbalance serves wallets
-without the flag from its own mapWallet walk, which has to agree.
+The flag is an on-disk representation choice: a wallet carrying it keeps its
+BLSCT outputs in mapOutputs, one without it keeps them in mapWallet. Two wallets
+holding the same coins must therefore report the same numbers from every balance
+RPC.
 
-The two wallets exercised here hold the same coins and differ only in the
-storage flag, which is an on-disk representation choice: getbalances must
-report the identical numbers for both.
+Two things are pinned here:
+
+* `stakelock`ed funds cannot be spent until `stakeunlock` releases them, so they
+  belong in getbalances().mine.staked_commitment_balance and must stay out of
+  the available balance in both storage modes.
+* The change of a locally-created send is part of the available balance. Under
+  output storage that change is recorded both as a CWalletTx and as a mapOutputs
+  entry, and getblsctbalance has to count it exactly once.
+
+getbalance, getbalances and getwalletinfo compose GetBalance() with
+GetBlsctBalance(); getblsctbalance is BLSCT-only. On these wallets, which hold
+no transparent coins at all, all four must agree.
 """
 
 from decimal import Decimal
@@ -23,6 +31,13 @@ from test_framework.util import assert_equal, assert_greater_than
 FUND_AMOUNT = Decimal("500.00000000")
 # blsctregtest requires a minimum stake of 100 NAV.
 STAKE_AMOUNT = Decimal("200.00000000")
+# Two sends, so the second one has no choice but to spend the change of the
+# first: that change is the credit the storage path used to lose.
+SEND_AMOUNTS = (Decimal("120.00000000"), Decimal("35.00000000"))
+
+
+def to_dec(value):
+    return Decimal(str(value))
 
 
 class BlsctBalanceStorageParityTest(BitcoinTestFramework):
@@ -44,9 +59,46 @@ class BlsctBalanceStorageParityTest(BitcoinTestFramework):
             self.generatetoblsctaddress(self.nodes[0], to_generate, address)
             remaining -= to_generate
 
+    def unconfirmed_send_fee(self, wallet):
+        """Fee of the one send still sitting unconfirmed in `wallet`.
+
+        sendtoblsctaddress returns an output hash rather than a txid, so the fee
+        has to be read back from the transaction list.
+        """
+        fees = {e["txid"]: -to_dec(e["fee"])
+                for e in wallet.listtransactions("*", 10 ** 9, 0, True)
+                if e.get("category") == "send" and e.get("confirmations", 1) == 0}
+        assert_equal(len(fees), 1)
+        fee = next(iter(fees.values()))
+        assert_greater_than(fee, Decimal("0"))
+        return fee
+
+    def assert_balance_rpcs(self, wallet, expected, scenario):
+        """Every balance RPC must report `expected` as the spendable balance.
+
+        getbalance/getbalances/getwalletinfo go through GetBalance() +
+        GetBlsctBalance(); getblsctbalance has its own BLSCT-only accounting.
+        Holding all four to one independently computed figure is what keeps the
+        two paths from drifting.
+        """
+        mine = wallet.getbalances()["mine"]
+        trusted = to_dec(mine["trusted"])
+        blsct_balance = to_dec(wallet.getblsctbalance())
+        plain_balance = to_dec(wallet.getbalance())
+        info_balance = to_dec(wallet.getwalletinfo()["balance"])
+        self.log.info(
+            f"[{scenario}] expected={expected} getblsctbalance={blsct_balance} "
+            f"getbalances.trusted={trusted} getbalance={plain_balance} "
+            f"getwalletinfo.balance={info_balance}")
+        assert_equal(trusted, expected)
+        assert_equal(plain_balance, expected)
+        assert_equal(info_balance, expected)
+        assert_equal(blsct_balance, expected)
+        return mine
+
     def stake_and_measure(self, storage_output):
         """Fund a fresh wallet with one output, stake part of it, and return
-        (getblsctbalance, getbalances().mine) once the stake is confirmed."""
+        getbalances().mine once the stake is confirmed."""
         node = self.nodes[0]
         name = f"staker_storage_{int(storage_output)}"
         node.createwallet(wallet_name=name, blsct=True, storage_output=storage_output)
@@ -57,44 +109,77 @@ class BlsctBalanceStorageParityTest(BitcoinTestFramework):
         self.generate_blsct_blocks(self.miner_addr, 1)
         # A single unspent output of a known size, so both wallets under test
         # build the identical stakelock transaction.
-        assert_equal(Decimal(str(wallet.getbalance())), FUND_AMOUNT)
-        assert_equal(Decimal(str(wallet.getblsctbalance())), FUND_AMOUNT)
+        self.assert_balance_rpcs(wallet, FUND_AMOUNT, f"storage={storage_output} funded")
 
         wallet.stakelock(STAKE_AMOUNT)
         self.generate_blsct_blocks(self.miner_addr, 1)
 
         mine = wallet.getbalances()["mine"]
-        blsct_balance = Decimal(str(wallet.getblsctbalance()))
+        blsct_balance = to_dec(wallet.getblsctbalance())
         self.log.info(
             f"storage_output={storage_output}: getblsctbalance={blsct_balance} "
             f"trusted={mine['trusted']} staked={mine['staked_commitment_balance']}")
 
-        staked = Decimal(str(mine["staked_commitment_balance"]))
-        trusted = Decimal(str(mine["trusted"]))
+        staked = to_dec(mine["staked_commitment_balance"])
+        trusted = to_dec(mine["trusted"])
 
         assert_equal(staked, STAKE_AMOUNT)
         # Everything that is left, minus the stakelock fee, is the available
         # balance; the staked commitment is locked and is not part of it.
         assert_greater_than(FUND_AMOUNT - STAKE_AMOUNT, trusted)
         assert_greater_than(trusted, FUND_AMOUNT - STAKE_AMOUNT - Decimal("1"))
-        # getblsctbalance reports available balance, so it can never exceed the
-        # trusted bucket, and in particular must not carry the staked amount.
-        assert_greater_than(trusted + Decimal("0.00000001"), blsct_balance)
+        # The staked commitment must be bucketed out of the available balance by
+        # both accounting paths, so every balance RPC lands on `trusted`.
+        self.assert_balance_rpcs(wallet, trusted, f"storage={storage_output} staked")
 
-        if not storage_output:
-            # Without the storage flag getblsctbalance walks mapWallet itself;
-            # that walk must bucket staked commitments exactly as
-            # wallet::GetBlsctBalance() does, i.e. out of the available balance.
-            #
-            # The storage_output=True wallet is deliberately not held to this
-            # equality: wallet::GetBlsctBalance() skips every mapOutputs entry
-            # whose CWalletTx is confirmed or in the mempool (getbalances counts
-            # those through GetBalance), so getblsctbalance loses the change of
-            # any locally-created BLSCT transaction - a separate defect from the
-            # bucketing this test pins.
-            assert_equal(blsct_balance, trusted)
+        return mine
 
-        return blsct_balance, mine
+    def spend_and_measure(self, storage_output):
+        """Fund a fresh wallet, spend from it twice, and return
+        (final spendable balance, getbalances().mine).
+
+        The second send can only be paid from the change of the first, so a
+        balance that misses locally-created change shows up here.
+        """
+        node = self.nodes[0]
+        name = f"spender_storage_{int(storage_output)}"
+        node.createwallet(wallet_name=name, blsct=True, storage_output=storage_output)
+        wallet = node.get_wallet_rpc(name)
+        addr = wallet.getnewaddress(label="", address_type="blsct")
+
+        self.miner.sendtoblsctaddress(addr, FUND_AMOUNT)
+        self.generate_blsct_blocks(self.miner_addr, 1)
+        expected = FUND_AMOUNT
+        self.assert_balance_rpcs(wallet, expected, f"storage={storage_output} funded")
+
+        # minconf and include_watchonly are RPC-level plumbing on top of the
+        # shared accounting; check they still bite.
+        assert_equal(to_dec(wallet.getblsctbalance(1)), expected)
+        assert_equal(to_dec(wallet.getblsctbalance(9999)), Decimal("0"))
+        assert_equal(to_dec(wallet.getblsctbalance(0, True)), expected)
+
+        for i, amount in enumerate(SEND_AMOUNTS, start=1):
+            unspent_before = wallet.listblsctunspent(0, 9999999)
+            # One output in, one output out: the next send has to spend the
+            # change this one produces.
+            assert_equal(len(unspent_before), 1)
+            assert_equal(to_dec(unspent_before[0]["amount"]), expected)
+
+            wallet.sendtoblsctaddress(self.miner_addr, amount)
+            fee = self.unconfirmed_send_fee(wallet)
+            self.generate_blsct_blocks(self.miner_addr, 1)
+
+            expected = expected - amount - fee
+            self.assert_balance_rpcs(wallet, expected, f"storage={storage_output} send{i}")
+
+        return expected, wallet.getbalances()["mine"]
+
+    def assert_mine_parity(self, mine_no_storage, mine_storage, scenario):
+        self.log.info(f"[{scenario}] the storage flag must not change any getbalances amount")
+        for key in ("trusted", "staked_commitment_balance",
+                    "pending_staked_commitment_balance", "untrusted_pending",
+                    "immature"):
+            assert_equal(to_dec(mine_no_storage[key]), to_dec(mine_storage[key]))
 
     def run_test(self):
         node = self.nodes[0]
@@ -107,17 +192,21 @@ class BlsctBalanceStorageParityTest(BitcoinTestFramework):
         self.generate_blsct_blocks(self.miner_addr, 101)
 
         self.log.info("Staking on a wallet without WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
-        _, mine_no_storage = self.stake_and_measure(False)
+        mine_no_storage = self.stake_and_measure(False)
 
         self.log.info("Staking on a wallet with WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
-        _, mine_storage = self.stake_and_measure(True)
+        mine_storage = self.stake_and_measure(True)
 
-        self.log.info("The storage flag must not change any getbalances amount")
-        for key in ("trusted", "staked_commitment_balance",
-                    "pending_staked_commitment_balance", "untrusted_pending",
-                    "immature"):
-            assert_equal(Decimal(str(mine_no_storage[key])),
-                         Decimal(str(mine_storage[key])))
+        self.assert_mine_parity(mine_no_storage, mine_storage, "stakelock")
+
+        self.log.info("Spending from a wallet without WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
+        spent_no_storage, mine_spent_no_storage = self.spend_and_measure(False)
+
+        self.log.info("Spending from a wallet with WALLET_FLAG_BLSCT_OUTPUT_STORAGE")
+        spent_storage, mine_spent_storage = self.spend_and_measure(True)
+
+        assert_equal(spent_no_storage, spent_storage)
+        self.assert_mine_parity(mine_spent_no_storage, mine_spent_storage, "sends")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rebased onto `master` now that #324 has landed; this branch is a single commit
against master.

## The bug

`getblsctbalance` returns **0** on an output-storage wallet after any locally
created send. Output storage is the **default** for BLSCT wallets (`createwallet`
sets `WALLET_FLAG_BLSCT_OUTPUT_STORAGE` unconditionally when `blsct=true`), so
this is the normal configuration, not an edge case.

`getblsctbalance`'s storage path returned only
`wallet::GetBlsctBalance(...).m_mine_trusted`. That helper deliberately **skips**
every `mapOutputs` entry whose matching `CWalletTx` is confirmed or in the
mempool — which is correct for its other callers, because `getbalance`,
`getbalances` and `getwalletinfo` add the `mapWallet` walk (`GetBalance()`) to
it, and the skip is exactly what stops those two from double-counting.

`getblsctbalance` never added that half. So externally-received outputs (no
`CWalletTx`) were counted and the wallet's own change (which has one) was not:

```
[storage=True staked] getblsctbalance=0E-8   getbalances.trusted=299.99587750
[storage=False staked] getblsctbalance=299.99587750  getbalances.trusted=299.99587750
```

## The fix

New `wallet::GetBlsctTrustedBalance()` in `wallet/receive.{h,cpp}`, next to
`GetBalance`/`GetBlsctBalance`. It walks **both** maps in one pass with the
established dedup rule (`GetWalletTxFromOutpoint` non-null *and*
confirmed-or-in-mempool ⇒ skip — the same rule `GetReceived()` uses, including
the subtlety that an *inactive* `CWalletTx` must not cause a skip, since a
staker-aggregated block tx has a different txid and leaves the `mapOutputs` entry
as the sole record of the credit).

Both branches of the RPC collapse into one call, so the answer no longer depends
on the storage flag. This also removes the inline `mapWallet` fallback that the
previous commit on this branch fixed — that fallback was the second of two
divergent tallies, and the point of this change is that there is now one.

Properties enforced structurally rather than documented:

- **BLSCT-only**: `HasBLSCTRangeProof()` on the `mapWallet` side, `fBLSCTOutput`
  on the `mapOutputs` side. `GetBalance()` folds transparent and BLSCT credit
  together; an RPC named `getblsctbalance` must not.
- **Staked commitments excluded**: `ISMINE_STAKED_COMMITMENT_BLSCT` matches
  neither bucket, so locked stake cannot appear as available balance.

`GetBalance` and `GetBlsctBalance` are **untouched** — `getbalance`,
`getbalances` and `getwalletinfo` report exactly what they did before.

## Tests

`test/functional/blsct_balance_storage_parity.py` (added by #324) is upgraded:
the `getblsctbalance == getbalances().mine.trusted` equality is now asserted for
**both** storage modes, and the comment documenting the storage-path defect is
gone. New coverage for the case the bug is about — a storage wallet receives,
spends, then spends the change of that spend — with the balance checked after
each step.

Constraint "the other three RPCs must not move" is held by an **external
oracle**, not a cross-comparison: every step asserts `getbalance`,
`getbalances().mine.trusted`, `getwalletinfo().balance` and `getblsctbalance`
against an independently computed `500 − sent − fee`, with the fee read back
from `listtransactions`.

Four separate deliberate breaks were each watched go red and restored:

```
# pre-fix tree, upgraded assertion
[storage=True staked] getblsctbalance=0E-8 getbalances.trusted=299.99587750
AssertionError: not(0E-8 == 299.99587750)

# mapWallet half gated off for storage wallets, send scenario
[storage=True send1] getblsctbalance=0E-8 getbalances.trusted=379.99698875
AssertionError: not(0E-8 == 379.99698875)

# GetBlsctBalance's dedup skip disabled -- the double-count this guards against
[storage=True send1] getblsctbalance=379.99698875 getbalances.trusted=759.99397750
AssertionError: not(759.99397750 == 379.99698875)

# min_depth ignored in the helper
AssertionError: not(500.00000000 == 0)
```

Note the third: `getblsctbalance` stayed correct while the other three doubled,
which is the evidence that the new path is genuinely independent of theirs.

Green locally: `blsct_output_storage.py`, `blsct_unconfirmed_spending.py`,
`blsct_unconfirmed_chain_single_utxo.py`, `blsct_same_block_multi_send.py`,
`blsct_aggregated_spend_no_phantom.py`, `blsct_getbalanceforaddress.py`,
`blsct_listtransactions_stake.py`, `blsct_staking.py`,
`blsct_stake_no_consolidate.py`, `blsct_watchonly_balances.py`,
`wallet_basic.py`, and `ctest -R "blsct|wallet"` 13/13.

## Gap worth knowing

The BLSCT-only filtering is enforced but **not** covered by a red-green test: a
BLSCT wallet holds no transparent coins, so nothing observable distinguishes
filtering from not filtering without inventing a hybrid-wallet fixture. Stated
rather than papered over.

