### PR TITLE
mining, rpc: outid/txid confusion in getblocktemplate, plus small cleanups

### DIFF
--- a/src/blsct/range_proof/rpc.cpp
+++ b/src/blsct/range_proof/rpc.cpp
@@ -75,11 +75,3 @@ void RegisterRangeProofRPCCommands(CRPCTable& t)
         t.appendCommand(c.name, &c);
     }
 }
-
-Span<const CRPCCommand> GetRangeProofRPCCommands()
-{
-    static const CRPCCommand commands[]{
-        {"blsct", &verifyblsctbalanceproof},
-    };
-    return commands;
-}

--- a/src/blsct/wallet/rpc.cpp
+++ b/src/blsct/wallet/rpc.cpp
@@ -171,8 +171,6 @@ UniValue CreateTokenOrNft(const RPCHelpMan& self, const JSONRPCRequest& request,
     if (tokens.contains(tokenId))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Token already exists");
 
-    auto token = tokens[tokenId];
-
     tokenInfo.publicKey = blsct_km->GetTokenKey(tokenId).GetPublicKey();
 
     blsct::CreateTransactionData
@@ -1405,6 +1403,7 @@ RPCHelpMan listblsctunspent()
                                                                                  {RPCResult::Type::BOOL, "spendable", "Whether the output may be selected for spending right now (depends on coin control / wallet state)"},
                                                                                  {RPCResult::Type::BOOL, "signable", "Whether the wallet can derive a non-zero spending key for this output. Outputs imported via importblsctscript (e.g. HTLCs) are reported as signable=false because the wallet only holds view material for them."},
                                                                                  {RPCResult::Type::BOOL, "watchonly", "Whether this output matches an imported watch-only scriptPubKey (e.g. an HTLC added via importblsctscript)"},
+                                                                                 {RPCResult::Type::STR, "scriptAddress", /*optional=*/true, "The decoded destination address for the output script, omitted when the script has no standard destination"},
                                                                                  {RPCResult::Type::STR_HEX, "scriptPubKey", "The scriptPubKey of the output"},
                                                                              }},
                                           }},
@@ -3363,20 +3362,23 @@ RPCHelpMan getblsctoutput()
                 }
             }
 
-            // Try mapOutputs (output storage mode)
-            for (const auto& [outpoint, wout] : pwallet->mapOutputs) {
-                if (wout.out && wout.GetOutputHash() == output_hash) {
-                    const auto& tokenId = wout.out->tokenId;
+            // Try mapOutputs (output storage mode). It is keyed by COutPoint,
+            // which in this chain is the output hash itself — the same value
+            // CWalletOutput::GetOutputHash() reports — so this is a direct
+            // lookup rather than a scan.
+            const auto wout_it = pwallet->mapOutputs.find(COutPoint(output_hash));
+            if (wout_it != pwallet->mapOutputs.end() && wout_it->second.out) {
+                const wallet::CWalletOutput& wout = wout_it->second;
+                const auto& tokenId = wout.out->tokenId;
 
-                    UniValue result(UniValue::VOBJ);
-                    result.pushKV("outputHash", output_hash.GetHex());
-                    result.pushKV("amount", wout.blsctRecoveryData.amount);
-                    result.pushKV("memo", wout.blsctRecoveryData.message);
-                    result.pushKV("tokenId", tokenId.IsNull() ? "" : tokenId.ToString());
-                    result.pushKV("confirmations", pwallet->GetOutputDepthInMainChain(wout));
-                    result.pushKV("spendable", !wout.IsSpent());
-                    return result;
-                }
+                UniValue result(UniValue::VOBJ);
+                result.pushKV("outputHash", output_hash.GetHex());
+                result.pushKV("amount", wout.blsctRecoveryData.amount);
+                result.pushKV("memo", wout.blsctRecoveryData.message);
+                result.pushKV("tokenId", tokenId.IsNull() ? "" : tokenId.ToString());
+                result.pushKV("confirmations", pwallet->GetOutputDepthInMainChain(wout));
+                result.pushKV("spendable", !wout.IsSpent());
+                return result;
             }
 
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Output not found");

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -8,7 +8,7 @@
 #include <primitives/transaction.h>
 #include <consensus/validation.h>
 
-bool CheckTransaction(const CTransaction& tx, TxValidationState& state, const bool& fBLSCT)
+bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty() && !tx.IsBLSCT())

