### PR TITLE
rpc: omit UTXO-set amounts on a confidential chain

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -901,9 +901,9 @@ static RPCHelpMan gettxoutsetinfo()
                         {RPCResult::Type::STR_HEX, "muhash", /*optional=*/true, "The serialized hash (only present if 'muhash' hash_type is chosen)"},
                         {RPCResult::Type::NUM, "transactions", /*optional=*/true, "The number of transactions with unspent outputs (not available when coinstatsindex is used)"},
                         {RPCResult::Type::NUM, "disk_size", /*optional=*/true, "The estimated size of the chainstate on disk (not available when coinstatsindex is used)"},
-                        {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount of coins in the UTXO set"},
-                        {RPCResult::Type::STR_AMOUNT, "total_unspendable_amount", /*optional=*/true, "The total amount of coins permanently excluded from the UTXO set (only available if coinstatsindex is used)"},
-                        {RPCResult::Type::OBJ, "block_info", /*optional=*/true, "Info on amounts in the block at this block height (only available if coinstatsindex is used)",
+                        {RPCResult::Type::STR_AMOUNT, "total_amount", /*optional=*/true, "The total amount of coins in the UTXO set (omitted on a confidential chain, where output values are Pedersen commitments rather than plain amounts, so no coin total can be derived from the UTXO set)"},
+                        {RPCResult::Type::STR_AMOUNT, "total_unspendable_amount", /*optional=*/true, "The total amount of coins permanently excluded from the UTXO set (only available if coinstatsindex is used; omitted on a confidential chain, where output values are Pedersen commitments rather than plain amounts)"},
+                        {RPCResult::Type::OBJ, "block_info", /*optional=*/true, "Info on amounts in the block at this block height (only available if coinstatsindex is used; omitted on a confidential chain, where output values are Pedersen commitments rather than plain amounts, so every amount below would be meaningless)",
                         {
                             {RPCResult::Type::STR_AMOUNT, "prevout_spent", "Total amount of all prevouts spent in this block"},
                             {RPCResult::Type::STR_AMOUNT, "coinbase", "Coinbase subsidy amount of this block"},
@@ -991,12 +991,19 @@ static RPCHelpMan gettxoutsetinfo()
         if (hash_type == CoinStatsHashType::MUHASH) {
             ret.pushKV("muhash", stats.hashSerialized.GetHex());
         }
-        CHECK_NONFATAL(stats.total_amount.has_value());
-        ret.pushKV("total_amount", ValueFromAmount(stats.total_amount.value()));
+        // On a confidential chain an output carries a Pedersen commitment, not a
+        // plain nValue, so every amount the coin statistics accumulate is
+        // meaningless. Omit them rather than hand back a confident-looking
+        // number that is not the coin supply.
+        const bool confidential{chainman.GetConsensus().fBLSCT};
+        if (!confidential) {
+            CHECK_NONFATAL(stats.total_amount.has_value());
+            ret.pushKV("total_amount", ValueFromAmount(stats.total_amount.value()));
+        }
         if (!stats.index_used) {
             ret.pushKV("transactions", static_cast<int64_t>(stats.nTransactions));
             ret.pushKV("disk_size", stats.nDiskSize);
-        } else {
+        } else if (!confidential) {
             ret.pushKV("total_unspendable_amount", ValueFromAmount(stats.total_unspendable_amount));
 
             CCoinsStats prev_stats{};
@@ -2208,7 +2215,7 @@ static RPCHelpMan scantxoutset()
                         {RPCResult::Type::NUM, "height", "Height of the unspent transaction output"},
                     }},
                 }},
-                {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount of all found unspent outputs in " + CURRENCY_UNIT},
+                {RPCResult::Type::STR_AMOUNT, "total_amount", /*optional=*/true, "The total amount of all found unspent outputs in " + CURRENCY_UNIT + " (omitted on a confidential chain, where output values are Pedersen commitments rather than plain amounts, so the outputs cannot be totalled)"},
             }},
             scan_result_abort,
             scan_result_status_some,