--- a/src/consensus/tx_check.h
+++ b/src/consensus/tx_check.h
@@ -15,6 +15,6 @@
 class CTransaction;
 class TxValidationState;
 
-bool CheckTransaction(const CTransaction& tx, TxValidationState& state, const bool& fBLSCT = false);
+bool CheckTransaction(const CTransaction& tx, TxValidationState& state);
 
 #endif // BITCOIN_CONSENSUS_TX_CHECK_H

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -260,6 +260,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBLSCTBlock(const blsct:
 
         nFees += txFees;
         pblock->vtx.push_back(MakeTransactionRef(tx));
+        // Keep the per-transaction template vectors in lockstep with vtx:
+        // getblocktemplate indexes them by the transaction's position in the
+        // block, so a vtx entry without them is an out-of-range read.
+        pblocktemplate->vTxFees.push_back(txFees);
+        pblocktemplate->vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx.back()));
     }
 
     const auto time_1{SteadyClock::now()};
@@ -318,6 +323,19 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBLSCTBlock(const blsct:
         auto aggregatedTx = blsct::AggregateTransactions(vToAggregate);
         pblock->vtx.resize(1);
         pblock->vtx.push_back(aggregatedTx);
+        // The merged transactions no longer exist in the block, so their
+        // per-transaction fee / sigop entries have to collapse onto the single
+        // aggregate as well. Left alone, getblocktemplate would index these
+        // vectors by block position and report the first merged transaction's
+        // figures as the aggregate's.
+        CAmount aggregated_fees = 0;
+        for (size_t idx = 1; idx < pblocktemplate->vTxFees.size(); ++idx) {
+            aggregated_fees += pblocktemplate->vTxFees[idx];
+        }
+        pblocktemplate->vTxFees.resize(1);
+        pblocktemplate->vTxFees.push_back(aggregated_fees);
+        pblocktemplate->vTxSigOpsCost.resize(1);
+        pblocktemplate->vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*aggregatedTx));
     }
     Assert(pblock->vtx.size() <= 2);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -838,12 +838,19 @@ static RPCHelpMan getblocktemplate()
             aCaps.push_back("proposal");
 
             UniValue transactions(UniValue::VARR);
-            std::map<uint256, int64_t> setTxIndex;
+            // An outpoint on this chain names an output by its own hash, not by
+            // (txid, n), so a dependency is resolved by mapping every output
+            // hash produced so far back to the index of the transaction that
+            // produced it. Keying this by txid would never match a prevout.
+            std::map<uint256, int64_t> setOutputIndex;
             int i = 0;
             for (const auto& it : pblock->vtx) {
                 const CTransaction& tx = *it;
                 uint256 txHash = tx.GetHash();
-                setTxIndex[txHash] = i++;
+                for (const CTxOut& out : tx.vout) {
+                    setOutputIndex[out.GetHash()] = i;
+                }
+                ++i;
 
                 if (!consensusParams.fBLSCT && tx.IsCoinBase())
                     continue;
@@ -856,8 +863,9 @@ static RPCHelpMan getblocktemplate()
 
                 UniValue deps(UniValue::VARR);
                 for (const CTxIn& in : tx.vin) {
-                    if (setTxIndex.contains(in.prevout.hash))
-                        deps.push_back(setTxIndex[in.prevout.hash]);
+                    const auto dep = setOutputIndex.find(in.prevout.hash);
+                    if (dep != setOutputIndex.end())
+                        deps.push_back(dep->second);
                 }
                 entry.pushKV("depends", deps);
 

--- a/src/test/blsct/wallet/output_storage_tests.cpp
+++ b/src/test/blsct/wallet/output_storage_tests.cpp
@@ -412,17 +412,13 @@ BOOST_FIXTURE_TEST_CASE(getblsctoutput_output_storage_lookup, TestingSetup)
     BOOST_CHECK(wout->GetOutputHash() == originalHash);
     BOOST_CHECK(!wout->out->HasBLSCTRangeProof());
 
-    // Lookup by original hash using the same logic as getblsctoutput.
-    bool found = false;
-    for (const auto& [op, w] : wallet->mapOutputs) {
-        if (w.out && w.GetOutputHash() == originalHash) {
-            found = true;
-            BOOST_CHECK_EQUAL(w.blsctRecoveryData.amount, 500 * COIN);
-            BOOST_CHECK(!w.IsSpent());
-            break;
-        }
-    }
-    BOOST_CHECK(found);
+    // Lookup by original hash using the same logic as getblsctoutput: the
+    // mapOutputs key is the output hash, so this is a direct find().
+    const auto found = wallet->mapOutputs.find(COutPoint(originalHash));
+    BOOST_REQUIRE(found != wallet->mapOutputs.end());
+    BOOST_REQUIRE(found->second.out);
+    BOOST_CHECK_EQUAL(found->second.blsctRecoveryData.amount, 500 * COIN);
+    BOOST_CHECK(!found->second.IsSpent());
 }
 
 BOOST_FIXTURE_TEST_CASE(getblsctoutput_output_storage_spent_flag, TestingSetup)