@@ -2276,8 +2283,8 @@ static RPCHelpMan scantxoutset()
         std::unique_ptr<CCoinsViewCursor> pcursor;
         const CBlockIndex* tip;
         NodeContext& node = EnsureAnyNodeContext(request.context);
+        ChainstateManager& chainman = EnsureChainman(node);
         {
-            ChainstateManager& chainman = EnsureChainman(node);
             LOCK(cs_main);
             Chainstate& active_chainstate = chainman.ActiveChainstate();
             active_chainstate.ForceFlushStateToDisk();
@@ -2308,7 +2315,12 @@ static RPCHelpMan scantxoutset()
             unspents.push_back(unspent);
         }
         result.pushKV("unspents", unspents);
-        result.pushKV("total_amount", ValueFromAmount(total_in));
+        // On a confidential chain an output carries a Pedersen commitment rather
+        // than a plain nValue, so the scanned outputs cannot be totalled. Omit
+        // the total instead of reporting a number that is not the amount found.
+        if (!chainman.GetConsensus().fBLSCT) {
+            result.pushKV("total_amount", ValueFromAmount(total_in));
+        }
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }

--- a/test/functional/blsct_txoutset_amounts.py
+++ b/test/functional/blsct_txoutset_amounts.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Navio Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test that UTXO-set RPCs omit amounts on a confidential chain.
+
+On a BLSCT chain an output's value is a Pedersen commitment, so the plain
+nValue the coin statistics sum over is not the amount. gettxoutsetinfo and
+scantxoutset must therefore leave their amount fields out entirely rather than
+report a number that is not the coin supply. Everything else they report is
+still meaningful and must survive.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than, assert_greater_than_or_equal
+
+AMOUNT_FIELDS = ("total_amount", "total_unspendable_amount", "block_info")
+
+
+class BLSCTTxoutsetAmountsTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, blsct=True)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "blsctregtest"
+        self.setup_clean_chain = True
+        self.extra_args = [["-coinstatsindex"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def assert_no_amounts(self, stats):
+        for field in AMOUNT_FIELDS:
+            assert field not in stats, f"{field} must be absent on a confidential chain, got {stats.get(field)!r}"
+
+    def assert_common_fields(self, node, stats, height):
+        assert_equal(stats["height"], height)
+        assert_equal(stats["bestblock"], node.getbestblockhash())
+        assert_greater_than(stats["txouts"], 0)
+        assert_greater_than(stats["bogosize"], 0)
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.createwallet(wallet_name="wallet", blsct=True)
+        wallet = node.get_wallet_rpc("wallet")
+
+        address = wallet.getnewaddress(label="", address_type="blsct")
+        blocks = 10
+        self.generatetoblsctaddress(node, blocks, address)
+        self.wait_until(lambda: node.getindexinfo()["coinstatsindex"]["synced"])
+
+        self.log.info("gettxoutsetinfo omits amounts without the coinstats index")
+        stats = node.gettxoutsetinfo("hash_serialized_3")
+        self.assert_no_amounts(stats)
+        self.assert_common_fields(node, stats, blocks)
+        assert_equal(len(stats["hash_serialized_3"]), 64)
+        # These two are only reported when the index is not consulted, which is
+        # the case for the hash_serialized_3 hash type. disk_size is a leveldb
+        # estimate that is legitimately 0 for a chain this short, so only assert
+        # it is reported at all.
+        assert_greater_than(stats["transactions"], 0)
+        assert_greater_than_or_equal(stats["disk_size"], 0)
+
+        self.log.info("gettxoutsetinfo omits amounts and block_info with the coinstats index")
+        indexed = node.gettxoutsetinfo("muhash")
+        self.assert_no_amounts(indexed)
+        self.assert_common_fields(node, indexed, blocks)
+        assert_equal(len(indexed["muhash"]), 64)
+        assert_equal(indexed["txouts"], stats["txouts"])
+        assert_equal(indexed["bogosize"], stats["bogosize"])
+
+        self.log.info("gettxoutsetinfo omits amounts for a historical height too")
+        historical = node.gettxoutsetinfo("muhash", blocks - 1)
+        self.assert_no_amounts(historical)
+        assert_equal(historical["height"], blocks - 1)
+        assert_equal(historical["bestblock"], node.getblockhash(blocks - 1))
+
+        self.log.info("gettxoutsetinfo omits amounts for the 'none' hash type")
+        self.assert_no_amounts(node.gettxoutsetinfo("none"))
+
+        self.log.info("scantxoutset omits total_amount")
+        # Confidential outputs pay to a bare OP_TRUE (0x51) script, so a raw
+        # descriptor for it matches the coinbase outputs generated above.
+        descriptor = node.getdescriptorinfo("raw(51)")["descriptor"]
+        scan = node.scantxoutset("start", [descriptor])
+        assert_equal(scan["success"], True)
+        assert "total_amount" not in scan, f"total_amount must be absent on a confidential chain, got {scan.get('total_amount')!r}"
+        assert_equal(scan["height"], blocks)
+        assert_equal(scan["bestblock"], node.getbestblockhash())
+        assert_greater_than(len(scan["unspents"]), 0)
+        for unspent in scan["unspents"]:
+            assert_greater_than(unspent["height"], 0)
+
+
+if __name__ == "__main__":
+    BLSCTTxoutsetAmountsTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -372,6 +372,7 @@ BASE_SCRIPTS = [
     'blsct_pops_consensus.py',
     'blsct_output_storage.py',
     'blsct_block_rpc.py',
+    'blsct_txoutset_amounts.py',
     'blsct_rawtransaction.py',
     'blsct_cold_signing.py',
     'blsct_import_scriptpubkeys.py',


### PR DESCRIPTION
## The bug

`gettxoutsetinfo` reports `total_amount`, documented as *"The total amount of
coins in the UTXO set"*, summed from `coin.out.nValue`
(`kernel/coinstats.cpp:122`). On a BLSCT chain an output's value is a Pedersen
commitment and `nValue` is zero (`blsct::CreateOutput`,
`txfactory_global.cpp:93`), so that sum is not the supply and cannot become it.

It is not "roughly zero" — it is **exactly** zero, and the reason is worth
stating because it also rules out fixing it by summing something else:

- the **fee output** never contributes: it is `CTxOut{fee, OP_RETURN}`, and
  `CCoinsViewCache::AddCoin` returns early on `IsUnspendable()` (`coins.cpp:95`),
  so it never enters the UTXO set at all;
- the only outputs with a non-zero `nValue` are **NFTs**, hardcoded to 1 navoshi
  each (`txfactory_global.cpp:76,131,192`).

So the field reports *the number of live NFT outputs, denominated in navoshis*,
labelled as the coin supply. Measured on `blsctregtest`: `Decimal('0E-8')`.

The index-backed fields are worse than zero — they are confidently wrong.
`total_unspendable_amount` read **550.00000000** after ten blocks, because
`unclaimed_rewards` (`index/coinstatsindex.cpp:211`) is
`(prevout_spent + subsidy) − (new_outputs + coinbase + unspendable)` and every
coinbase `nValue` on this chain is zero. The node was reporting that stakers had
claimed **none** of their rewards, on every block, forever.

Failure scenario: an exchange or explorer wires supply monitoring to
`gettxoutsetinfo`, as they would on any Bitcoin fork, and silently gets a wrong
number — no error, no warning.

## The fix

On chains with `fBLSCT`, omit the amount fields instead of answering with a
number no caller can use:

- `gettxoutsetinfo`: `total_amount`, `total_unspendable_amount`, and `block_info`;
- `scantxoutset`: `total_amount`.

Everything else is unaffected and still reported — `height`, `bestblock`,
`txouts`, `bogosize`, `hash_serialized_3`, `muhash`, `transactions`, `disk_size`,
and `scantxoutset`'s `unspents` list. The `RPCResult` declarations are marked
optional and say why the field is absent; the runtime `-rpcdoccheck` (on by
default in the functional framework) enforces that they match what is emitted, on
both chain types.

**The coin statistics themselves are untouched.** The coinstats index serializes
`total_amount` into its on-disk `DBVal` and re-asserts it on rewind
(`coinstatsindex.cpp:49,489`), so changing the kernel would be a database-format
change rather than a reporting one.

`block_info` is omitted whole rather than emitted as `{}`: every one of its
members is an amount, and keeping a hollow object would force marking all five
inner fields optional, which weakens the doc check on regtest where they must be
present. `block_info` was already optional, so this costs no declaration strength.
Happy to switch to the hollow object if you prefer it.

## assumeutxo — checked, no dependency

`CreateUTXOSnapshot` writes only `{tip hash, coins_count}` and reports
`coins_written` / `base_hash` / `base_height` / `txoutset_hash` / `nchaintx`;
`total_amount` is computed and never read. Snapshot validation compares only
`hashSerialized` (`validation.cpp:6193`) — a content hash of the coin records,
not a coin total. `feature_assumeutxo.py` green.

## Tests

`test/functional/blsct_txoutset_amounts.py` (new, `blsctregtest`, one node with
`-coinstatsindex`): asserts the fields are absent across all four
`gettxoutsetinfo` shapes (non-index `hash_serialized_3`, index-backed `muhash`,
historical height, `none`) and from `scantxoutset`, while the non-amount fields
stay present and sane.

Each assertion group was watched go red with the guard disabled and green again
after restoring:

```
AssertionError: total_amount must be absent on a confidential chain, got Decimal('0E-8')
AssertionError: total_unspendable_amount must be absent on a confidential chain, got Decimal('550.00000000')
```

`fBLSCT` is false on regtest and signet, so regtest behaviour is unchanged —
confirmed rather than assumed: `rpc_blockchain.py` (both transports),
`rpc_scantxoutset.py`, `feature_coinstatsindex.py`, `feature_assumeutxo.py`,
`rpc_help.py`, `blsct_block_rpc.py`, `blsct_pops_consensus.py` all pass unchanged.
`ctest -R "coinstats|blockchain|validation"` 11/11.

## Two related fields left alone, deliberately

Same defect, per-output rather than aggregate, and they need a decision this PR
didn't:

- `scantxoutset`'s `unspents[].amount` — verified: a scan over `raw(51)` on
  `blsctregtest` returns ten confidential coinbase outputs each reported as
  `Decimal('0E-8')`.
- `gettxout`'s `value` (`blockchain.cpp:1112`).

Unlike the totals, these are load-bearing for callers who only want the script,
so "omit" is not obviously right — `null` or a documented zero may be better. Say
which you'd like and I'll follow up.

## One check I cannot make pass, with the reason

`git diff -U0 -- src/ | contrib/devtools/clang-format-diff.py -p1` emits ~42KB on
this branch. That is **not** this diff. `gettxoutsetinfo` and `scantxoutset` are
each a single `return RPCHelpMan{...}` statement spanning ~160 lines with the
handler lambda as an argument, and clang-format reflows the whole enclosing
statement whatever `-lines=` it is given — so any edit anywhere in those
functions drags all of it.

Verified with a control: running the same check against the **pristine**
`git show HEAD:src/rpc/blockchain.cpp` over the same line ranges produces 514
lines of diff on untouched code. My own added lines, extracted and run through
`clang-format --style=file:src/.clang-format` in isolation, come back
byte-identical. Satisfying the check as written would mean reformatting two whole
upstream functions inside a behaviour fix.