@@ -452,15 +448,10 @@ BOOST_FIXTURE_TEST_CASE(getblsctoutput_output_storage_spent_flag, TestingSetup)
                         nullptr, true, false, TxStateConfirmed{InsecureRand256(), 2, 0}, false);
 
     // getblsctoutput should report spendable=false for a spent output.
-    bool found = false;
-    for (const auto& [op, w] : wallet->mapOutputs) {
-        if (w.out && w.GetOutputHash() == originalHash) {
-            found = true;
-            BOOST_CHECK(w.IsSpent());
-            break;
-        }
-    }
-    BOOST_CHECK(found);
+    const auto found = wallet->mapOutputs.find(COutPoint(originalHash));
+    BOOST_REQUIRE(found != wallet->mapOutputs.end());
+    BOOST_REQUIRE(found->second.out);
+    BOOST_CHECK(found->second.IsSpent());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4303,7 +4303,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     for (const auto& tx : block.vtx) {
         TxValidationState tx_state;
-        if (!CheckTransaction(*tx, tx_state, consensusParams.fBLSCT)) {
+        if (!CheckTransaction(*tx, tx_state)) {
             // CheckBlock() does context-free validation checks. The only
             // possible failures are consensus failures.
             assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS);

--- a/test/functional/blsct_output_storage.py
+++ b/test/functional/blsct_output_storage.py
@@ -12,10 +12,12 @@ reduced compared to transaction mode.
 
 import os
 from decimal import Decimal
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_raises_rpc_error,
 )
 
 BLOCK_REWARD = Decimal("50.00000000")
@@ -136,10 +138,32 @@ class NavioBlsctOutputStorageTest(BitcoinTestFramework):
 
         # --- Scenario: incoming external (peer sends us) ---
         self.log.info("Scenario: incoming external receive")
-        wa.sendtoblsctaddress(ab, Decimal("25.00000000"))
+        recv_amount = Decimal("25.00000000")
+        wa.sendtoblsctaddress(ab, recv_amount)
         self.sync_mempools()
         self.generate_blsct_blocks(self.nodes[0], aa, 1)
         self.sync_all()
+
+        # B holds this output in mapOutputs only, so getblsctoutput must find it
+        # there. mapOutputs is keyed by COutPoint, which is the output hash
+        # itself, so the lookup is a direct find on that key.
+        #
+        # Take the hash from B's own view of the output rather than from what
+        # the sender's RPC returned: on this branch that return value is picked
+        # by vout position, which the tx factory shuffles, so it names one of
+        # the sender's own outputs about two thirds of the time.
+        self.log.info("getblsctoutput resolves an output-storage receive by its output hash")
+        recv_output_hash = next(
+            u["outid"] for u in wb.listblsctunspent(0, 9999999)
+            if u.get("address") == ab and Decimal(str(u["amount"])) == recv_amount)
+        received = wb.getblsctoutput(recv_output_hash)
+        assert_equal(received["outputHash"], recv_output_hash)
+        assert_equal(received["amount"], int(recv_amount * COIN))
+        assert_equal(received["spendable"], True)
+        assert_greater_than(received["confirmations"], 0)
+        assert_raises_rpc_error(-5, "Output not found",
+                                wb.getblsctoutput, "00" * 32)
+
         b_entries = wb.listtransactions("*", 100, 0, True)
         # B sees an external receive (mapOutputs only — B did not build the tx).
         recv = [e for e in b_entries if e.get("category") == "receive"]

--- a/test/functional/blsct_same_block_multi_send.py
+++ b/test/functional/blsct_same_block_multi_send.py
@@ -18,6 +18,7 @@ race into the same block as siblings.
 
 from decimal import Decimal
 
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
@@ -107,6 +108,21 @@ class BlsctSameBlockMultiSendTest(BitcoinTestFramework):
 
         self.sync_mempools()
         assert_equal(len(self.nodes[0].getrawmempool()), NUM_SENDS)
+
+        # The block assembler merges the sibling sends into a single block
+        # transaction. getblocktemplate indexes its per-transaction fee/sigop
+        # vectors by position in the block, so those vectors have to collapse
+        # onto the aggregate too: otherwise the entry reports whichever send
+        # was merged first (one fee) instead of the aggregate's.
+        self.log.info("getblocktemplate reports the aggregate's own fee")
+        template = self.nodes[0].getblocktemplate({"rules": [""], "coinbasedest": miner_addr})
+        mempool_fee_total = sum(int(e["fees"]["base"] * COIN)
+                                for e in self.nodes[0].getrawmempool(True).values())
+        # Coinbase plus the single aggregated transaction.
+        assert_equal(len(template["transactions"]), 2)
+        aggregate = template["transactions"][1]
+        assert "fee" not in template["transactions"][0]
+        assert_equal(aggregate["fee"], mempool_fee_total)
 
         # Drain mempool (BLSCT block aggregation may need >1 block).
         for _ in range(NUM_SENDS + 5):

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -334,7 +334,25 @@ class MiningTest(BitcoinTestFramework):
         node.submitheader(hexdata=CBlockHeader(bad_block_root).serialize().hex())
         assert_equal(node.submitblock(hexdata=block.serialize().hex()), 'duplicate')  # valid
 
+        self.test_gbt_depends()
         self.test_blockmintxfee_parameter()
+
+    def test_gbt_depends(self):
+        self.log.info("getblocktemplate: Test that depends links a child to its parent")
+        node = self.nodes[0]
+        self.wallet.rescan_utxos()
+        parent, child = self.wallet.send_self_transfer_chain(from_node=node, chain_length=2)
+
+        tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+        template_txids = [tx['txid'] for tx in tmpl['transactions']]
+        entries = {tx['txid']: tx for tx in tmpl['transactions']}
+        assert_equal(entries[parent['txid']]['depends'], [])
+        # A `depends` entry is the 1-based index into the `transactions` list,
+        # the coinbase taking index 0 of the block itself.
+        assert_equal(entries[child['txid']]['depends'],
+                     [template_txids.index(parent['txid']) + 1])
+
+        self.generate(self.wallet, 1, sync_fun=self.no_op)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Three commits, reviewable independently.

## 1. `getblocktemplate` — `depends` keyed by the wrong identifier, and the template vectors desync after aggregation

`setTxIndex` was keyed by `tx.GetHash()` (a **txid**) and probed with
`in.prevout.hash`, which is an **`Outid`** — an output hash. `Txid` and `Outid`
are the same underlying `transaction_identifier<false>`, so it compiled happily
and simply never matched: `depends` came back empty for every transaction.

Not dead code, despite BLSCT blocks holding at most one non-coinbase transaction:
`consensus.fBLSCT` is **false** for regtest and signet
(`kernel/chainparams.cpp:444,525`), so this path serves transparent chains where
dependency chains are real and BIP22 miners consume the field. Fixed by mapping
each output hash produced so far to the index of the transaction that produced
it, which is correct on every chain here.

While in there, a second instance of the same "position in `vtx` indexes a
parallel vector" assumption:

- `CreateNewBLSCTBlock` replaces every non-coinbase transaction with one
  aggregate (`node/miner.cpp:316-321`) but left `vTxFees` / `vTxSigOpsCost`
  holding one entry per **pre**-aggregation transaction. `getblocktemplate`
  indexes them by block position, so it reported the first merged transaction's
  figures as the aggregate's — measured **301125 where the five merged sends
  totalled 1505625**.
- The explicit-`txns` loop pushed to `vtx` without pushing to those vectors at
  all, which is an out-of-range read for any caller passing a non-empty `txns`.
  Both RPC call sites pass `{}` today, so that half is latent rather than live.

## 2. `getblsctoutput` lookup, and two smaller things in the same file

`mapOutputs` is keyed by `COutPoint`, and a `COutPoint` here **is** the output
hash — so the linear scan comparing `GetOutputHash()` against every entry was
walking the map to find the key it already held. Replaced with `find()`.

Also drops a dead lookup in `CreateTokenOrNft` (`auto token = tokens[tokenId];`
ran only after the existence check had proven the token absent, default-inserting
an entry into the map and assigning it to an unused variable), and declares
`listblsctunspent`'s `scriptAddress` key in its `RPCResult` schema — it was
emitted but undeclared.

## 3. Dead code

- `CheckTransaction` took an `fBLSCT` flag it never read, defaulted in the
  header, with `CheckBlock` its only caller passing one. It reads like a
  consensus gate and is not one — the real "BLSCT tx only on a BLSCT chain" check
  is in `ConnectBlock`. Removing the parameter keeps the signature honest
  **without inventing a new rule**; if you want that check hoisted into
  context-free validation, that is a separate, deliberate change.
- `GetRangeProofRPCCommands()` duplicated the command table with no callers —
  registration goes through `RegisterRangeProofRPCCommands()`.

## Tests

- `mining_basic.py` — new `test_gbt_depends`: a child spending a parent in the
  same template must list the parent's index. Red before: `not([] == [1])`.
- `blsct_same_block_multi_send.py` — the aggregate's `fee` in
  `getblocktemplate` must equal the sum of the merged sends' fees. Red before:
  `not(301125 == 1505625)`.
- `blsct_output_storage.py` — `getblsctoutput` coverage against the
  **output-storage** wallets. Worth noting: the first version of this assertion
  was placed against the transaction-storage wallets, where the RPC's other
  branch answers first, so it passed with a deliberately broken lookup. Moved,
  and it now goes red: `Output not found (-5)`.
- The `scriptAddress` schema entry was verified by temporarily forcing the
  emission: without the declaration the RPC self-check fails with
  `"scriptAddress": "key returned that was not in doc"`.

`ctest` 151/151 green. Functional green: `mining_basic.py`,
`mining_getblocktemplate_longpoll.py`, `mining_prioritisetransaction.py`,
`blsct_same_block_multi_send.py`, `blsct_output_storage.py`,
`blsct_spend_rpc_guards.py`, `blsct_legacy_rpc_guards.py`, `blsct_block_rpc.py`,
`blsct_pops_consensus.py`, `blsct_token.py`, `blsct_nft.py`, `rpc_help.py`.

## Stated plainly: what is not covered

- The `sigops` half of the aggregation fix. BLSCT transactions carry no script
  sigops, so every observed value is `0` and an assertion could not fail. Only
  `fee` is guarded.
- `scriptAddress`: no test reaches the emitting branch (no BLSCT output script
  has a destination `ExtractDestination` resolves). Verified only by forcing it.
- `CheckTransaction`'s parameter removal and the `GetRangeProofRPCCommands()`
  deletion have no new tests — the compiler and the existing consensus suites are
  the check.

## Separate bug found while testing, not fixed here

`getblsctoutput`'s **first** branch (`mapOutpointHashToWalletTx`) returns a
non-deterministic `amount` for a wallet's own freshly committed send: across
eight runs of an otherwise unmodified tree it reported `1000000000` (correct),
`0`, and `7499988999397750` (decrypted garbage). It is already wrong while the
transaction is still in the mempool, so it is set at commit time, not by block
connection. Suspected mechanism — `CWallet::AddToWallet` runs BLSCT recovery only
when `rescanning_old_block || fInsertedNew`, and `try_store_recovery` accepts any
result with non-zero gamma, so a wrong-nonce recovery lands as a plausible
amount and nothing retries — but that is unconfirmed and diagnosing it means
instrumenting `RecoverOutputs`. Out of scope for this PR; happy to take it next
if you want it.
